### PR TITLE
chore: add .claude/ to gitignore, add default persona to CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ htmlcov/
 .env
 .env.*
 
+# Claude Code
+.claude/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # MangroveKnowledgeBase
 
+## Default Persona
+
+When working in this repo, you are the **product owner**. Read `.claude/agents/product-owner.md` for your full agent spec and follow it. Load your memory from the repo memory directory on every session start.
+
+---
+
 ## Start Here
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` (Claude Code local config, not repo content)
- Add standard Default Persona section to CLAUDE.md (consistent with all other Mangrove repos)
- Removed junk files (`=8`, unused notebooks)

## Test plan
- [x] No code changes -- config only