### PR TITLE
fix: remove MangroveAI imports from docstring_parser

### DIFF
--- a/mangrove_kb/docstring_parser.py
+++ b/mangrove_kb/docstring_parser.py
@@ -287,7 +287,7 @@ def _get_rule_name_from_registry(func) -> Optional[str]:
         The registered rule name string, or None if not found.
     """
     try:
-        from MangroveAI.domains.signals.registry import RuleRegistry
+        from mangrove_kb.registry import RuleRegistry
         for name, registered_func in RuleRegistry._registry.items():
             if registered_func is func:
                 return name
@@ -450,17 +450,8 @@ def parse_all_signals(signal_modules: list) -> dict:
                 ...
             }
     """
-    try:
-        from mangrove_kb.registry import RuleRegistry
-        registry = RuleRegistry._registry
-    except ImportError:
-        try:
-            from MangroveAI.domains.signals.registry import RuleRegistry
-            registry = RuleRegistry._registry
-        except ImportError:
-            raise ImportError(
-                "Cannot import RuleRegistry. Ensure mangrove_kb or MangroveAI is on sys.path."
-            )
+    from mangrove_kb.registry import RuleRegistry
+    registry = RuleRegistry._registry
 
     # Build a set of module names for fast lookup
     module_names = set()


### PR DESCRIPTION
## Summary
- Remove two `from MangroveAI.domains.signals.registry import RuleRegistry` imports from `docstring_parser.py`
- `_get_rule_name_from_registry()` now uses `mangrove_kb.registry.RuleRegistry` (the KB's own registry) instead of MangroveAI's
- `parse_all_signals()` no longer falls back to MangroveAI's registry

## Why
The KB is the upstream dependency — it should never import from MangroveAI. When MangroveAI is on sys.path (e.g. pip-installed in the same env), importing it triggers MangroveAI's config loading, which calls `sys.exit(1)` when GCP credentials aren't configured. This crashes any consumer (like MangroveOracle) that calls `parse_signal_docstring()` or `parse_all_signals()`.

## Test plan
- [ ] `from mangrove_kb.docstring_parser import parse_all_signals` no longer crashes in envs where MangroveAI is installed without GCP
- [ ] `parse_all_signals()` still returns all 136 signals
- [ ] MangroveOracle signal service loads signals correctly