### PR TITLE
perf(mangrove_kb): Waves 1-3 + 4a + X.1 — indicator & signal optimizations

### DIFF
--- a/mangrove_kb/indicators/pattern_indicators.py
+++ b/mangrove_kb/indicators/pattern_indicators.py
@@ -472,7 +472,8 @@ class TweezerTops(IndicatorInterface):
         prev_h = h.shift(1)
         prev_o, prev_c = o.shift(1), c.shift(1)
         rng = candle_range(h, l)
-        avg_rng = rng.rolling(window=20, min_periods=1).mean()
+        avg_window = params.get("avg_window", 20)
+        avg_rng = rng.rolling(window=avg_window, min_periods=1).mean()
         tol = params["tolerance"]
 
         matching_highs = (h - prev_h).abs() <= avg_rng * tol
@@ -504,7 +505,8 @@ class TweezerBottoms(IndicatorInterface):
         prev_l = l.shift(1)
         prev_o, prev_c = o.shift(1), c.shift(1)
         rng = candle_range(h, l)
-        avg_rng = rng.rolling(window=20, min_periods=1).mean()
+        avg_window = params.get("avg_window", 20)
+        avg_rng = rng.rolling(window=avg_window, min_periods=1).mean()
         tol = params["tolerance"]
 
         matching_lows = (l - prev_l).abs() <= avg_rng * tol

--- a/mangrove_kb/indicators/trend_indicators.py
+++ b/mangrove_kb/indicators/trend_indicators.py
@@ -76,15 +76,18 @@ class WMA(IndicatorInterface):
         close = data['close']
         window = params['window']
 
-        weight = pd.Series(
-            [i * 2 / (window * (window + 1)) for i in range(1, window + 1)]
-        )
+        weights = np.arange(1, window + 1, dtype=np.float64) * (2.0 / (window * (window + 1)))
+        close_values = close.to_numpy(dtype=np.float64, copy=False)
 
-        def weighted_average(x):
-            return (weight * x).sum()
+        wma_values = np.empty(len(close_values), dtype=np.float64)
+        if len(close_values) < window:
+            wma_values[:] = np.nan
+        else:
+            # output[j] = sum(close[j:j+window] * weights); pad warmup with NaN
+            wma_values[: window - 1] = np.nan
+            wma_values[window - 1 :] = np.convolve(close_values, weights[::-1], mode='valid')
 
-        wma_values = close.rolling(window).apply(weighted_average, raw=True)
-        return {'wma': pd.Series(wma_values, name=f'wma_{window}')}
+        return {'wma': pd.Series(wma_values, index=close.index, name=f'wma_{window}')}
 
 
 class MACD(IndicatorInterface):
@@ -153,16 +156,21 @@ class Aroon(IndicatorInterface):
         low = data['low']
         window = params['window']
 
-        rolling_high = high.rolling(window + 1, min_periods=window + 1)
-        aroon_up = rolling_high.apply(
-            lambda x: float(np.argmax(x)) / window * 100, raw=True
-        )
+        w = window + 1
+        high_arr = high.to_numpy(dtype=np.float64, copy=False)
+        low_arr = low.to_numpy(dtype=np.float64, copy=False)
+        n = len(high_arr)
 
-        rolling_low = low.rolling(window + 1, min_periods=window + 1)
-        aroon_down = rolling_low.apply(
-            lambda x: float(np.argmin(x)) / window * 100, raw=True
-        )
+        aroon_up_arr = np.full(n, np.nan)
+        aroon_down_arr = np.full(n, np.nan)
+        if n >= w:
+            high_wins = np.lib.stride_tricks.sliding_window_view(high_arr, w)
+            low_wins = np.lib.stride_tricks.sliding_window_view(low_arr, w)
+            aroon_up_arr[w - 1 :] = high_wins.argmax(axis=-1).astype(np.float64) / window * 100.0
+            aroon_down_arr[w - 1 :] = low_wins.argmin(axis=-1).astype(np.float64) / window * 100.0
 
+        aroon_up = pd.Series(aroon_up_arr, index=high.index)
+        aroon_down = pd.Series(aroon_down_arr, index=low.index)
         aroon_diff = aroon_up - aroon_down
 
         return {
@@ -418,13 +426,24 @@ class CCI(IndicatorInterface):
         window = params['window']
         constant = params['constant']
 
-        def _mad(x):
-            return np.mean(np.abs(x - np.mean(x)))
-
         typical_price = (high + low + close) / 3.0
+        tp_arr = typical_price.to_numpy(dtype=np.float64, copy=False)
+        n = len(tp_arr)
+
+        # True rolling mean absolute deviation: for each window, deviations are
+        # measured against the window's OWN mean. Not the same as
+        # |tp - rolling_mean|.rolling(w).mean() (which uses each bar's own
+        # rolling mean as its reference point).
+        mad_arr = np.full(n, np.nan)
+        if n >= window:
+            tp_wins = np.lib.stride_tricks.sliding_window_view(tp_arr, window)
+            win_means = tp_wins.mean(axis=-1, keepdims=True)
+            mad_arr[window - 1 :] = np.abs(tp_wins - win_means).mean(axis=-1)
+        mad = pd.Series(mad_arr, index=typical_price.index)
+
         cci = (
             typical_price - typical_price.rolling(window, min_periods=window).mean()
-        ) / (constant * typical_price.rolling(window, min_periods=window).apply(_mad, True))
+        ) / (constant * mad)
 
         return {'cci': pd.Series(cci, name="cci")}
 

--- a/mangrove_kb/indicators/trend_indicators.py
+++ b/mangrove_kb/indicators/trend_indicators.py
@@ -496,95 +496,85 @@ class ADX(IndicatorInterface):
         if window == 0:
             raise ValueError("window may not be 0")
 
+        n = len(close)
         close_shift = close.shift(1)
 
+        # True-range equivalent: max(high, prev_close) - min(low, prev_close).
         pdm = get_min_max(high, close_shift, "max")
         pdn = get_min_max(low, close_shift, "min")
+        tr_arr = (pdm - pdn).to_numpy(dtype=np.float64)
 
-        diff_directional_movement = pdm - pdn
-
-        trs_initial = np.zeros(window - 1)
-        trs = np.zeros(len(close) - (window - 1))
-        trs[0] = diff_directional_movement.dropna().iloc[0:window].sum()
-        diff_directional_movement = diff_directional_movement.reset_index(drop=True)
-
-        for i in range(1, len(trs) - 1):
-            trs[i] = (
-                trs[i - 1] - (trs[i - 1] / float(window))
-                + diff_directional_movement[window + i]
-            )
-
+        # Directional movements. Preserve original NaN-at-index-0 semantics so
+        # nansum(...[:window+1]) matches dropna().iloc[0:window].sum().
         diff_up = high - high.shift(1)
         diff_down = low.shift(1) - low
-
         pos = abs(((diff_up > diff_down) & (diff_up > 0)) * diff_up)
         neg = abs(((diff_down > diff_up) & (diff_down > 0)) * diff_down)
+        pos_arr = pos.to_numpy(dtype=np.float64)
+        neg_arr = neg.to_numpy(dtype=np.float64)
 
-        dip = np.zeros(len(close) - (window - 1))
-        dip[0] = pos.dropna().iloc[0:window].sum()
-        pos = pos.reset_index(drop=True)
+        trs_len = n - window + 1
+        trs = np.zeros(trs_len)
+        dip = np.zeros(trs_len)
+        din = np.zeros(trs_len)
 
-        for i in range(1, len(dip) - 1):
-            dip[i] = dip[i - 1] - (dip[i - 1] / float(window)) + pos[window + i]
+        if trs_len >= 1:
+            trs[0] = np.nansum(tr_arr[: window + 1])
+            dip[0] = np.nansum(pos_arr[: window + 1])
+            din[0] = np.nansum(neg_arr[: window + 1])
 
-        din = np.zeros(len(close) - (window - 1))
-        din[0] = neg.dropna().iloc[0:window].sum()
-        neg = neg.reset_index(drop=True)
+        # Wilder running-sum recurrence:
+        #   x[i] = x[i-1] * (1 - 1/w) + raw[w + i]   for i = 1..trs_len-2
+        # The original loop stops one short, leaving trs[trs_len-1] at 0.
+        # Mean form y = x/w obeys ewm(alpha=1/w, adjust=False); scale back.
+        if trs_len >= 3:
+            alpha = 1.0 / window
+            last_inclusive = trs_len - 2
 
-        for i in range(1, len(din) - 1):
-            din[i] = din[i - 1] - (din[i - 1] / float(window)) + neg[window + i]
+            def _wilder_sum(seed_sum: float, raw: np.ndarray) -> np.ndarray:
+                # Convert the Wilder running-sum recurrence into the ewm mean
+                # form: y[i] = x[i]/w obeys ewm(alpha=1/w, adjust=False) when
+                # its input is inp[0]=seed_sum/w and inp[k>=1]=raw[w+k]. Then
+                # x = y * w. (Do NOT divide the tail by w -- that's the bug.)
+                inp = np.empty(last_inclusive + 1)
+                inp[0] = seed_sum / window
+                inp[1:] = raw[window + 1 : window + last_inclusive + 1]
+                y = pd.Series(inp).ewm(alpha=alpha, adjust=False).mean().to_numpy()
+                return y * window
 
-        # Calculate ADX
-        dip_percent = np.zeros(len(trs))
-        for idx, value in enumerate(trs):
-            if value != 0:
-                dip_percent[idx] = 100 * (dip[idx] / value)
-            else:
-                dip_percent[idx] = 0
+            trs[0 : last_inclusive + 1] = _wilder_sum(trs[0], tr_arr)
+            dip[0 : last_inclusive + 1] = _wilder_sum(dip[0], pos_arr)
+            din[0 : last_inclusive + 1] = _wilder_sum(din[0], neg_arr)
 
-        din_percent = np.zeros(len(trs))
-        for idx, value in enumerate(trs):
-            if value != 0:
-                din_percent[idx] = 100 * (din[idx] / value)
-            else:
-                din_percent[idx] = 0
+        # Percent directional indices + DX (zero-guarded to match original ifs).
+        with np.errstate(divide='ignore', invalid='ignore'):
+            dip_pct = np.where(trs != 0, 100.0 * dip / trs, 0.0)
+            din_pct = np.where(trs != 0, 100.0 * din / trs, 0.0)
+            denom = dip_pct + din_pct
+            dx = np.where(denom != 0, 100.0 * np.abs(dip_pct - din_pct) / denom, 0.0)
 
-        directional_index = np.zeros(len(trs))
-        for idx in range(len(trs)):
-            if dip_percent[idx] + din_percent[idx] != 0:
-                directional_index[idx] = 100 * np.abs(
-                    (dip_percent[idx] - din_percent[idx]) / (dip_percent[idx] + din_percent[idx])
-                )
-            else:
-                directional_index[idx] = 0
+        # ADX: Wilder smoothing of DX with a one-step lag.
+        #   adx[w]   = mean(DX[0:w])
+        #   adx[i]   = (adx[i-1]*(w-1) + DX[i-1]) / w    for i = w+1..trs_len-1
+        # Equivalent to ewm(alpha=1/w, adjust=False) on [seed, DX[w..trs_len-2]].
+        adx_local = np.zeros(trs_len)
+        if trs_len > window:
+            seed = dx[0:window].mean()
+            adx_input = np.concatenate(([seed], dx[window : trs_len - 1]))
+            adx_out = pd.Series(adx_input).ewm(alpha=1.0 / window, adjust=False).mean().to_numpy()
+            adx_local[window:trs_len] = adx_out
 
-        adx_series = np.zeros(len(trs))
-        adx_series[window] = directional_index[0:window].mean()
+        trs_initial = np.zeros(window - 1)
+        adx_series = pd.Series(np.concatenate((trs_initial, adx_local), axis=0), index=close.index)
 
-        for i in range(window + 1, len(adx_series)):
-            adx_series[i] = (
-                (adx_series[i - 1] * (window - 1)) + directional_index[i - 1]
-            ) / float(window)
-
-        adx_series = np.concatenate((trs_initial, adx_series), axis=0)
-        adx_series = pd.Series(data=adx_series, index=close.index)
-
-        # Calculate ADX pos
-        dip_output = np.zeros(len(close))
-        for i in range(1, len(trs) - 1):
-            if trs[i] != 0:
-                dip_output[i + window] = 100 * (dip[i] / trs[i])
-            else:
-                dip_output[i + window] = 0
+        # adx_pos / adx_neg: fill positions [window+1 .. n-1] with the
+        # percent directional indices for i = 1..trs_len-2 (original loop).
+        dip_output = np.zeros(n)
+        din_output = np.zeros(n)
+        if trs_len >= 3:
+            dip_output[window + 1 : n] = dip_pct[1 : trs_len - 1]
+            din_output[window + 1 : n] = din_pct[1 : trs_len - 1]
         adx_pos_series = pd.Series(dip_output, index=close.index)
-
-        # Calculate ADX neg
-        din_output = np.zeros(len(close))
-        for i in range(1, len(trs) - 1):
-            if trs[i] != 0:
-                din_output[i + window] = 100 * (din[i] / trs[i])
-            else:
-                din_output[i + window] = 0
         adx_neg_series = pd.Series(din_output, index=close.index)
 
         return {

--- a/mangrove_kb/indicators/trend_indicators.py
+++ b/mangrove_kb/indicators/trend_indicators.py
@@ -6,11 +6,21 @@ ADX, Aroon, Ichimoku, PSAR, and more.
 
 Originally from ta-master library by Dario Lopez Padial (Bukosabino).
 """
+from functools import lru_cache
+
 import numpy as np
 import pandas as pd
 
 from mangrove_kb.indicators.indicator_interface import IndicatorInterface
 from mangrove_kb.indicators.utils import get_min_max, true_range
+
+
+@lru_cache(maxsize=64)
+def _wma_weights(window: int) -> np.ndarray:
+    """Weighted-moving-average weights. Read-only; safe to reuse across calls."""
+    w = np.arange(1, window + 1, dtype=np.float64) * (2.0 / (window * (window + 1)))
+    w.flags.writeable = False
+    return w
 
 
 class SMA(IndicatorInterface):
@@ -76,7 +86,7 @@ class WMA(IndicatorInterface):
         close = data['close']
         window = params['window']
 
-        weights = np.arange(1, window + 1, dtype=np.float64) * (2.0 / (window * (window + 1)))
+        weights = _wma_weights(window)
         close_values = close.to_numpy(dtype=np.float64, copy=False)
 
         wma_values = np.empty(len(close_values), dtype=np.float64)

--- a/mangrove_kb/indicators/trend_indicators.py
+++ b/mangrove_kb/indicators/trend_indicators.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 
 from mangrove_kb.indicators.indicator_interface import IndicatorInterface
-from mangrove_kb.indicators.utils import get_min_max, true_range
+from mangrove_kb.indicators.utils import get_min_max, true_range, typical_price
 
 
 @lru_cache(maxsize=64)
@@ -436,8 +436,8 @@ class CCI(IndicatorInterface):
         window = params['window']
         constant = params['constant']
 
-        typical_price = (high + low + close) / 3.0
-        tp_arr = typical_price.to_numpy(dtype=np.float64, copy=False)
+        tp = typical_price(high, low, close)
+        tp_arr = tp.to_numpy(dtype=np.float64, copy=False)
         n = len(tp_arr)
 
         # True rolling mean absolute deviation: for each window, deviations are
@@ -449,10 +449,10 @@ class CCI(IndicatorInterface):
             tp_wins = np.lib.stride_tricks.sliding_window_view(tp_arr, window)
             win_means = tp_wins.mean(axis=-1, keepdims=True)
             mad_arr[window - 1 :] = np.abs(tp_wins - win_means).mean(axis=-1)
-        mad = pd.Series(mad_arr, index=typical_price.index)
+        mad = pd.Series(mad_arr, index=tp.index)
 
         cci = (
-            typical_price - typical_price.rolling(window, min_periods=window).mean()
+            tp - tp.rolling(window, min_periods=window).mean()
         ) / (constant * mad)
 
         return {'cci': pd.Series(cci, name="cci")}

--- a/mangrove_kb/indicators/utils.py
+++ b/mangrove_kb/indicators/utils.py
@@ -30,22 +30,28 @@ def true_range(high: pd.Series, low: pd.Series, close: pd.Series) -> pd.Series:
         J. Welles Wilder Jr.
         Used by ATR, Ultimate Oscillator, Vortex, etc.
     """
-    prev_close = close.shift(1)
-    tr1 = high - low
-    tr2 = (high - prev_close).abs()
-    tr3 = (low - prev_close).abs()
-    return pd.DataFrame({"tr1": tr1, "tr2": tr2, "tr3": tr3}).max(axis=1)
+    high_arr = high.to_numpy(dtype=np.float64, copy=False)
+    low_arr = low.to_numpy(dtype=np.float64, copy=False)
+    prev_close = close.shift(1).to_numpy(dtype=np.float64, copy=False)
+    tr1 = high_arr - low_arr
+    tr2 = np.abs(high_arr - prev_close)
+    tr3 = np.abs(low_arr - prev_close)
+    # np.fmax ignores NaN (matches pandas DataFrame.max(skipna=True)); at index
+    # 0, tr2/tr3 are NaN because prev_close is NaN -- the original fell back to
+    # tr1 there, so we must do the same.
+    tr = np.fmax(tr1, np.fmax(tr2, tr3))
+    return pd.Series(tr, index=high.index)
 
 
 def get_min_max(series1: pd.Series, series2: pd.Series, function: str = "min") -> pd.Series:
     """Element-wise min/max between two series."""
-    arr1 = np.array(series1)
-    arr2 = np.array(series2)
+    arr1 = series1.to_numpy(copy=False)
+    arr2 = series2.to_numpy(copy=False)
 
     if function == "min":
-        output = np.amin([arr1, arr2], axis=0)
+        output = np.minimum(arr1, arr2)
     elif function == "max":
-        output = np.amax([arr1, arr2], axis=0)
+        output = np.maximum(arr1, arr2)
     else:
         raise ValueError('function must be "min" or "max"')
 

--- a/mangrove_kb/indicators/utils.py
+++ b/mangrove_kb/indicators/utils.py
@@ -43,6 +43,14 @@ def true_range(high: pd.Series, low: pd.Series, close: pd.Series) -> pd.Series:
     return pd.Series(tr, index=high.index)
 
 
+def typical_price(high: pd.Series, low: pd.Series, close: pd.Series) -> pd.Series:
+    """Typical price: (high + low + close) / 3.
+
+    Used by CCI, MFI, VWAP, and the original-formula KeltnerChannel.
+    """
+    return (high + low + close) / 3.0
+
+
 def get_min_max(series1: pd.Series, series2: pd.Series, function: str = "min") -> pd.Series:
     """Element-wise min/max between two series."""
     arr1 = series1.to_numpy(copy=False)

--- a/mangrove_kb/indicators/volatility_indicators.py
+++ b/mangrove_kb/indicators/volatility_indicators.py
@@ -41,12 +41,23 @@ class ATR(IndicatorInterface):
         window = params['window']
 
         tr = true_range(high, low, close)
-        atr = np.zeros(len(close))
-        atr[window - 1] = tr[0:window].mean()
-        for i in range(window, len(atr)):
-            atr[i] = (atr[i - 1] * (window - 1) + tr.iloc[i]) / float(window)
+        tr_arr = tr.to_numpy(dtype=np.float64)
+        n = len(tr_arr)
 
-        return {'atr': pd.Series(atr, index=close.index, name='atr')}
+        # Original convention: atr[0..window-2] = 0 (from np.zeros warm-up),
+        # atr[window-1] = mean of the first `window` tr values (skipna; tr[0]
+        # is NaN so it's really mean of window-1 valid values), then Wilder
+        # smooth forward. Wilder's recurrence is identical to
+        # ewm(alpha=1/window, adjust=False) applied to
+        # [seed, tr[window], tr[window+1], ...].
+        atr_arr = np.zeros(n)
+        if n >= window:
+            seed = np.nanmean(tr_arr[:window])
+            tail = np.concatenate(([seed], tr_arr[window:]))
+            smoothed = pd.Series(tail).ewm(alpha=1.0 / window, adjust=False).mean().to_numpy()
+            atr_arr[window - 1 :] = smoothed
+
+        return {'atr': pd.Series(atr_arr, index=close.index, name='atr')}
 
 
 class BollingerBands(IndicatorInterface):

--- a/mangrove_kb/indicators/volatility_indicators.py
+++ b/mangrove_kb/indicators/volatility_indicators.py
@@ -235,11 +235,7 @@ class UlcerIndex(IndicatorInterface):
         ui_max = close.rolling(window, min_periods=1).max()
         r_i = 100 * (close - ui_max) / ui_max
 
-        def ui_function():
-            def _ui_function(x):
-                return np.sqrt((x**2 / window).sum())
-            return _ui_function
-
-        ulcer_idx = r_i.rolling(window).apply(ui_function(), raw=True)
+        # sqrt(sum(r_i^2) / window) over the rolling window == sqrt(mean(r_i^2)).
+        ulcer_idx = np.sqrt((r_i ** 2).rolling(window, min_periods=window).mean())
 
         return {'ulcer_index': pd.Series(ulcer_idx, name="ui")}

--- a/mangrove_kb/indicators/volatility_indicators.py
+++ b/mangrove_kb/indicators/volatility_indicators.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 from mangrove_kb.indicators.indicator_interface import IndicatorInterface
-from mangrove_kb.indicators.utils import true_range
+from mangrove_kb.indicators.utils import true_range, typical_price
 
 
 class ATR(IndicatorInterface):
@@ -143,7 +143,7 @@ class KeltnerChannel(IndicatorInterface):
         multiplier = params['multiplier']
 
         if original_version:
-            tp = ((high + low + close) / 3.0).rolling(window, min_periods=window).mean()
+            tp = typical_price(high, low, close).rolling(window, min_periods=window).mean()
             tp_high = (((4 * high) - (2 * low) + close) / 3.0).rolling(window, min_periods=window).mean()
             tp_low = (((-2 * high) + (4 * low) + close) / 3.0).rolling(window, min_periods=window).mean()
         else:

--- a/mangrove_kb/indicators/volume_indicators.py
+++ b/mangrove_kb/indicators/volume_indicators.py
@@ -249,13 +249,18 @@ class NVI(IndicatorInterface):
 
         price_change = close.pct_change()
         vol_decrease = volume.shift(1) > volume
-        nvi = pd.Series(data=np.nan, index=close.index, dtype="float64", name="nvi")
-        nvi.iloc[0] = 1000
-        for i in range(1, len(nvi)):
-            if vol_decrease.iloc[i]:
-                nvi.iloc[i] = nvi.iloc[i - 1] * (1.0 + price_change.iloc[i])
-            else:
-                nvi.iloc[i] = nvi.iloc[i - 1]
+
+        # NVI is a compounding index: on volume-decrease bars, scale by
+        # (1 + pct_change); otherwise carry forward. Express as a cumulative
+        # product of per-bar factors. pct_change[0] is NaN by definition;
+        # vol_decrease[0] is False (prev_volume is NaN); so factor[0] is 1
+        # and nvi[0] = 1000 * 1 = 1000, matching the original's hand-seed.
+        pct_arr = price_change.to_numpy(dtype=np.float64)
+        dec_arr = vol_decrease.to_numpy(dtype=bool)
+        pct_clean = np.where(np.isnan(pct_arr), 0.0, pct_arr)
+        factor = np.where(dec_arr, 1.0 + pct_clean, 1.0)
+        nvi_arr = 1000.0 * np.cumprod(factor)
+        nvi = pd.Series(nvi_arr, index=close.index, name="nvi")
 
         nvi_ema = nvi.ewm(span=window, adjust=False).mean()
 

--- a/mangrove_kb/indicators/volume_indicators.py
+++ b/mangrove_kb/indicators/volume_indicators.py
@@ -300,15 +300,13 @@ class MFI(IndicatorInterface):
         )
         mfr = typical_price * volume * up_down
 
-        # Positive and negative money flow with n periods
-        n_positive_mf = mfr.rolling(window, min_periods=window).apply(
-            lambda x: np.sum(np.where(x >= 0.0, x, 0.0)), raw=True
-        )
-        n_negative_mf = abs(
-            mfr.rolling(window, min_periods=window).apply(
-                lambda x: np.sum(np.where(x < 0.0, x, 0.0)), raw=True
-            )
-        )
+        # Positive and negative money flow with n periods.
+        # Mask outside the roll so the window op is a plain vectorized sum.
+        mfr_arr = np.asarray(mfr, dtype=np.float64)
+        pos_mfr = pd.Series(np.where(mfr_arr >= 0.0, mfr_arr, 0.0), index=typical_price.index)
+        neg_mfr = pd.Series(np.where(mfr_arr < 0.0, mfr_arr, 0.0), index=typical_price.index)
+        n_positive_mf = pos_mfr.rolling(window, min_periods=window).sum()
+        n_negative_mf = neg_mfr.rolling(window, min_periods=window).sum().abs()
 
         # Money flow index
         mfi_ratio = n_positive_mf / n_negative_mf

--- a/mangrove_kb/indicators/volume_indicators.py
+++ b/mangrove_kb/indicators/volume_indicators.py
@@ -6,13 +6,12 @@ CMF, Force Index, ADI, VWAP, and more.
 
 Originally from ta-master library by Dario Lopez Padial (Bukosabino).
 """
-import typing as tp
-
 import numpy as np
 import pandas as pd
 
 from mangrove_kb.indicators.indicator_interface import IndicatorInterface
 from mangrove_kb.indicators.trend_indicators import EMA, SMA
+from mangrove_kb.indicators.utils import typical_price
 
 
 class ADI(IndicatorInterface):
@@ -297,19 +296,19 @@ class MFI(IndicatorInterface):
         volume = data['volume']
         window = params['window']
 
-        typical_price = (high + low + close) / 3.0
+        tp = typical_price(high, low, close)
         up_down = np.where(
-            typical_price > typical_price.shift(1),
+            tp > tp.shift(1),
             1,
-            np.where(typical_price < typical_price.shift(1), -1, 0),
+            np.where(tp < tp.shift(1), -1, 0),
         )
-        mfr = typical_price * volume * up_down
+        mfr = tp * volume * up_down
 
         # Positive and negative money flow with n periods.
         # Mask outside the roll so the window op is a plain vectorized sum.
         mfr_arr = np.asarray(mfr, dtype=np.float64)
-        pos_mfr = pd.Series(np.where(mfr_arr >= 0.0, mfr_arr, 0.0), index=typical_price.index)
-        neg_mfr = pd.Series(np.where(mfr_arr < 0.0, mfr_arr, 0.0), index=typical_price.index)
+        pos_mfr = pd.Series(np.where(mfr_arr >= 0.0, mfr_arr, 0.0), index=tp.index)
+        neg_mfr = pd.Series(np.where(mfr_arr < 0.0, mfr_arr, 0.0), index=tp.index)
         n_positive_mf = pos_mfr.rolling(window, min_periods=window).sum()
         n_negative_mf = neg_mfr.rolling(window, min_periods=window).sum().abs()
 
@@ -351,13 +350,13 @@ class VWAP(IndicatorInterface):
         window = params['window']
 
         # 1 typical price
-        typical_price = (high + low + close) / 3.0
+        tp = typical_price(high, low, close)
 
         # 2 typical price * volume
-        typical_price_volume = typical_price * volume
+        tp_volume = tp * volume
 
         # 3 total price * volume
-        total_pv = typical_price_volume.rolling(window, min_periods=window).sum()
+        total_pv = tp_volume.rolling(window, min_periods=window).sum()
 
         # 4 total volume
         total_volume = volume.rolling(window, min_periods=window).sum()

--- a/mangrove_kb/signals/patterns.py
+++ b/mangrove_kb/signals/patterns.py
@@ -78,6 +78,16 @@ def _hl_data(df: pd.DataFrame) -> dict:
     return {"high": df["High"], "low": df["Low"]}
 
 
+def _hit(series: pd.Series, window: int) -> bool:
+    """True if any value in the last `window` entries is > 0.
+
+    Used by the FILTER composites below to short-circuit the compute/check
+    loop: each pattern indicator is computed only until the first positive
+    hit is found in its last-`window` slice.
+    """
+    return bool((series.iloc[-window:] > 0).any())
+
+
 # =============================================================================
 # Single-Candle TRIGGER Signals
 # =============================================================================
@@ -947,28 +957,33 @@ def bullish_pattern_recent(df: pd.DataFrame, window: int = 5) -> bool:
         return False
     ohlc = _ohlc_data(df)
     oc = _oc_data(df)
+    w = window
 
-    checks = [
-        Hammer.compute(data=ohlc, params={"wick_ratio": 2.0, "upper_wick_max": 0.1})["hammer"],
-        InvertedHammer.compute(data=ohlc, params={"wick_ratio": 2.0, "lower_wick_max": 0.1})["inverted_hammer"],
-        Engulfing.compute(data=oc, params={})["engulfing"].clip(lower=0),
-        Harami.compute(data=oc, params={})["harami"].clip(lower=0),
-        PiercingLine.compute(data=ohlc, params={"min_penetration": 0.5, "require_gap": False})["piercing_line"],
-        DragonflyDoji.compute(data=ohlc, params={"body_threshold": 0.1, "upper_wick_max": 0.1})["dragonfly_doji"],
-        TweezerBottoms.compute(data=ohlc, params={"tolerance": 0.01})["tweezer_bottoms"],
-        PinBar.compute(data=ohlc, params={"wick_ratio": 2.0, "body_position": 0.33})["pin_bar"].clip(lower=0),
-    ]
+    if _hit(Hammer.compute(data=ohlc, params={"wick_ratio": 2.0, "upper_wick_max": 0.1})["hammer"], w):
+        return True
+    if _hit(InvertedHammer.compute(data=ohlc, params={"wick_ratio": 2.0, "lower_wick_max": 0.1})["inverted_hammer"], w):
+        return True
+    if _hit(Engulfing.compute(data=oc, params={})["engulfing"].clip(lower=0), w):
+        return True
+    if _hit(Harami.compute(data=oc, params={})["harami"].clip(lower=0), w):
+        return True
+    if _hit(PiercingLine.compute(data=ohlc, params={"min_penetration": 0.5, "require_gap": False})["piercing_line"], w):
+        return True
+    if _hit(DragonflyDoji.compute(data=ohlc, params={"body_threshold": 0.1, "upper_wick_max": 0.1})["dragonfly_doji"], w):
+        return True
+    if _hit(TweezerBottoms.compute(data=ohlc, params={"tolerance": 0.01})["tweezer_bottoms"], w):
+        return True
+    if _hit(PinBar.compute(data=ohlc, params={"wick_ratio": 2.0, "body_position": 0.33})["pin_bar"].clip(lower=0), w):
+        return True
+
     if len(df) >= 3:
-        checks.extend([
-            MorningStar.compute(data=ohlc, params={"body_threshold": 0.3})["morning_star"],
-            ThreeWhiteSoldiers.compute(data=ohlc, params={"min_body_ratio": 0.5})["three_white_soldiers"],
-            ThreeInsideUp.compute(data=oc, params={})["three_inside_up"],
-        ])
-
-    for series in checks:
-        recent = series.iloc[-window:]
-        if (recent > 0).any():
+        if _hit(MorningStar.compute(data=ohlc, params={"body_threshold": 0.3})["morning_star"], w):
             return True
+        if _hit(ThreeWhiteSoldiers.compute(data=ohlc, params={"min_body_ratio": 0.5})["three_white_soldiers"], w):
+            return True
+        if _hit(ThreeInsideUp.compute(data=oc, params={})["three_inside_up"], w):
+            return True
+
     return False
 
 
@@ -995,28 +1010,33 @@ def bearish_pattern_recent(df: pd.DataFrame, window: int = 5) -> bool:
         return False
     ohlc = _ohlc_data(df)
     oc = _oc_data(df)
+    w = window
 
-    checks = [
-        HangingMan.compute(data=ohlc, params={"wick_ratio": 2.0, "upper_wick_max": 0.1})["hanging_man"],
-        ShootingStar.compute(data=ohlc, params={"wick_ratio": 2.0, "lower_wick_max": 0.1})["shooting_star"],
-        Engulfing.compute(data=oc, params={})["engulfing"].clip(upper=0).abs(),
-        Harami.compute(data=oc, params={})["harami"].clip(upper=0).abs(),
-        DarkCloudCover.compute(data=ohlc, params={"min_penetration": 0.5, "require_gap": False})["dark_cloud_cover"].abs(),
-        GravestoneDoji.compute(data=ohlc, params={"body_threshold": 0.1, "lower_wick_max": 0.1})["gravestone_doji"],
-        TweezerTops.compute(data=ohlc, params={"tolerance": 0.01})["tweezer_tops"].abs(),
-        PinBar.compute(data=ohlc, params={"wick_ratio": 2.0, "body_position": 0.33})["pin_bar"].clip(upper=0).abs(),
-    ]
+    if _hit(HangingMan.compute(data=ohlc, params={"wick_ratio": 2.0, "upper_wick_max": 0.1})["hanging_man"], w):
+        return True
+    if _hit(ShootingStar.compute(data=ohlc, params={"wick_ratio": 2.0, "lower_wick_max": 0.1})["shooting_star"], w):
+        return True
+    if _hit(Engulfing.compute(data=oc, params={})["engulfing"].clip(upper=0).abs(), w):
+        return True
+    if _hit(Harami.compute(data=oc, params={})["harami"].clip(upper=0).abs(), w):
+        return True
+    if _hit(DarkCloudCover.compute(data=ohlc, params={"min_penetration": 0.5, "require_gap": False})["dark_cloud_cover"].abs(), w):
+        return True
+    if _hit(GravestoneDoji.compute(data=ohlc, params={"body_threshold": 0.1, "lower_wick_max": 0.1})["gravestone_doji"], w):
+        return True
+    if _hit(TweezerTops.compute(data=ohlc, params={"tolerance": 0.01})["tweezer_tops"].abs(), w):
+        return True
+    if _hit(PinBar.compute(data=ohlc, params={"wick_ratio": 2.0, "body_position": 0.33})["pin_bar"].clip(upper=0).abs(), w):
+        return True
+
     if len(df) >= 3:
-        checks.extend([
-            EveningStar.compute(data=ohlc, params={"body_threshold": 0.3})["evening_star"].abs(),
-            ThreeBlackCrows.compute(data=ohlc, params={"min_body_ratio": 0.5})["three_black_crows"].abs(),
-            ThreeInsideDown.compute(data=oc, params={})["three_inside_down"].abs(),
-        ])
-
-    for series in checks:
-        recent = series.iloc[-window:]
-        if (recent > 0).any():
+        if _hit(EveningStar.compute(data=ohlc, params={"body_threshold": 0.3})["evening_star"].abs(), w):
             return True
+        if _hit(ThreeBlackCrows.compute(data=ohlc, params={"min_body_ratio": 0.5})["three_black_crows"].abs(), w):
+            return True
+        if _hit(ThreeInsideDown.compute(data=oc, params={})["three_inside_down"].abs(), w):
+            return True
+
     return False
 
 
@@ -1042,23 +1062,23 @@ def reversal_pattern_bullish(df: pd.DataFrame, window: int = 5) -> bool:
         return False
     ohlc = _ohlc_data(df)
     oc = _oc_data(df)
+    w = window
 
-    checks = [
-        Hammer.compute(data=ohlc, params={"wick_ratio": 2.0, "upper_wick_max": 0.1})["hammer"],
-        InvertedHammer.compute(data=ohlc, params={"wick_ratio": 2.0, "lower_wick_max": 0.1})["inverted_hammer"],
-        Engulfing.compute(data=oc, params={})["engulfing"].clip(lower=0),
-        PiercingLine.compute(data=ohlc, params={"min_penetration": 0.5, "require_gap": False})["piercing_line"],
-        DragonflyDoji.compute(data=ohlc, params={"body_threshold": 0.1, "upper_wick_max": 0.1})["dragonfly_doji"],
-    ]
+    if _hit(Hammer.compute(data=ohlc, params={"wick_ratio": 2.0, "upper_wick_max": 0.1})["hammer"], w):
+        return True
+    if _hit(InvertedHammer.compute(data=ohlc, params={"wick_ratio": 2.0, "lower_wick_max": 0.1})["inverted_hammer"], w):
+        return True
+    if _hit(Engulfing.compute(data=oc, params={})["engulfing"].clip(lower=0), w):
+        return True
+    if _hit(PiercingLine.compute(data=ohlc, params={"min_penetration": 0.5, "require_gap": False})["piercing_line"], w):
+        return True
+    if _hit(DragonflyDoji.compute(data=ohlc, params={"body_threshold": 0.1, "upper_wick_max": 0.1})["dragonfly_doji"], w):
+        return True
+
     if len(df) >= 3:
-        checks.append(
-            MorningStar.compute(data=ohlc, params={"body_threshold": 0.3})["morning_star"]
-        )
-
-    for series in checks:
-        recent = series.iloc[-window:]
-        if (recent > 0).any():
+        if _hit(MorningStar.compute(data=ohlc, params={"body_threshold": 0.3})["morning_star"], w):
             return True
+
     return False
 
 
@@ -1084,23 +1104,23 @@ def reversal_pattern_bearish(df: pd.DataFrame, window: int = 5) -> bool:
         return False
     ohlc = _ohlc_data(df)
     oc = _oc_data(df)
+    w = window
 
-    checks = [
-        HangingMan.compute(data=ohlc, params={"wick_ratio": 2.0, "upper_wick_max": 0.1})["hanging_man"],
-        ShootingStar.compute(data=ohlc, params={"wick_ratio": 2.0, "lower_wick_max": 0.1})["shooting_star"],
-        Engulfing.compute(data=oc, params={})["engulfing"].clip(upper=0).abs(),
-        DarkCloudCover.compute(data=ohlc, params={"min_penetration": 0.5, "require_gap": False})["dark_cloud_cover"].abs(),
-        GravestoneDoji.compute(data=ohlc, params={"body_threshold": 0.1, "lower_wick_max": 0.1})["gravestone_doji"],
-    ]
+    if _hit(HangingMan.compute(data=ohlc, params={"wick_ratio": 2.0, "upper_wick_max": 0.1})["hanging_man"], w):
+        return True
+    if _hit(ShootingStar.compute(data=ohlc, params={"wick_ratio": 2.0, "lower_wick_max": 0.1})["shooting_star"], w):
+        return True
+    if _hit(Engulfing.compute(data=oc, params={})["engulfing"].clip(upper=0).abs(), w):
+        return True
+    if _hit(DarkCloudCover.compute(data=ohlc, params={"min_penetration": 0.5, "require_gap": False})["dark_cloud_cover"].abs(), w):
+        return True
+    if _hit(GravestoneDoji.compute(data=ohlc, params={"body_threshold": 0.1, "lower_wick_max": 0.1})["gravestone_doji"], w):
+        return True
+
     if len(df) >= 3:
-        checks.append(
-            EveningStar.compute(data=ohlc, params={"body_threshold": 0.3})["evening_star"].abs()
-        )
-
-    for series in checks:
-        recent = series.iloc[-window:]
-        if (recent > 0).any():
+        if _hit(EveningStar.compute(data=ohlc, params={"body_threshold": 0.3})["evening_star"].abs(), w):
             return True
+
     return False
 
 
@@ -1125,16 +1145,12 @@ def continuation_pattern_bullish(df: pd.DataFrame, window: int = 5) -> bool:
         return False
     ohlc = _ohlc_data(df)
     oc = _oc_data(df)
+    w = window
 
-    checks = [
-        ThreeWhiteSoldiers.compute(data=ohlc, params={"min_body_ratio": 0.5})["three_white_soldiers"],
-        ThreeInsideUp.compute(data=oc, params={})["three_inside_up"],
-    ]
-
-    for series in checks:
-        recent = series.iloc[-window:]
-        if (recent > 0).any():
-            return True
+    if _hit(ThreeWhiteSoldiers.compute(data=ohlc, params={"min_body_ratio": 0.5})["three_white_soldiers"], w):
+        return True
+    if _hit(ThreeInsideUp.compute(data=oc, params={})["three_inside_up"], w):
+        return True
     return False
 
 
@@ -1159,16 +1175,12 @@ def continuation_pattern_bearish(df: pd.DataFrame, window: int = 5) -> bool:
         return False
     ohlc = _ohlc_data(df)
     oc = _oc_data(df)
+    w = window
 
-    checks = [
-        ThreeBlackCrows.compute(data=ohlc, params={"min_body_ratio": 0.5})["three_black_crows"].abs(),
-        ThreeInsideDown.compute(data=oc, params={})["three_inside_down"].abs(),
-    ]
-
-    for series in checks:
-        recent = series.iloc[-window:]
-        if (recent > 0).any():
-            return True
+    if _hit(ThreeBlackCrows.compute(data=ohlc, params={"min_body_ratio": 0.5})["three_black_crows"].abs(), w):
+        return True
+    if _hit(ThreeInsideDown.compute(data=oc, params={})["three_inside_down"].abs(), w):
+        return True
     return False
 
 
@@ -1193,20 +1205,16 @@ def indecision_pattern_recent(df: pd.DataFrame, window: int = 5) -> bool:
         return False
     ohlc = _ohlc_data(df)
     hl = _hl_data(df)
+    w = window
 
-    checks = [
-        Doji.compute(data=ohlc, params={"body_threshold": 0.1})["doji"],
-        SpinningTop.compute(data=ohlc, params={"body_max": 0.3, "wick_min": 0.2})["spinning_top"],
-        InsideBar.compute(data=hl, params={})["inside_bar"],
-    ]
+    if _hit(Doji.compute(data=ohlc, params={"body_threshold": 0.1})["doji"], w):
+        return True
+    if _hit(SpinningTop.compute(data=ohlc, params={"body_max": 0.3, "wick_min": 0.2})["spinning_top"], w):
+        return True
+    if _hit(InsideBar.compute(data=hl, params={})["inside_bar"], w):
+        return True
     if len(df) >= 7:
-        checks.append(
-            NarrowRange.compute(data=hl, params={"window": 7})["narrow_range"]
-        )
-
-    for series in checks:
-        recent = series.iloc[-window:]
-        if (recent > 0).any():
+        if _hit(NarrowRange.compute(data=hl, params={"window": 7})["narrow_range"], w):
             return True
     return False
 


### PR DESCRIPTION
Indicator and signal optimization workstream from `MangroveOracle-optim/OPTIMIZATION_PLAN.md`. Four commits, five landed sub-waves, one abandoned (Wave 4 — documented below, nothing to review there).

All measurements on the same 30,479-bar BTC 5m fixture (`btc_2026-01-01_2026-04-16_5m.csv`), 5 runs per signal/indicator, inside the isolated `mangrove-oracle-dev` container (no contact with the prod mangrove-oracle container running the replay).

---

## Wave 1 — vectorize 7 `.rolling().apply(python_callback)` sites (commit `1c570f8`)

### Speedups

| Indicator | Before | After | Speedup | Max rel diff |
|---|---:|---:|---:|---:|
| WMA | 1612.25 ms | **0.48 ms** | **3365×** | 6.1e-16 |
| MFI | 332.03 ms | **2.21 ms** | **150×** | 2.2e-14 |
| CCI | 299.34 ms | **3.24 ms** | **92×** | 0 |
| UlcerIndex | 123.03 ms | **1.59 ms** | **77×** | 6.8e-13 |
| Aroon | 117.41 ms | **1.80 ms** | **65×** | 0 |

Rewrite strategies:
- WMA: `np.convolve(close, weights[::-1], mode='valid')` with NaN warm-up prefix.
- Aroon: `sliding_window_view` + `np.argmax/argmin`.
- CCI: `sliding_window_view` for MAD (each window's own mean; *not* the tempting `(tp - rolling_mean).abs().rolling.mean()` which is algebraically different).
- MFI: move the `np.where` mask outside the rolling window, reducing to two plain `rolling().sum()` calls.
- UlcerIndex: `sqrt((r_i**2).rolling(w).mean())` — the nested closure collapses.

### Signal firing parity (Wave 1 signals, 30,479 bars each)

| Signal | Mismatches | Fires pre | Fires post |
|---|---:|---:|---:|
| wma_cross_up | 0 / 30,479 | 977 | 977 |
| wma_cross_down | 0 / 30,479 | 977 | 977 |
| aroon_up_trend | 0 / 30,479 | 9,825 | 9,825 |
| aroon_down_trend | 0 / 30,479 | 9,982 | 9,982 |
| aroon_cross_bullish | 0 / 30,479 | 670 | 670 |
| aroon_cross_bearish | 0 / 30,479 | 672 | 672 |
| cci_overbought | 0 / 30,479 | 5,997 | 5,997 |
| cci_oversold | 0 / 30,479 | 6,135 | 6,135 |
| mfi_overbought | 0 / 30,479 | 1,437 | 1,437 |
| mfi_oversold | 0 / 30,479 | 1,666 | 1,666 |
| ulcer_high_risk | 0 / 30,479 | 0 | 0 |
| ulcer_low_risk | 0 / 30,479 | 30,466 | 30,466 |

**365,748 boolean positions checked, 68,804 fires each side, 0 mismatches.**

---

## Wave 2 — hoist allocations + utils fixes (commit `bd75f9e`)

### Speedups (vs post-Wave-1 baseline)

| Indicator | Before | After | Speedup |
|---|---:|---:|---:|
| **Vortex** | 6.80 ms | **1.86 ms** | **3.65×** |
| **UltimateOscillator** | 10.75 ms | **5.56 ms** | **1.93×** |
| TweezerTops | 1.62 ms | 1.43 ms | 1.13× |
| ATR | 114.02 ms | 108.65 ms | 1.05× (helper is a small fraction of the Wilder loop cost — gets real in Wave 3) |
| KeltnerChannel | 113.94 ms | 109.97 ms | 1.04× (same) |
| ADX | 290.20 ms | 290.23 ms | 1.00× (same) |
| TweezerBottoms | 1.22 ms | 1.24 ms | noise |
| WMA | 0.48 ms | 0.51 ms | noise |

Changes: `@lru_cache(maxsize=64)` for WMA weight vector; `np.fmax` in `true_range` (preserves pandas `.max(skipna=True)` NaN semantics — **caught a real bug** on first pass with `np.maximum`); `np.minimum/maximum` element-wise in `get_min_max`; parametrized `avg_window` on Tweezer patterns (X.3).

### Correctness (against post-Wave-1 golden)

18 output series across 8 indicators: **all `np.allclose(rtol=1e-12, atol=1e-12)` with 0 diff**. NaN masks exact.

---

## Wave 3 — vectorize manual Wilder/DMI loops (commit `95220a1`)

### Speedups (vs post-Wave-2 baseline)

| Indicator | Before | After | Speedup |
|---|---:|---:|---:|
| **NVI** | 891.58 ms | **1.31 ms** | **683×** |
| **ATR** | 106.54 ms | **0.73 ms** | **146×** |
| **KeltnerChannel** (downstream of ATR) | 109.05 ms | **1.81 ms** | **60×** |
| **ADX** | 286.65 ms | **4.56 ms** | **63×** |

### Indicator drift vs pre-Wave-3 golden

| Output | Max abs | Max rel |
|---|---:|---:|
| ATR | 5.7e-13 | 1.9e-15 |
| ADX / adx_pos / adx_neg | ≤ 1.1e-13 | ≤ 3.2e-15 |
| NVI / NVI ema | ≤ 1.3e-11 | ≤ 1.0e-14 |
| KC hband / lband | 1.5e-11 | 2.2e-16 |

All at machine-epsilon levels — pandas `ewm(alpha=1/w, adjust=False)` runs the identical Wilder recurrence as the manual loop, just in C.

### Signal firing parity (Wave 3 signals)

| Signal | Mismatches | Fires pre | Fires post |
|---|---:|---:|---:|
| atr_high_volatility | 0 / 30,479 | 0 | 0 |
| kc_upper_breakout | 0 / 30,479 | 680 | 680 |
| kc_lower_breakout | 0 / 30,479 | 780 | 780 |
| adx_strong_trend | 0 / 30,479 | 12,787 | 12,787 |
| adx_bullish_di | 0 / 30,479 | 14,812 | 14,812 |
| nvi_bullish | 0 / 30,479 | 18,159 | 18,159 |
| nvi_bearish | 0 / 30,479 | 12,318 | 12,318 |

**213,353 boolean positions checked, 59,536 fires each side, 0 mismatches.**

**KAMA deferred** — its state recurrence `kama[i] = kama[i-1] + sc[i] * (close[i] - kama[i-1])` has a non-constant coefficient (`sc` varies per bar), so it doesn't map to `ewm`. Numba fix filed as MangroveKnowledgeBase#28.

### Bug caught on first ADX pass

My initial ADX rewrite divided the ewm tail input by `window`, producing max abs drift of 32 absolute / 100% relative. The golden + firing harness caught it within one bench cycle. The correct conversion is `inp[0] = seed_sum/w, inp[k>=1] = raw[w+k]` (no divide), then scale `y × w`. This is exactly why the harness exists even when `ewm` "should just work."

---

## Wave 4a — composite pattern signal short-circuit + X.1 (commit `8152fcf`)

### 4a — short-circuit

The 8 composite signals in `signals/patterns.py` previously computed 2–11 pattern indicators on a 100-bar window then looped to check for fires. Rewrite interleaves compute → check → early-return so patterns after the first hit aren't computed.

| Signal | Patterns | Fire rate | Before | After | Speedup |
|---|---:|---:|---:|---:|---:|
| **bullish_pattern_recent** | 11 | 73% | 12,355 µs | **7,326 µs** | **1.69×** |
| **bearish_pattern_recent** | 11 | 72% | 12,982 µs | **7,574 µs** | **1.71×** |
| **indecision_pattern_recent** | 3–4 | 89% | 2,297 µs | **1,452 µs** | **1.58×** |
| reversal_pattern_bearish | 5–6 | 54% | 6,388 µs | **4,928 µs** | 1.30× |
| reversal_pattern_bullish | 5–6 | 54% | 6,016 µs | **4,707 µs** | 1.28× |
| continuation_pattern_bearish | 2 | 7% | 2,299 µs | 2,280 µs | 1.01× (noise) |
| continuation_pattern_bullish | 2 | 8% | 2,019 µs | 2,020 µs | 1.00× (noise) |
| strong_body_recent | 1 | 29% | 1,670 µs | 1,664 µs | 1.00× (only 1 pattern — no short-circuit) |

Wins scale with `patterns × fire_rate`. 2-pattern composites with low fire rates can't benefit.

### 4a — signal firing parity (sliding 100-bar window × 1000 positions)

| Signal | Mismatches | Fires pre | Fires post |
|---|---:|---:|---:|
| bullish_pattern_recent | 0 / 1,000 | 726 | 726 |
| bearish_pattern_recent | 0 / 1,000 | 716 | 716 |
| reversal_pattern_bullish | 0 / 1,000 | 536 | 536 |
| reversal_pattern_bearish | 0 / 1,000 | 540 | 540 |
| continuation_pattern_bullish | 0 / 1,000 | 80 | 80 |
| continuation_pattern_bearish | 0 / 1,000 | 69 | 69 |
| indecision_pattern_recent | 0 / 1,000 | 890 | 890 |
| strong_body_recent | 0 / 1,000 | 294 | 294 |

**8,000 boolean positions checked, 3,851 fires each side, 0 mismatches.**

### X.1 — typical_price helper

Pure refactor, no perf impact. Added `typical_price(high, low, close)` to `indicators/utils.py`. Consolidated four duplicated `(high + low + close) / 3.0` call sites: CCI, MFI, VWAP, and the original-formula branch of KeltnerChannel. Also dropped an unused `import typing as tp` from `volume_indicators.py`.

CMF uses a different formula (`((C-L) - (H-C))/(H-L)`) and was *not* a typical-price call site.

**Wave 1 + Wave 3 firing re-verified after this refactor**: 0 mismatches across 579,101 boolean positions.

---

## Overall correctness

| Harness | Positions | Mismatches |
|---|---:|---:|
| Wave 1 signal firing (pre-optim baseline) | 365,748 | **0** |
| Wave 3 signal firing (pre-Wave-3 golden) | 213,353 | **0** |
| Wave 4a signal firing (pre-4a golden) | 8,000 | **0** |
| **Total** | **587,101** | **0** |

---

## Wave 4 (abandoned — no changes in this PR)

A `compute_tail(..., n=1)` API was attempted. At the engine's 100-bar sliding-window pattern, it regressed every signal by 7–27% because Series construction overhead exceeded the saved compute work now that Waves 1–3 had made the underlying compute C-fast. Fully reverted before any commit. Empirical write-up in `MangroveOracle-optim/OPTIMIZATION_PLAN.md`. **Do not redo.** The real remaining lever is Wave 5 (incremental indicator state), filed as MangroveAI#419.

---

## Test plan

- [x] 5-run benchmarks per wave on 30,479-bar 5m BTC fixture in `mangrove-oracle-dev`
- [x] Indicator-level golden comparison per wave (allclose or drift summary)
- [x] Signal-firing parity per wave — 0 mismatches across 587k boolean positions total
- [x] Wave 1 + Wave 3 regression re-check after X.1 refactor
- [x] Wave 4a sliding-window correctness via bar-by-bar boolean compare
- [ ] End-to-end sweep validation on `mangrove-oracle` **after merge + KB tag + image rebuild** — that's the real proof point, can't run it inside this PR

## Post-merge checklist (for reviewer)

1. Merge this PR.
2. Run `.github/workflows/release.yml` (workflow_dispatch) to cut a new `mangrove-kb` tag (`v0.4.2` — additive backwards-compatible optimizations warrant a patch bump). Workflow bumps version, tags, creates GitHub Release, publishes to PyPI.
3. Rebuild the production `mangrove-oracle` container (`docker compose up --build -d`) so its `mangrove-kb>=0.4.1` pin pulls the new release.
4. Resume sweep backtests. Record pre/post sweep wall time for end-to-end validation.

## Related

- Issues filed for deferred items: MangroveKnowledgeBase#28 (KAMA numba), MangroveKnowledgeBase#29 (X.2 request-scoped indicator cache), MangroveAI#418 (X.4 normalize_timeframe), MangroveAI#419 (Wave 5 incremental state — the biggest remaining perf lever).
- Bench + firing harnesses and the full plan doc sit on the `feature/indicator-optimizations` branch of MangroveOracle-optim, to be committed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
