### PR TITLE
docs: cooldown_config migration + deprecate legacy cooldown keys (Phase 6)

### DIFF
--- a/docs/api-reference/backtesting.mdx
+++ b/docs/api-reference/backtesting.mdx
@@ -54,7 +54,7 @@ curl -X POST http://localhost:5001/api/v1/backtesting/backtest \
     "volatility_mode": "stddev",
     "enable_volatility_adjustment": false,
     "cooldown_config": {
-      "1h": {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
+      "1h": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
     },
     "strategy_json": "{\"name\": \"ETH Strategy\", \"asset\": \"ETH\", \"entry\": [{\"name\": \"macd_bullish_cross\", \"timeframe\": \"1h\", \"signal_type\": \"TRIGGER\", \"params\": {\"window_fast\": 12, \"window_slow\": 26, \"window_sign\": 9}}, {\"name\": \"is_above_sma\", \"timeframe\": \"1h\", \"params\": {\"window\": 50}, \"signal_type\": \"FILTER\"}], \"exit\": []}"
   }'
@@ -83,7 +83,7 @@ response = requests.post(
         "volatility_mode": "stddev",
         "enable_volatility_adjustment": False,
         "cooldown_config": {
-            "1h": {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
+            "1h": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
         },
         "strategy_json": '{"name": "ETH Strategy", "asset": "ETH", "entry": [{"name": "macd_bullish_cross", "timeframe": "1h", "signal_type": "TRIGGER", "params": {"window_fast": 12, "window_slow": 26, "window_sign": 9}}, {"name": "is_above_sma", "timeframe": "1h", "params": {"window": 50}, "signal_type": "FILTER"}], "exit": []}'
     }
@@ -180,7 +180,7 @@ curl -X POST http://localhost:5001/api/v1/backtesting/backtest/bulk \
     "volatility_mode": "stddev",
     "enable_volatility_adjustment": false,
     "cooldown_config": {
-      "1h": {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
+      "1h": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
     }
   }'
 ```
@@ -193,20 +193,21 @@ Pass `cooldown_config` as a top-level key in the backtest request body to contro
 
 ```json
 "cooldown_config": {
-  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
-  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
-  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
-  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+  "5m":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+  "15m": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+  "1h":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+  "1d":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
 }
 ```
 
 | Key | Description |
 |-----|-------------|
-| `max_hold_time_hours` | Max position hold time in hours for this timeframe |
 | `short_loss_limit` | Losses in `short_window_bars` that trip the short-tier cooldown |
 | `long_loss_limit` | Losses in `long_window_bars` that trip the long-tier cooldown |
 | `short_window_bars` | Rolling lookback AND cooldown duration (bars) for the short tier |
 | `long_window_bars` | Rolling lookback AND cooldown duration (bars) for the long tier |
+
+Max hold time is controlled by `execution_config.max_hold_bars`, not by `cooldown_config`.
 
 <Warning>
 **Deprecated parameters:** `cooldown_bars`, `daily_momentum_limit`, and `weekly_momentum_limit` are deprecated flat keys accepted for backward compatibility during the 90-day grace period. Migrate to `cooldown_config` before the next major version. The legacy keys are not shown in the examples above.

--- a/docs/api-reference/backtesting.mdx
+++ b/docs/api-reference/backtesting.mdx
@@ -53,9 +53,9 @@ curl -X POST http://localhost:5001/api/v1/backtesting/backtest \
     "target_volatility": 0.02,
     "volatility_mode": "stddev",
     "enable_volatility_adjustment": false,
-    "cooldown_bars": 24,
-    "daily_momentum_limit": 3.0,
-    "weekly_momentum_limit": 3.0,
+    "cooldown_config": {
+      "1h": {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
+    },
     "strategy_json": "{\"name\": \"ETH Strategy\", \"asset\": \"ETH\", \"entry\": [{\"name\": \"macd_bullish_cross\", \"timeframe\": \"1h\", \"signal_type\": \"TRIGGER\", \"params\": {\"window_fast\": 12, \"window_slow\": 26, \"window_sign\": 9}}, {\"name\": \"is_above_sma\", \"timeframe\": \"1h\", \"params\": {\"window\": 50}, \"signal_type\": \"FILTER\"}], \"exit\": []}"
   }'
 ```
@@ -82,9 +82,9 @@ response = requests.post(
         "target_volatility": 0.02,
         "volatility_mode": "stddev",
         "enable_volatility_adjustment": False,
-        "cooldown_bars": 24,
-        "daily_momentum_limit": 3.0,
-        "weekly_momentum_limit": 3.0,
+        "cooldown_config": {
+            "1h": {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
+        },
         "strategy_json": '{"name": "ETH Strategy", "asset": "ETH", "entry": [{"name": "macd_bullish_cross", "timeframe": "1h", "signal_type": "TRIGGER", "params": {"window_fast": 12, "window_slow": 26, "window_sign": 9}}, {"name": "is_above_sma", "timeframe": "1h", "params": {"window": 50}, "signal_type": "FILTER"}], "exit": []}'
     }
 )
@@ -179,10 +179,37 @@ curl -X POST http://localhost:5001/api/v1/backtesting/backtest/bulk \
     "target_volatility": 0.02,
     "volatility_mode": "stddev",
     "enable_volatility_adjustment": false,
-    "cooldown_bars": 24,
-    "daily_momentum_limit": 3.0,
-    "weekly_momentum_limit": 3.0
+    "cooldown_config": {
+      "1h": {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48, "long_window_bars": 144}
+    }
   }'
 ```
 
 Individual strategy failures are captured per-result without aborting the batch. The `data_fetches` field shows how many unique API calls were made.
+
+## Cooldown Parameters
+
+Pass `cooldown_config` as a top-level key in the backtest request body to control loss-streak limits and cooldown durations. The engine selects the entry keyed to the `interval` value of the request.
+
+```json
+"cooldown_config": {
+  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+}
+```
+
+| Key | Description |
+|-----|-------------|
+| `max_hold_time_hours` | Max position hold time in hours for this timeframe |
+| `short_loss_limit` | Losses in `short_window_bars` that trip the short-tier cooldown |
+| `long_loss_limit` | Losses in `long_window_bars` that trip the long-tier cooldown |
+| `short_window_bars` | Rolling lookback AND cooldown duration (bars) for the short tier |
+| `long_window_bars` | Rolling lookback AND cooldown duration (bars) for the long tier |
+
+<Warning>
+**Deprecated parameters:** `cooldown_bars`, `daily_momentum_limit`, and `weekly_momentum_limit` are deprecated flat keys accepted for backward compatibility during the 90-day grace period. Migrate to `cooldown_config` before the next major version. The legacy keys are not shown in the examples above.
+</Warning>
+
+See the [Risk Management guide](/guides/risk-management) for full cooldown tuning details.

--- a/docs/api-reference/execution.mdx
+++ b/docs/api-reference/execution.mdx
@@ -236,20 +236,21 @@ The execution engine reads `cooldown_config` from the strategy's `execution_conf
 
 ```json
 "cooldown_config": {
-  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
-  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
-  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
-  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+  "5m":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+  "15m": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+  "1h":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+  "1d":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
 }
 ```
 
 | Key | Description |
 |-----|-------------|
-| `max_hold_time_hours` | Max position hold time in hours for this timeframe |
 | `short_loss_limit` | Losses in `short_window_bars` that trip the short-tier cooldown |
 | `long_loss_limit` | Losses in `long_window_bars` that trip the long-tier cooldown |
 | `short_window_bars` | Rolling lookback AND cooldown duration (bars) for the short tier |
 | `long_window_bars` | Rolling lookback AND cooldown duration (bars) for the long tier |
+
+Max hold time is controlled by `execution_config.time_based_exits.max_hold_bars`, not by `cooldown_config`.
 
 The engine selects the entry keyed to the strategy's primary timeframe. If `cooldown_config` is absent or the timeframe key is missing, it falls back to the legacy flat keys (`cooldown_bars`, `daily_momentum_limit`, `weekly_momentum_limit`) and emits a deprecation warning.
 

--- a/docs/api-reference/execution.mdx
+++ b/docs/api-reference/execution.mdx
@@ -229,3 +229,32 @@ curl -s -X POST http://localhost:5001/api/v1/execution/evaluate/bulk \
   -H "Content-Type: application/json" \
   -d '{"strategy_ids": ["$ID1", "$ID2"], "persist": false}' | jq '.'
 ```
+
+## Cooldown Configuration
+
+The execution engine reads `cooldown_config` from the strategy's `execution_config` to determine per-timeframe loss streak limits and cooldown durations. When a cooldown trips, new entries for that asset are blocked for a number of bars equal to the window that tripped.
+
+```json
+"cooldown_config": {
+  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+}
+```
+
+| Key | Description |
+|-----|-------------|
+| `max_hold_time_hours` | Max position hold time in hours for this timeframe |
+| `short_loss_limit` | Losses in `short_window_bars` that trip the short-tier cooldown |
+| `long_loss_limit` | Losses in `long_window_bars` that trip the long-tier cooldown |
+| `short_window_bars` | Rolling lookback AND cooldown duration (bars) for the short tier |
+| `long_window_bars` | Rolling lookback AND cooldown duration (bars) for the long tier |
+
+The engine selects the entry keyed to the strategy's primary timeframe. If `cooldown_config` is absent or the timeframe key is missing, it falls back to the legacy flat keys (`cooldown_bars`, `daily_momentum_limit`, `weekly_momentum_limit`) and emits a deprecation warning.
+
+<Warning>
+**Deprecated keys:** `cooldown_bars`, `daily_momentum_limit`, `weekly_momentum_limit`, and the top-level `max_hold_time_hours` are deprecated. They continue to work during the 90-day grace period. Migrate to `cooldown_config` before the next major version.
+</Warning>
+
+See the [Risk Management guide](/guides/risk-management) for full tuning details.

--- a/docs/api-reference/strategies.mdx
+++ b/docs/api-reference/strategies.mdx
@@ -258,8 +258,26 @@ Each strategy includes `execution_config` for risk management:
 | `atr_volatility_factor` | number | ATR multiplier for stop loss distance |
 | `max_open_positions` | integer | Maximum concurrent open positions |
 | `max_trades_per_day` | integer | Daily trade limit |
-| `cooldown_bars` | integer | Bars to wait between trades |
 | `max_hold_bars` | integer | Maximum bars to hold any position |
+| `cooldown_config` | object | Per-timeframe cooldown settings (see below) |
+| ~~`cooldown_bars`~~ | integer | **Deprecated.** Use `cooldown_config[tf].short_window_bars`. |
+| ~~`daily_momentum_limit`~~ | number | **Deprecated.** Use `cooldown_config[tf].short_loss_limit`. |
+| ~~`weekly_momentum_limit`~~ | number | **Deprecated.** Use `cooldown_config[tf].long_loss_limit`. |
+
+### cooldown_config
+
+`cooldown_config` is a nested object keyed by primary timeframe. Each entry controls loss-streak limits and the resulting cooldown duration for that timeframe. The window bar count is both the rolling lookback and the cooldown duration when the limit trips.
+
+```json
+"cooldown_config": {
+  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+}
+```
+
+See the [Risk Management guide](/guides/risk-management) for full tuning details and migration instructions.
 
 ## Error Codes
 

--- a/docs/api-reference/strategies.mdx
+++ b/docs/api-reference/strategies.mdx
@@ -270,10 +270,10 @@ Each strategy includes `execution_config` for risk management:
 
 ```json
 "cooldown_config": {
-  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
-  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
-  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
-  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+  "5m":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+  "15m": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+  "1h":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+  "1d":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
 }
 ```
 

--- a/docs/guides/risk-management.mdx
+++ b/docs/guides/risk-management.mdx
@@ -1,11 +1,24 @@
 ---
 title: "Risk Management"
-description: "Understand how stop losses, position sizing, and risk controls work in MangroveAI's execution_config."
+description: "Understand how stop losses, position sizing, cooldown controls, and risk limits work in MangroveAI's execution_config."
 ---
 
 # Risk Management
 
 Every strategy in MangroveAI has an `execution_config` that controls risk management, position sizing, and trade lifecycle rules. This guide explains each field, how they interact, and how to tune them for your trading style.
+
+<Warning>
+**Deprecation notice:** The legacy cooldown keys `cooldown_bars`, `daily_momentum_limit`, `weekly_momentum_limit`, and the top-level `max_hold_time_hours` are deprecated as of the v2 cooldown redesign. They continue to work during the 90-day grace period but will be removed in a future major version. Migrate to the `cooldown_config` block described below.
+
+Migration summary:
+
+| Legacy key | Replacement |
+|------------|-------------|
+| `cooldown_bars` | `cooldown_config[tf].short_window_bars` (also drives cooldown duration) |
+| `daily_momentum_limit` | `cooldown_config[tf].short_loss_limit` |
+| `weekly_momentum_limit` | `cooldown_config[tf].long_loss_limit` |
+| `max_hold_time_hours` (top-level) | `cooldown_config[tf].max_hold_time_hours` |
+</Warning>
 
 ## How risk management works
 
@@ -32,14 +45,16 @@ Here is the complete `execution_config` with default values. Each field is expla
   "target_volatility": 0.02,
   "volatility_mode": "stddev",
   "enable_volatility_adjustment": false,
-  "max_hold_time_hours": null,
-  "cooldown_bars": 24,
-  "daily_momentum_limit": 3,
-  "weekly_momentum_limit": 3,
   "max_hold_bars": 50,
   "exit_on_loss_after_bars": 50,
   "exit_on_profit_after_bars": 60,
-  "profit_threshold_pct": 0.05
+  "profit_threshold_pct": 0.05,
+  "cooldown_config": {
+    "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+    "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+    "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+    "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+  }
 }
 ```
 
@@ -164,21 +179,66 @@ These fields prevent over-concentration and overtrading:
 | Moderate | 5 - 10 | 20 - 50 |
 | Active | 10 - 20 | 50 - 100 |
 
-## Cooldown bars
+## Cooldown system
 
-After a trade closes (win or loss), the `cooldown_bars` setting prevents the strategy from immediately re-entering.
+The cooldown system prevents a strategy from entering new positions after a losing streak. It uses a two-tier design -- a short tier that catches acute streaks, and a long tier that catches sustained underperformance. Both tiers operate independently per asset.
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| `cooldown_bars` | `24` | Number of bars to wait after a trade before the next entry is allowed. |
+### Two-tier design
 
-On a 1-hour timeframe, the default of 24 means the strategy waits 24 hours between trades. This prevents:
+| Tier | Purpose | Trips when... |
+|------|---------|---------------|
+| Short | Detects an acute losing streak | `short_loss_limit` losses occur within the last `short_window_bars` bars |
+| Long | Detects sustained underperformance | `long_loss_limit` losses occur within the last `long_window_bars` bars |
 
-- Whipsaw entries in choppy markets
-- Excessive trading around the same price level
-- Emotional re-entry after a stop-out
+When a tier trips, the strategy enters a cooldown. The cooldown duration equals the window itself: tripping the short tier blocks entries for `short_window_bars` bars; tripping the long tier blocks entries for `long_window_bars` bars. This means the window bar count serves double duty -- it is both the rolling lookback and the cooldown duration.
 
-**Tuning:** Set `cooldown_bars` relative to your timeframe. For 4h bars, a cooldown of 6 (24 hours) might make sense. For daily bars, a cooldown of 1-3 is typical.
+If a short-tier trip occurs while a long cooldown is already active, the longer cooldown is preserved. Cooldowns never shorten an already-active block.
+
+### The cooldown_config block
+
+`cooldown_config` is a dict keyed by primary timeframe. Each timeframe has five values:
+
+| Key | Description |
+|-----|-------------|
+| `max_hold_time_hours` | Maximum time to hold any position on this timeframe, in hours |
+| `short_loss_limit` | Number of losses in the short window that trips the short-tier cooldown |
+| `long_loss_limit` | Number of losses in the long window that trips the long-tier cooldown |
+| `short_window_bars` | Rolling lookback for the short tier AND the cooldown duration when short trips |
+| `long_window_bars` | Rolling lookback for the long tier AND the cooldown duration when long trips |
+
+```json
+"cooldown_config": {
+  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+}
+```
+
+### Reading the defaults
+
+For a 1h strategy with the defaults above:
+- Short tier: 4 losses in the last 48 bars (2 days) trips a 48-bar cooldown
+- Long tier: 6 losses in the last 144 bars (6 days) trips a 144-bar cooldown
+- Max hold: any position open longer than 24 hours is forced closed
+
+For a 5m strategy:
+- Short tier: 4 losses in the last 180 bars (15 hours) trips a 180-bar cooldown
+- Long tier: 6 losses in the last 480 bars (40 hours) trips a 480-bar cooldown
+- Max hold: any position open longer than 96 hours is forced closed
+
+### Tuning guidance
+
+The defaults are calibrated for standard multi-timeframe use. Adjust based on your strategy's expected win rate and trade frequency:
+
+- **Higher `short_loss_limit`**: more tolerance for short losing streaks before cooling off
+- **Lower `short_window_bars`**: narrower lookback -- only very recent losses count
+- **Larger `long_window_bars`**: spread the long-tier assessment over a wider history
+- **Shorter `max_hold_time_hours`**: force position turnover faster on the given timeframe
+
+### Fallback (legacy keys)
+
+If `cooldown_config` is absent from `execution_config`, or if the strategy's primary timeframe is not a key in `cooldown_config`, the engine falls back to the legacy flat keys and emits a structured deprecation warning in the logs. See the deprecation notice at the top of this page for the migration mapping.
 
 ## Time-based exits
 
@@ -187,7 +247,6 @@ These fields force positions to close after a certain number of bars, regardless
 | Field | Default | Description |
 |-------|---------|-------------|
 | `max_hold_bars` | `50` | Maximum bars to hold any position. Forces exit after this limit. |
-| `max_hold_time_hours` | `null` | Maximum hold time in hours. `null` means no time limit (uses `max_hold_bars` instead). |
 | `exit_on_loss_after_bars` | `50` | Force-exit losing positions after this many bars. |
 | `exit_on_profit_after_bars` | `60` | Force-exit winning positions after this many bars. |
 | `profit_threshold_pct` | `0.05` | What counts as "winning" for `exit_on_profit_after_bars`. 0.05 = 5% unrealized profit. |
@@ -201,18 +260,9 @@ With defaults on a 1h timeframe:
 - A winning trade (5%+ profit) is forced closed after 60 bars (about 2.5 days)
 - Any position, regardless of P&L, closes after 50 bars (`max_hold_bars`)
 
-## Momentum limits
-
-| Field | Default | Description |
-|-------|---------|-------------|
-| `daily_momentum_limit` | `3` | Daily momentum threshold. |
-| `weekly_momentum_limit` | `3` | Weekly momentum threshold. |
-
-These thresholds limit entry signals in extreme momentum conditions, preventing the strategy from chasing moves that have already played out.
-
 ## Putting it all together
 
-Here is a complete example that creates a strategy with custom risk parameters -- tighter stops, smaller position sizes, and fewer concurrent positions:
+Here is a complete example that creates a strategy with custom risk parameters -- tighter stops, smaller position sizes, fewer concurrent positions, and explicit cooldown config for a 1h timeframe:
 
 <CodeGroup>
 ```bash cURL
@@ -226,13 +276,13 @@ curl -s -X POST "http://localhost:5001/api/v1/strategies" \
       {
         "name": "sma_cross_up",
         "signal_type": "TRIGGER",
-        "timeframe": "4h",
+        "timeframe": "1h",
         "params": {"window_fast": 10, "window_slow": 50}
       },
       {
         "name": "adx_strong_trend",
         "signal_type": "FILTER",
-        "timeframe": "4h",
+        "timeframe": "1h",
         "params": {"window": 14, "threshold": 25}
       }
     ],
@@ -252,14 +302,13 @@ curl -s -X POST "http://localhost:5001/api/v1/strategies" \
       "target_volatility": 0.02,
       "volatility_mode": "stddev",
       "enable_volatility_adjustment": false,
-      "max_hold_time_hours": null,
-      "cooldown_bars": 12,
-      "daily_momentum_limit": 3,
-      "weekly_momentum_limit": 3,
       "max_hold_bars": 30,
       "exit_on_loss_after_bars": 24,
       "exit_on_profit_after_bars": 36,
-      "profit_threshold_pct": 0.03
+      "profit_threshold_pct": 0.03,
+      "cooldown_config": {
+        "1h": {"max_hold_time_hours": 24, "short_loss_limit": 3, "long_loss_limit": 5, "short_window_bars": 48, "long_window_bars": 144}
+      }
     }
   }' | python3 -m json.tool
 ```
@@ -272,13 +321,13 @@ conservative_strategy = {
         {
             "name": "sma_cross_up",
             "signal_type": "TRIGGER",
-            "timeframe": "4h",
+            "timeframe": "1h",
             "params": {"window_fast": 10, "window_slow": 50},
         },
         {
             "name": "adx_strong_trend",
             "signal_type": "FILTER",
-            "timeframe": "4h",
+            "timeframe": "1h",
             "params": {"window": 14, "threshold": 25},
         },
     ],
@@ -298,14 +347,19 @@ conservative_strategy = {
         "target_volatility": 0.02,
         "volatility_mode": "stddev",
         "enable_volatility_adjustment": False,
-        "max_hold_time_hours": None,
-        "cooldown_bars": 12,                # 12 bars = 2 days on 4h
-        "daily_momentum_limit": 3,
-        "weekly_momentum_limit": 3,
-        "max_hold_bars": 30,                # Max 30 bars = 5 days on 4h
+        "max_hold_bars": 30,                # Max 30 bars = 30 hours on 1h
         "exit_on_loss_after_bars": 24,
         "exit_on_profit_after_bars": 36,
         "profit_threshold_pct": 0.03,       # 3% counts as "winning"
+        "cooldown_config": {
+            "1h": {
+                "max_hold_time_hours": 24,
+                "short_loss_limit": 3,      # Trip short cooldown after 3 losses in 48 bars
+                "long_loss_limit": 5,       # Trip long cooldown after 5 losses in 144 bars
+                "short_window_bars": 48,    # 48-bar lookback AND 48-bar cooldown on short trip
+                "long_window_bars": 144,    # 144-bar lookback AND 144-bar cooldown on long trip
+            }
+        },
     },
 }
 
@@ -328,40 +382,45 @@ const conservativeStrategy = {
     {
       name: "sma_cross_up",
       signal_type: "TRIGGER",
-      timeframe: "4h",
+      timeframe: "1h",
       params: { window_fast: 10, window_slow: 50 },
     },
     {
       name: "adx_strong_trend",
       signal_type: "FILTER",
-      timeframe: "4h",
+      timeframe: "1h",
       params: { window: 14, threshold: 25 },
     },
   ],
   exit: [],
   reward_factor: 2.5,
   execution_config: {
-    max_risk_per_trade: 0.005,        // 0.5% risk per trade
-    reward_factor: 2.5,                // Higher reward target
+    max_risk_per_trade: 0.005,         // 0.5% risk per trade
+    reward_factor: 2.5,                 // Higher reward target
     stop_loss_calculation: "dynamic_atr",
     atr_period: 14,
-    atr_volatility_factor: 1.5,        // Tighter stops
+    atr_volatility_factor: 1.5,         // Tighter stops
     min_balance_threshold: 0.1,
     min_trade_amount: 50,
-    max_open_positions: 3,             // Max 3 concurrent positions
+    max_open_positions: 3,              // Max 3 concurrent positions
     max_trades_per_day: 10,
     volatility_window: 24,
     target_volatility: 0.02,
     volatility_mode: "stddev",
     enable_volatility_adjustment: false,
-    max_hold_time_hours: null,
-    cooldown_bars: 12,                 // 12 bars = 2 days on 4h
-    daily_momentum_limit: 3,
-    weekly_momentum_limit: 3,
-    max_hold_bars: 30,                 // Max 30 bars = 5 days on 4h
+    max_hold_bars: 30,                  // Max 30 bars = 30 hours on 1h
     exit_on_loss_after_bars: 24,
     exit_on_profit_after_bars: 36,
-    profit_threshold_pct: 0.03,        // 3% counts as "winning"
+    profit_threshold_pct: 0.03,         // 3% counts as "winning"
+    cooldown_config: {
+      "1h": {
+        max_hold_time_hours: 24,
+        short_loss_limit: 3,
+        long_loss_limit: 5,
+        short_window_bars: 48,
+        long_window_bars: 144,
+      },
+    },
   },
 };
 
@@ -382,7 +441,7 @@ Key differences from defaults:
 - **1.5x ATR** stops instead of 2x -- tighter exit on losses
 - **2.5x reward** factor -- requires more upside before taking profit
 - **3 max positions** instead of 10 -- less capital at risk simultaneously
-- **12-bar cooldown** -- waits 2 days between entries on 4h bars
+- **Explicit 1h cooldown_config** -- 3-loss short trip, 5-loss long trip, both tuned for conservative operation
 
 ## Quick reference: all fields
 
@@ -401,14 +460,15 @@ Key differences from defaults:
 | `target_volatility` | number | 0.02 | Target portfolio volatility |
 | `volatility_mode` | string | `"stddev"` | Volatility method (`"stddev"` or `"atr"`) |
 | `enable_volatility_adjustment` | bool | false | Scale position sizes by volatility |
-| `max_hold_time_hours` | number/null | null | Max hold time in hours (null = no limit) |
-| `cooldown_bars` | int | 24 | Bars between trades |
-| `daily_momentum_limit` | number | 3 | Daily momentum cap |
-| `weekly_momentum_limit` | number | 3 | Weekly momentum cap |
 | `max_hold_bars` | int | 50 | Max bars for any position |
 | `exit_on_loss_after_bars` | int | 50 | Force-exit losers after N bars |
 | `exit_on_profit_after_bars` | int | 60 | Force-exit winners after N bars |
 | `profit_threshold_pct` | number | 0.05 | Threshold for "winning" (0.05 = 5%) |
+| `cooldown_config` | object | see defaults | Per-timeframe cooldown settings (see above) |
+| ~~`cooldown_bars`~~ | int | 24 | **Deprecated.** Use `cooldown_config[tf].short_window_bars`. |
+| ~~`daily_momentum_limit`~~ | number | 3 | **Deprecated.** Use `cooldown_config[tf].short_loss_limit`. |
+| ~~`weekly_momentum_limit`~~ | number | 3 | **Deprecated.** Use `cooldown_config[tf].long_loss_limit`. |
+| ~~`max_hold_time_hours`~~ | number/null | null | **Deprecated.** Use `cooldown_config[tf].max_hold_time_hours`. |
 
 ## Next steps
 

--- a/docs/guides/risk-management.mdx
+++ b/docs/guides/risk-management.mdx
@@ -17,7 +17,7 @@ Migration summary:
 | `cooldown_bars` | `cooldown_config[tf].short_window_bars` (also drives cooldown duration) |
 | `daily_momentum_limit` | `cooldown_config[tf].short_loss_limit` |
 | `weekly_momentum_limit` | `cooldown_config[tf].long_loss_limit` |
-| `max_hold_time_hours` (top-level) | `cooldown_config[tf].max_hold_time_hours` |
+| `max_hold_time_hours` (top-level) | `time_based_exits.max_hold_bars` (max hold is now in `execution_config.max_hold_bars`) |
 </Warning>
 
 ## How risk management works
@@ -50,10 +50,10 @@ Here is the complete `execution_config` with default values. Each field is expla
   "exit_on_profit_after_bars": 60,
   "profit_threshold_pct": 0.05,
   "cooldown_config": {
-    "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
-    "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
-    "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
-    "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+    "5m":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+    "15m": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+    "1h":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+    "1d":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
   }
 }
 ```
@@ -196,22 +196,23 @@ If a short-tier trip occurs while a long cooldown is already active, the longer 
 
 ### The cooldown_config block
 
-`cooldown_config` is a dict keyed by primary timeframe. Each timeframe has five values:
+`cooldown_config` is a dict keyed by primary timeframe. Each timeframe has four values:
 
 | Key | Description |
 |-----|-------------|
-| `max_hold_time_hours` | Maximum time to hold any position on this timeframe, in hours |
 | `short_loss_limit` | Number of losses in the short window that trips the short-tier cooldown |
 | `long_loss_limit` | Number of losses in the long window that trips the long-tier cooldown |
 | `short_window_bars` | Rolling lookback for the short tier AND the cooldown duration when short trips |
 | `long_window_bars` | Rolling lookback for the long tier AND the cooldown duration when long trips |
 
+Max hold time is controlled separately via `time_based_exits.max_hold_bars` in `execution_config`.
+
 ```json
 "cooldown_config": {
-  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
-  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
-  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
-  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+  "5m":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+  "15m": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+  "1h":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+  "1d":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
 }
 ```
 
@@ -220,12 +221,12 @@ If a short-tier trip occurs while a long cooldown is already active, the longer 
 For a 1h strategy with the defaults above:
 - Short tier: 4 losses in the last 48 bars (2 days) trips a 48-bar cooldown
 - Long tier: 6 losses in the last 144 bars (6 days) trips a 144-bar cooldown
-- Max hold: any position open longer than 24 hours is forced closed
+- Max hold is set separately via `execution_config.max_hold_bars` (see Time-based exits below)
 
 For a 5m strategy:
 - Short tier: 4 losses in the last 180 bars (15 hours) trips a 180-bar cooldown
 - Long tier: 6 losses in the last 480 bars (40 hours) trips a 480-bar cooldown
-- Max hold: any position open longer than 96 hours is forced closed
+- Max hold is set separately via `execution_config.max_hold_bars` (see Time-based exits below)
 
 ### Tuning guidance
 
@@ -234,7 +235,7 @@ The defaults are calibrated for standard multi-timeframe use. Adjust based on yo
 - **Higher `short_loss_limit`**: more tolerance for short losing streaks before cooling off
 - **Lower `short_window_bars`**: narrower lookback -- only very recent losses count
 - **Larger `long_window_bars`**: spread the long-tier assessment over a wider history
-- **Shorter `max_hold_time_hours`**: force position turnover faster on the given timeframe
+- **Smaller `max_hold_bars`** (in `execution_config`): force position turnover faster regardless of timeframe
 
 ### Fallback (legacy keys)
 
@@ -307,7 +308,7 @@ curl -s -X POST "http://localhost:5001/api/v1/strategies" \
       "exit_on_profit_after_bars": 36,
       "profit_threshold_pct": 0.03,
       "cooldown_config": {
-        "1h": {"max_hold_time_hours": 24, "short_loss_limit": 3, "long_loss_limit": 5, "short_window_bars": 48, "long_window_bars": 144}
+        "1h": {"short_loss_limit": 3, "long_loss_limit": 5, "short_window_bars": 48, "long_window_bars": 144}
       }
     }
   }' | python3 -m json.tool
@@ -353,7 +354,6 @@ conservative_strategy = {
         "profit_threshold_pct": 0.03,       # 3% counts as "winning"
         "cooldown_config": {
             "1h": {
-                "max_hold_time_hours": 24,
                 "short_loss_limit": 3,      # Trip short cooldown after 3 losses in 48 bars
                 "long_loss_limit": 5,       # Trip long cooldown after 5 losses in 144 bars
                 "short_window_bars": 48,    # 48-bar lookback AND 48-bar cooldown on short trip
@@ -414,7 +414,6 @@ const conservativeStrategy = {
     profit_threshold_pct: 0.03,         // 3% counts as "winning"
     cooldown_config: {
       "1h": {
-        max_hold_time_hours: 24,
         short_loss_limit: 3,
         long_loss_limit: 5,
         short_window_bars: 48,
@@ -468,7 +467,7 @@ Key differences from defaults:
 | ~~`cooldown_bars`~~ | int | 24 | **Deprecated.** Use `cooldown_config[tf].short_window_bars`. |
 | ~~`daily_momentum_limit`~~ | number | 3 | **Deprecated.** Use `cooldown_config[tf].short_loss_limit`. |
 | ~~`weekly_momentum_limit`~~ | number | 3 | **Deprecated.** Use `cooldown_config[tf].long_loss_limit`. |
-| ~~`max_hold_time_hours`~~ | number/null | null | **Deprecated.** Use `cooldown_config[tf].max_hold_time_hours`. |
+| ~~`max_hold_time_hours`~~ | number/null | null | **Deprecated.** Use `execution_config.max_hold_bars` (bars) instead of hours. |
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

Phase 6 (KB portion) of the MangroveAI cooldown system redesign. Documentation-only.

Rewrites the risk-management guide and API references to document the new timeframe-keyed \`cooldown_config\` shape. Legacy keys (\`cooldown_bars\`, \`daily_momentum_limit\`, \`weekly_momentum_limit\`, \`max_hold_time_hours\`) are shown as deprecated with a 90-day grace window.

## Files

- \`docs/guides/risk-management.mdx\` — full cooldown section rewrite
- \`docs/api-reference/execution.mdx\` — new Cooldown Configuration section
- \`docs/api-reference/backtesting.mdx\` — examples updated, new Cooldown Parameters section
- \`docs/api-reference/strategies.mdx\` — execution_config table updated, cooldown_config subsection added

## Canonical cooldown_config

\`\`\`json
{
  "5m":  {"max_hold_time_hours": 96, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
  "15m": {"max_hold_time_hours": 48, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
  "1h":  {"max_hold_time_hours": 24, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
  "1d":  {"max_hold_time_hours": 10, "short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
}
\`\`\`

## Related

- MangroveAI PR #420 (primary workstream)
- MangroveOracle PR #161 (Phase 4)
- MangroveAI-SDK PR #4 (Phase 5)
- Plan: MangroveAI:docs/plans/2026-04-19-cooldown-system-redesign.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)