### PR TITLE
fix(ui): update TemplateResponse to new Starlette signature — fixes prod 500

### DIFF
--- a/kb_server/routers/ui.py
+++ b/kb_server/routers/ui.py
@@ -277,9 +277,9 @@ async def home(
     all_tags = search_engine.get_all_tags()
 
     return templates.TemplateResponse(
+        request,
         "index.html",
         {
-            "request": request,
             "title": "Table of Contents",
             "toc_html": toc_html,
             "all_docs": docs,
@@ -338,9 +338,9 @@ async def view_document(
     all_tags = search_engine.get_all_tags()
 
     return templates.TemplateResponse(
+        request,
         "document.html",
         {
-            "request": request,
             "title": doc['title'],
             "document": doc,
             "html_content": html_content,
@@ -392,9 +392,9 @@ async def search_page(
     all_docs = search_engine.get_all_documents()
 
     return templates.TemplateResponse(
+        request,
         "search.html",
         {
-            "request": request,
             "title": "Search" + (f" - {q}" if q else ""),
             "query": q or "",
             "selected_tags": selected_tags,
@@ -438,9 +438,9 @@ async def glossary_page(
     all_tags = search_engine.get_all_tags()
 
     return templates.TemplateResponse(
+        request,
         "glossary.html",
         {
-            "request": request,
             "title": "Glossary",
             "entries": entries,
             "grouped_entries": grouped,
@@ -493,9 +493,9 @@ async def tag_page(
     all_docs = search_engine.get_all_documents()
 
     return templates.TemplateResponse(
+        request,
         "tag.html",
         {
-            "request": request,
             "title": f"Tag: {tag_name}",
             "tag_name": tag_name,
             "documents": documents,


### PR DESCRIPTION
## Summary

`https://kb.mangrovedeveloper.ai/` is **currently returning 500** to all users. Cause: every `TemplateResponse(...)` call site in `kb_server/routers/ui.py` uses the deprecated positional form `TemplateResponse(name, context)`. Starlette ≥ 0.49 removed the deprecation shim, so the context dict ends up where the template name should be, and Jinja2 explodes on the unhashable key:

\`\`\`
TypeError: unhashable type: 'dict'
  File "/app/kb_server/routers/ui.py", line 279, in home
    return templates.TemplateResponse(...)
  File "jinja2/utils.py", line 515, in __getitem__
    rv = self._mapping[key]
\`\`\`

This regression came in via `kb_server/requirements.txt`'s open-ended \`fastapi>=0.104.0\` — the docker build pulled a newer Starlette via FastAPI's transitive deps. The KB code itself was last touched in #39 (site overhaul, commit \`da9c2dc\`).

## Fix

5 call sites — all in `routers/ui.py` (home, document, search, glossary, tag pages). Mechanically:

- Move `request` to first positional arg
- Drop redundant `"request": request` from each context dict (Starlette injects it under the new signature)

10 lines changed. No behavior change beyond unblocking the templates.

## Verification

- [x] `python -c "import ast; ast.parse(open('kb_server/routers/ui.py').read())"` — syntax clean
- [ ] Reviewer: pull this branch + run `kb_server` locally + hit `/`, `/document/<slug>`, `/search`, `/glossary`, `/tag/<name>` — all should render
- [ ] After merge: existing `build-and-push.yaml` fires on main push, builds new image. Cloud Run prod is sha-pinned (\`mangrove-ai-kb:da9c2dc\`) so it does NOT auto-roll — needs a manual update to the new sha to recover prod.

## Follow-ups (not this PR)

1. **Pin fastapi + starlette + jinja2 to upper bounds** in \`kb_server/requirements.txt\` so an unbounded \`>=0.104.0\` doesn't silently re-break this on the next rebuild.
2. **Switch \`build-and-push.yaml\` to tag-triggered + version-tagged image** (mirror of MangroveOracle PR #178). Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)