### PR TITLE
docs(site): IA reorder + spec refresh + accordion catalog + 5 missing API domains

### DIFF
--- a/docs/api-reference/config.mdx
+++ b/docs/api-reference/config.mdx
@@ -1,0 +1,58 @@
+---
+title: "Config API"
+description: "Trading defaults and execution-config endpoints used by the strategy engine."
+---
+
+# Config API
+
+Trading defaults and execution-config endpoints used by the strategy engine.
+
+## Base URL
+
+```
+https://api.mangrovedeveloper.ai/api/v1/config
+```
+
+## Authentication
+
+All endpoints require a JWT bearer token.
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+## Endpoints
+
+### Return the flattened `execution_config` the server builds from defaults
+
+`GET /api/v1/config/execution-defaults`
+
+Matches exactly what `domains/strategies/services.py` uses when a
+request omits `execution_config`. Sections `risk_management`,
+`position_limits`, `volatility_settings`, `trading_rules`,
+`time_based_exits` are merged into one dict; `signal_defaults` and
+`backtest_defaults` are intentionally excluded (same as the legacy
+flattening).
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/config/execution-defaults"
+```
+
+### Return the full trading defaults, nested sections intact
+
+`GET /api/v1/config/trading-defaults`
+
+Shape mirrors `trading_defaults.json` one-to-one: `signal_defaults`,
+`backtest_defaults`, `risk_management`, `position_limits`,
+`volatility_settings`, `trading_rules`, `time_based_exits`, plus the
+top-level `description` field.
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/config/trading-defaults"
+```

--- a/docs/api-reference/defi.mdx
+++ b/docs/api-reference/defi.mdx
@@ -1,0 +1,69 @@
+---
+title: "Defi API"
+description: "DeFi metrics — protocol TVL, chain TVL, stablecoin supply."
+---
+
+# Defi API
+
+DeFi metrics — protocol TVL, chain TVL, stablecoin supply.
+
+## Base URL
+
+```
+https://api.mangrovedeveloper.ai/api/v1/defi
+```
+
+## Authentication
+
+All endpoints require a JWT bearer token.
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+## Endpoints
+
+### Get TVL and top protocols for a blockchain
+
+`GET /api/v1/defi/chain/{chain}/tvl`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `chain` | path | `string` | yes | Blockchain name (e.g. Ethereum, Solana, Arbitrum) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/defi/chain/<chain>/tvl"
+```
+
+### Get TVL and chain breakdown for a DeFi protocol
+
+`GET /api/v1/defi/protocol/{protocol}/tvl`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `protocol` | path | `string` | yes | Protocol name or slug (e.g. aave, uniswap, lido) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/defi/protocol/<protocol>/tvl"
+```
+
+### Get stablecoin supply metrics with per-chain breakdown
+
+`GET /api/v1/defi/stablecoins/metrics`
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/defi/stablecoins/metrics"
+```

--- a/docs/api-reference/on-chain.mdx
+++ b/docs/api-reference/on-chain.mdx
@@ -1,0 +1,133 @@
+---
+title: "On Chain API"
+description: "On-chain analytics — wallet activity, transaction flows, holders, network metrics."
+---
+
+# On Chain API
+
+On-chain analytics — wallet activity, transaction flows, holders, network metrics.
+
+## Base URL
+
+```
+https://api.mangrovedeveloper.ai/api/v1/on-chain
+```
+
+## Authentication
+
+All endpoints require a JWT bearer token.
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+## Endpoints
+
+### Get aggregated exchange inflows/outflows, optionally filtered by token
+
+`GET /api/v1/on-chain/exchange-flows`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `hours_back` | query | `int` | no | Lookback hours (default: 24) |
+| `symbol` | query | `string` | no | Token symbol (e.g. btc, eth). Omit for all currencies. |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/exchange-flows?hours_back=<hours_back>&symbol=<symbol>"
+```
+
+### Screen for tokens with high smart money activity
+
+`GET /api/v1/on-chain/smart-money/screen`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `limit` | query | `int` | no | Max results (default: 50) |
+| `timeframe` | query | `string` | no | 5m, 1h, 6h, 24h, 7d, 30d (default: 24h) |
+| `chains` | query | `string` | no | Comma-separated chains (default: ethereum) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/smart-money/screen?limit=<limit>&timeframe=<timeframe>&chains=<chains>"
+```
+
+### Get smart money sentiment (accumulation vs distribution) for a token
+
+`GET /api/v1/on-chain/smart-money/sentiment`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `chain` | query | `string` | no | Blockchain (default: ethereum) |
+| `symbol` | query | `string` | yes | Token symbol (e.g. ETH, UNI) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/smart-money/sentiment?chain=<chain>&symbol=<symbol>"
+```
+
+### Get token holder distribution from Nansen
+
+`GET /api/v1/on-chain/token-holders/{symbol}`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `symbol` | path | `string` | yes | Token symbol (e.g. ETH, UNI) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/token-holders/<symbol>"
+```
+
+### Get high-level whale activity summary for a token
+
+`GET /api/v1/on-chain/whale-activity/{symbol}`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `symbol` | path | `string` | yes | Token symbol (e.g. btc, eth) |
+| `hours_back` | query | `int` | no | Lookback hours (default: 24) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/whale-activity/<symbol>?hours_back=<hours_back>"
+```
+
+### Get recent large-value on-chain transactions
+
+`GET /api/v1/on-chain/whale-transactions`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `hours_back` | query | `int` | no | Lookback hours (default: 24) |
+| `min_value` | query | `int` | no | Min USD value (default: 500000) |
+| `symbol` | query | `string` | no | Filter by symbol (e.g. btc, eth) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/whale-transactions?hours_back=<hours_back>&min_value=<min_value>&symbol=<symbol>"
+```

--- a/docs/api-reference/promo-codes.mdx
+++ b/docs/api-reference/promo-codes.mdx
@@ -1,0 +1,111 @@
+---
+title: "Promo Codes API"
+description: "Admin-managed promotional codes for subscription discounts."
+---
+
+# Promo Codes API
+
+Admin-managed promotional codes for subscription discounts.
+
+## Base URL
+
+```
+https://api.mangrovedeveloper.ai/api/v1/promo-codes
+```
+
+## Authentication
+
+All endpoints require a JWT bearer token.
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+## Endpoints
+
+### Create a new promo code (admin only)
+
+`POST /api/v1/promo-codes`
+
+**Example**
+
+```bash cURL
+curl -X POST "https://api.mangrovedeveloper.ai/api/v1/promo-codes" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### List all promo codes (admin only)
+
+`GET /api/v1/promo-codes`
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/promo-codes"
+```
+
+### Validate a promo code against a prospective checkout
+
+`POST /api/v1/promo-codes/validate`
+
+Body: { code, tier_id, scope }  where scope is 'user' or 'org'.
+Returns ValidationResult (valid, trial_days, reason, message).
+
+**Example**
+
+```bash cURL
+curl -X POST "https://api.mangrovedeveloper.ai/api/v1/promo-codes/validate" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### List redemptions for a promo code (admin only)
+
+`GET /api/v1/promo-codes/{code}/redemptions`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `code` | path | `string` | yes |  |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/promo-codes/<code>/redemptions"
+```
+
+### Re-activate a previously revoked promo code
+
+`PATCH /api/v1/promo-codes/{code}/reinstate`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `code` | path | `string` | yes |  |
+
+**Example**
+
+```bash cURL
+curl -X PATCH "https://api.mangrovedeveloper.ai/api/v1/promo-codes/<code>/reinstate" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Revoke a promo code (soft -- active = false)
+
+`PATCH /api/v1/promo-codes/{code}/revoke`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `code` | path | `string` | yes |  |
+
+**Example**
+
+```bash cURL
+curl -X PATCH "https://api.mangrovedeveloper.ai/api/v1/promo-codes/<code>/revoke" \
+  -H "Authorization: Bearer $TOKEN"
+```

--- a/docs/api-reference/social.mdx
+++ b/docs/api-reference/social.mdx
@@ -1,0 +1,78 @@
+---
+title: "Social API"
+description: "Social-data endpoints — sentiment, mention volume, influence scoring."
+---
+
+# Social API
+
+Social-data endpoints — sentiment, mention volume, influence scoring.
+
+## Base URL
+
+```
+https://api.mangrovedeveloper.ai/api/v1/social
+```
+
+## Authentication
+
+All endpoints require a JWT bearer token.
+
+```
+Authorization: Bearer YOUR_JWT_TOKEN
+```
+
+## Endpoints
+
+### Get influence score and follower metrics for a user
+
+`GET /api/v1/social/influence/{username}`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `username` | path | `string` | yes | X/Twitter username (without @) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/social/influence/<username>"
+```
+
+### Get recent mentions for a topic
+
+`GET /api/v1/social/mentions/{topic}`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `topic` | path | `string` | yes | Topic or keyword to search |
+| `limit` | query | `int` | no | Max posts to return (default 20) |
+| `hours_back` | query | `int` | no | Time window in hours (default 24) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/social/mentions/<topic>?limit=<limit>&hours_back=<hours_back>"
+```
+
+### Get social sentiment score for a topic
+
+`GET /api/v1/social/sentiment/{topic}`
+
+**Parameters**
+
+| Name | In | Type | Required | Description |
+|------|----|------|----------|-------------|
+| `topic` | path | `string` | yes | Topic or symbol to analyze (e.g. BTC, ETH, Solana) |
+| `hours_back` | query | `int` | no | Time window in hours (default 24) |
+
+**Example**
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/social/sentiment/<topic>?hours_back=<hours_back>"
+```

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -61,6 +61,19 @@
   ],
   "navigation": [
     {
+      "group": "API Reference",
+      "pages": [
+        "api-reference/overview",
+        "api-reference/strategies",
+        "api-reference/signals",
+        "api-reference/backtesting",
+        "api-reference/ai-copilot",
+        "api-reference/execution",
+        "api-reference/crypto-assets",
+        "api-reference/market-data"
+      ]
+    },
+    {
       "group": "Getting Started",
       "pages": [
         "introduction",
@@ -102,19 +115,6 @@
         "templates/overview",
         "templates/x402-app-template",
         "templates/x402-plugin-template"
-      ]
-    },
-    {
-      "group": "API Reference",
-      "pages": [
-        "api-reference/overview",
-        "api-reference/strategies",
-        "api-reference/signals",
-        "api-reference/backtesting",
-        "api-reference/ai-copilot",
-        "api-reference/execution",
-        "api-reference/crypto-assets",
-        "api-reference/market-data"
       ]
     },
     {

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -70,7 +70,12 @@
         "api-reference/ai-copilot",
         "api-reference/execution",
         "api-reference/crypto-assets",
-        "api-reference/market-data"
+        "api-reference/market-data",
+        "api-reference/on-chain",
+        "api-reference/defi",
+        "api-reference/social",
+        "api-reference/config",
+        "api-reference/promo-codes"
       ]
     },
     {

--- a/docs/openapi3.json
+++ b/docs/openapi3.json
@@ -267,18 +267,6 @@
                     }
                 }
             ],
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Success"
-                    }
-                },
-                "summary": "Get an organization's current subscription (admin only)",
-                "operationId": "get_admin_org_subscription",
-                "tags": [
-                    "admin"
-                ]
-            },
             "patch": {
                 "responses": {
                     "200": {
@@ -290,6 +278,61 @@
                 "requestBody": {
                     "$ref": "#/components/requestBodies/ChangeTierRequest"
                 },
+                "tags": [
+                    "admin"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Get an organization's current subscription (admin only)",
+                "operationId": "get_admin_org_subscription",
+                "tags": [
+                    "admin"
+                ]
+            }
+        },
+        "/admin/rate-limit/{provider}/reset": {
+            "parameters": [
+                {
+                    "name": "provider",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RateLimitResetResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Reset a provider's rate-limit bucket in Redis",
+                "description": "Clear MangroveRoots rate-limiter state for one provider.  Deletes the Redis token-bucket key so the next request starts fresh against the configured (max_tokens, window_seconds).  Useful after a deploy that bumps the rate limit — the bucket state carries over in Redis and only refills on the old schedule unless reset.",
+                "operationId": "post_rate_limit_reset",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "description": "An optional fields mask",
+                        "schema": {
+                            "type": "string",
+                            "format": "mask"
+                        }
+                    }
+                ],
                 "tags": [
                     "admin"
                 ]
@@ -833,38 +876,6 @@
                     }
                 }
             ],
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Conversation retrieved"
-                    },
-                    "400": {
-                        "description": "Validation error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                },
-                "summary": "Get full conversation state with working context",
-                "operationId": "get_get_conversation",
-                "tags": [
-                    "ai-copilot"
-                ]
-            },
             "delete": {
                 "responses": {
                     "200": {
@@ -900,6 +911,38 @@
                 },
                 "summary": "Delete a conversation",
                 "operationId": "delete_get_conversation",
+                "tags": [
+                    "ai-copilot"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Conversation retrieved"
+                    },
+                    "400": {
+                        "description": "Validation error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get full conversation state with working context",
+                "operationId": "get_get_conversation",
                 "tags": [
                     "ai-copilot"
                 ]
@@ -1471,50 +1514,6 @@
             }
         },
         "/auth/profile": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Profile retrieved successfully",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/UserProfile"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "User not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProfileErrorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error"
-                    }
-                },
-                "summary": "Get current user profile information",
-                "description": "Retrieves the profile information for the currently authenticated user.\nAuthentication is required via JWT token, API key, or Firebase token.\nThe user ID is extracted from the authentication context.\n\nReturns:\n    200 Success: User profile information\n    404 Error: If user record is not found\n    500 Error: If server error occurs during processing",
-                "operationId": "get_profile",
-                "parameters": [
-                    {
-                        "name": "X-Fields",
-                        "in": "header",
-                        "description": "An optional fields mask",
-                        "schema": {
-                            "type": "string",
-                            "format": "mask"
-                        }
-                    }
-                ],
-                "tags": [
-                    "auth"
-                ]
-            },
             "put": {
                 "responses": {
                     "200": {
@@ -1565,6 +1564,50 @@
                     },
                     "required": true
                 },
+                "tags": [
+                    "auth"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Profile retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UserProfile"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "User not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                },
+                "summary": "Get current user profile information",
+                "description": "Retrieves the profile information for the currently authenticated user.\nAuthentication is required via JWT token, API key, or Firebase token.\nThe user ID is extracted from the authentication context.\n\nReturns:\n    200 Success: User profile information\n    404 Error: If user record is not found\n    500 Error: If server error occurs during processing",
+                "operationId": "get_profile",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "description": "An optional fields mask",
+                        "schema": {
+                            "type": "string",
+                            "format": "mask"
+                        }
+                    }
+                ],
                 "tags": [
                     "auth"
                 ]
@@ -1921,6 +1964,36 @@
                 "operationId": "get_job_status",
                 "tags": [
                     "batch"
+                ]
+            }
+        },
+        "/config/execution-defaults": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Flattened execution config as applied by the server"
+                    }
+                },
+                "summary": "Return the flattened `execution_config` the server builds from defaults",
+                "description": "Matches exactly what `domains/strategies/services.py` uses when a\nrequest omits `execution_config`. Sections `risk_management`,\n`position_limits`, `volatility_settings`, `trading_rules`,\n`time_based_exits` are merged into one dict; `signal_defaults` and\n`backtest_defaults` are intentionally excluded (same as the legacy\nflattening).",
+                "operationId": "get_execution_defaults",
+                "tags": [
+                    "config"
+                ]
+            }
+        },
+        "/config/trading-defaults": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Full trading_defaults.json contents (nested sections intact)"
+                    }
+                },
+                "summary": "Return the full trading defaults, nested sections intact",
+                "description": "Shape mirrors `trading_defaults.json` one-to-one: `signal_defaults`,\n`backtest_defaults`, `risk_management`, `position_limits`,\n`volatility_settings`, `trading_rules`, `time_based_exits`, plus the\ntop-level `description` field.",
+                "operationId": "get_trading_defaults",
+                "tags": [
+                    "config"
                 ]
             }
         },
@@ -2342,6 +2415,7 @@
                         }
                     }
                 ],
+                "deprecated": true,
                 "tags": [
                     "crypto-assets"
                 ]
@@ -2597,6 +2671,7 @@
                         }
                     }
                 ],
+                "deprecated": true,
                 "tags": [
                     "crypto-assets"
                 ]
@@ -2666,6 +2741,7 @@
                         }
                     }
                 ],
+                "deprecated": true,
                 "tags": [
                     "crypto-assets"
                 ]
@@ -2850,6 +2926,7 @@
                 },
                 "summary": "Get token holder distribution for a specific crypto asset (Nansen)",
                 "operationId": "get_token_holders",
+                "deprecated": true,
                 "tags": [
                     "crypto-assets"
                 ]
@@ -2883,6 +2960,141 @@
                 "operationId": "get_trending_assets",
                 "tags": [
                     "crypto-assets"
+                ]
+            }
+        },
+        "/defi/chain/{chain}/tvl": {
+            "parameters": [
+                {
+                    "in": "path",
+                    "description": "Blockchain name (e.g. Ethereum, Solana, Arbitrum)",
+                    "name": "chain",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ChainTVLResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Chain not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DefiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DefiError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get TVL and top protocols for a blockchain",
+                "operationId": "get_chain_tvl",
+                "tags": [
+                    "defi"
+                ]
+            }
+        },
+        "/defi/protocol/{protocol}/tvl": {
+            "parameters": [
+                {
+                    "in": "path",
+                    "description": "Protocol name or slug (e.g. aave, uniswap, lido)",
+                    "name": "protocol",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProtocolTVLResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Protocol not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DefiError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DefiError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get TVL and chain breakdown for a DeFi protocol",
+                "operationId": "get_protocol_tvl",
+                "tags": [
+                    "defi"
+                ]
+            }
+        },
+        "/defi/stablecoins/metrics": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/StablecoinMetricsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DefiError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get stablecoin supply metrics with per-chain breakdown",
+                "operationId": "get_stablecoin_metrics",
+                "tags": [
+                    "defi"
                 ]
             }
         },
@@ -2979,6 +3191,9 @@
                     "401": {
                         "description": "Unauthorized"
                     },
+                    "429": {
+                        "description": "Rate limit exceeded"
+                    },
                     "500": {
                         "description": "Internal server error"
                     }
@@ -3029,6 +3244,9 @@
                     "401": {
                         "description": "Unauthorized"
                     },
+                    "429": {
+                        "description": "Rate limit exceeded"
+                    },
                     "500": {
                         "description": "Internal server error"
                     }
@@ -3078,6 +3296,9 @@
                     },
                     "404": {
                         "description": "Account not found"
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded"
                     },
                     "500": {
                         "description": "Internal server error"
@@ -3130,6 +3351,9 @@
                     "401": {
                         "description": "Unauthorized"
                     },
+                    "429": {
+                        "description": "Rate limit exceeded"
+                    },
                     "500": {
                         "description": "Internal server error"
                     }
@@ -3171,6 +3395,9 @@
                     "401": {
                         "description": "Unauthorized"
                     },
+                    "429": {
+                        "description": "Rate limit exceeded"
+                    },
                     "500": {
                         "description": "Internal server error"
                     }
@@ -3211,6 +3438,9 @@
                     },
                     "401": {
                         "description": "Unauthorized"
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded"
                     },
                     "500": {
                         "description": "Internal server error"
@@ -3254,6 +3484,56 @@
                 ]
             }
         },
+        "/execution/portfolio": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Portfolio data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PortfolioResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Validation error (missing IDs or exceeds 100)"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                },
+                "summary": "Batch-read portfolio data for N strategies",
+                "description": "Batch-read portfolio data for multiple strategies in one call. Accepts a CSV of strategy IDs or repeated query params. Returns execution state, open position counts, and recent trades for each strategy. Max 100 IDs per request.\nDesigned for dashboard UIs that render multiple strategy cards.\nFetches all data in batched DB queries (strategies, open position\ncounts, recent trades) instead of N+1 individual calls.",
+                "operationId": "get_portfolio_read",
+                "parameters": [
+                    {
+                        "description": "Comma-separated strategy UUIDs, or repeated query param (?strategy_ids=a&strategy_ids=b). Max 100.",
+                        "name": "strategy_ids",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "description": "An optional fields mask",
+                        "schema": {
+                            "type": "string",
+                            "format": "mask"
+                        }
+                    }
+                ],
+                "tags": [
+                    "execution"
+                ]
+            }
+        },
         "/execution/positions": {
             "get": {
                 "responses": {
@@ -3272,6 +3552,9 @@
                     },
                     "401": {
                         "description": "Unauthorized"
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded"
                     },
                     "500": {
                         "description": "Internal server error"
@@ -3362,6 +3645,9 @@
                     },
                     "401": {
                         "description": "Unauthorized"
+                    },
+                    "429": {
+                        "description": "Rate limit exceeded"
                     },
                     "500": {
                         "description": "Internal server error"
@@ -3455,6 +3741,333 @@
                 ],
                 "tags": [
                     "health"
+                ]
+            }
+        },
+        "/on-chain/exchange-flows": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ExchangeFlowsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get aggregated exchange inflows/outflows, optionally filtered by token",
+                "operationId": "get_exchange_flows",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Lookback hours (default: 24)",
+                        "name": "hours_back",
+                        "schema": {
+                            "type": "int"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "description": "Token symbol (e.g. btc, eth). Omit for all currencies.",
+                        "name": "symbol",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "on-chain"
+                ]
+            }
+        },
+        "/on-chain/smart-money/screen": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SmartMoneyScreenResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Screen for tokens with high smart money activity",
+                "operationId": "screen_smart_money_tokens",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Max results (default: 50)",
+                        "name": "limit",
+                        "schema": {
+                            "type": "int"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "description": "5m, 1h, 6h, 24h, 7d, 30d (default: 24h)",
+                        "name": "timeframe",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "description": "Comma-separated chains (default: ethereum)",
+                        "name": "chains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "on-chain"
+                ]
+            }
+        },
+        "/on-chain/smart-money/sentiment": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SmartMoneySentimentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get smart money sentiment (accumulation vs distribution) for a token",
+                "operationId": "get_smart_money_sentiment",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Blockchain (default: ethereum)",
+                        "name": "chain",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "required": true,
+                        "in": "query",
+                        "description": "Token symbol (e.g. ETH, UNI)",
+                        "name": "symbol",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "on-chain"
+                ]
+            }
+        },
+        "/on-chain/token-holders/{symbol}": {
+            "parameters": [
+                {
+                    "in": "path",
+                    "description": "Token symbol (e.g. ETH, UNI)",
+                    "name": "symbol",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainTokenHoldersResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainError"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get token holder distribution from Nansen",
+                "operationId": "get_token_holders",
+                "tags": [
+                    "on-chain"
+                ]
+            }
+        },
+        "/on-chain/whale-activity/{symbol}": {
+            "parameters": [
+                {
+                    "in": "path",
+                    "description": "Token symbol (e.g. btc, eth)",
+                    "name": "symbol",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WhaleActivityResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get high-level whale activity summary for a token",
+                "operationId": "get_whale_activity",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Lookback hours (default: 24)",
+                        "name": "hours_back",
+                        "schema": {
+                            "type": "int"
+                        }
+                    }
+                ],
+                "tags": [
+                    "on-chain"
+                ]
+            }
+        },
+        "/on-chain/whale-transactions": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WhaleTransactionsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OnChainError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get recent large-value on-chain transactions",
+                "operationId": "get_whale_transactions",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Lookback hours (default: 24)",
+                        "name": "hours_back",
+                        "schema": {
+                            "type": "int"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "description": "Min USD value (default: 500000)",
+                        "name": "min_value",
+                        "schema": {
+                            "type": "int"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "description": "Filter by symbol (e.g. btc, eth)",
+                        "name": "symbol",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "on-chain"
                 ]
             }
         },
@@ -3625,49 +4238,6 @@
                     }
                 }
             ],
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Organization"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    },
-                    "403": {
-                        "description": "Forbidden"
-                    },
-                    "404": {
-                        "description": "Not found"
-                    },
-                    "500": {
-                        "description": "Server error"
-                    }
-                },
-                "summary": "Get organization details",
-                "description": "Get organization by ID",
-                "operationId": "get_organization_detail",
-                "parameters": [
-                    {
-                        "name": "X-Fields",
-                        "in": "header",
-                        "description": "An optional fields mask",
-                        "schema": {
-                            "type": "string",
-                            "format": "mask"
-                        }
-                    }
-                ],
-                "tags": [
-                    "organizations"
-                ]
-            },
             "put": {
                 "responses": {
                     "200": {
@@ -3717,6 +4287,49 @@
                     },
                     "required": true
                 },
+                "tags": [
+                    "organizations"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Organization"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                },
+                "summary": "Get organization details",
+                "description": "Get organization by ID",
+                "operationId": "get_organization_detail",
+                "parameters": [
+                    {
+                        "name": "X-Fields",
+                        "in": "header",
+                        "description": "An optional fields mask",
+                        "schema": {
+                            "type": "string",
+                            "format": "mask"
+                        }
+                    }
+                ],
                 "tags": [
                     "organizations"
                 ]
@@ -4007,6 +4620,119 @@
                 },
                 "tags": [
                     "organizations"
+                ]
+            }
+        },
+        "/promo-codes": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Create a new promo code (admin only)",
+                "operationId": "post_promo_codes_collection",
+                "tags": [
+                    "promo-codes"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "List all promo codes (admin only)",
+                "operationId": "get_promo_codes_collection",
+                "tags": [
+                    "promo-codes"
+                ]
+            }
+        },
+        "/promo-codes/validate": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Validate a promo code against a prospective checkout",
+                "description": "Body: { code, tier_id, scope }  where scope is 'user' or 'org'.\nReturns ValidationResult (valid, trial_days, reason, message).",
+                "operationId": "post_validate_promo_code",
+                "tags": [
+                    "promo-codes"
+                ]
+            }
+        },
+        "/promo-codes/{code}/redemptions": {
+            "parameters": [
+                {
+                    "name": "code",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "List redemptions for a promo code (admin only)",
+                "operationId": "get_promo_code_redemptions",
+                "tags": [
+                    "promo-codes"
+                ]
+            }
+        },
+        "/promo-codes/{code}/reinstate": {
+            "parameters": [
+                {
+                    "name": "code",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "patch": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Re-activate a previously revoked promo code",
+                "operationId": "patch_reinstate_promo_code",
+                "tags": [
+                    "promo-codes"
+                ]
+            }
+        },
+        "/promo-codes/{code}/revoke": {
+            "parameters": [
+                {
+                    "name": "code",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "patch": {
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "summary": "Revoke a promo code (soft -- active = false)",
+                "operationId": "patch_revoke_promo_code",
+                "tags": [
+                    "promo-codes"
                 ]
             }
         },
@@ -4835,6 +5561,160 @@
                 ]
             }
         },
+        "/social/influence/{username}": {
+            "parameters": [
+                {
+                    "in": "path",
+                    "description": "X/Twitter username (without @)",
+                    "name": "username",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InfluenceScoreResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get influence score and follower metrics for a user",
+                "operationId": "get_influence",
+                "tags": [
+                    "social"
+                ]
+            }
+        },
+        "/social/mentions/{topic}": {
+            "parameters": [
+                {
+                    "in": "path",
+                    "description": "Topic or keyword to search",
+                    "name": "topic",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MentionsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get recent mentions for a topic",
+                "operationId": "get_mentions",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Max posts to return (default 20)",
+                        "name": "limit",
+                        "schema": {
+                            "type": "int"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "description": "Time window in hours (default 24)",
+                        "name": "hours_back",
+                        "schema": {
+                            "type": "int"
+                        }
+                    }
+                ],
+                "tags": [
+                    "social"
+                ]
+            }
+        },
+        "/social/sentiment/{topic}": {
+            "parameters": [
+                {
+                    "in": "path",
+                    "description": "Topic or symbol to analyze (e.g. BTC, ETH, Solana)",
+                    "name": "topic",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SentimentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get social sentiment score for a topic",
+                "operationId": "get_sentiment",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "description": "Time window in hours (default 24)",
+                        "name": "hours_back",
+                        "schema": {
+                            "type": "int"
+                        }
+                    }
+                ],
+                "tags": [
+                    "social"
+                ]
+            }
+        },
         "/strategies/": {
             "post": {
                 "responses": {
@@ -4896,25 +5776,6 @@
                     }
                 }
             ],
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetStrategyResponse"
-                                }
-                            }
-                        }
-                    }
-                },
-                "summary": "Get strategy by ID",
-                "operationId": "get_strategy",
-                "tags": [
-                    "strategies"
-                ]
-            },
             "delete": {
                 "responses": {
                     "200": {
@@ -4955,6 +5816,25 @@
                 },
                 "summary": "Update a draft strategy (name, asset, rules, execution_config)",
                 "operationId": "update_strategy",
+                "tags": [
+                    "strategies"
+                ]
+            },
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetStrategyResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "summary": "Get strategy by ID",
+                "operationId": "get_strategy",
                 "tags": [
                     "strategies"
                 ]
@@ -5342,203 +6222,6 @@
                     "users"
                 ]
             }
-        },
-        "/wallets": {
-            "post": {
-                "responses": {
-                    "201": {
-                        "description": "Wallet created"
-                    },
-                    "400": {
-                        "description": "Validation error"
-                    },
-                    "403": {
-                        "description": "Wallet limit exceeded"
-                    },
-                    "500": {
-                        "description": "Server error"
-                    }
-                },
-                "summary": "Create a new wallet",
-                "description": "Create a new wallet",
-                "operationId": "post_wallet_list",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateWallet"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "tags": [
-                    "wallets"
-                ]
-            },
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Wallet"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    },
-                    "500": {
-                        "description": "Server error"
-                    }
-                },
-                "summary": "List user's wallets",
-                "description": "List wallets for the authenticated user",
-                "operationId": "get_wallet_list",
-                "parameters": [
-                    {
-                        "description": "Filter by active status (true/false)",
-                        "name": "is_active",
-                        "in": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "X-Fields",
-                        "in": "header",
-                        "description": "An optional fields mask",
-                        "schema": {
-                            "type": "string",
-                            "format": "mask"
-                        }
-                    }
-                ],
-                "tags": [
-                    "wallets"
-                ]
-            }
-        },
-        "/wallets/{wallet_id}": {
-            "parameters": [
-                {
-                    "name": "wallet_id",
-                    "in": "path",
-                    "required": true,
-                    "schema": {
-                        "type": "string"
-                    }
-                }
-            ],
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Wallet"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Wallet not found"
-                    },
-                    "500": {
-                        "description": "Server error"
-                    }
-                },
-                "summary": "Get wallet by ID",
-                "description": "Get wallet by ID",
-                "operationId": "get_wallet_detail",
-                "parameters": [
-                    {
-                        "name": "X-Fields",
-                        "in": "header",
-                        "description": "An optional fields mask",
-                        "schema": {
-                            "type": "string",
-                            "format": "mask"
-                        }
-                    }
-                ],
-                "tags": [
-                    "wallets"
-                ]
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Success"
-                    },
-                    "404": {
-                        "description": "Wallet not found"
-                    },
-                    "500": {
-                        "description": "Server error"
-                    }
-                },
-                "summary": "Delete wallet (soft delete)",
-                "description": "Delete wallet",
-                "operationId": "delete_wallet_detail",
-                "tags": [
-                    "wallets"
-                ]
-            },
-            "put": {
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Wallet"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Wallet not found"
-                    },
-                    "500": {
-                        "description": "Server error"
-                    }
-                },
-                "summary": "Update wallet",
-                "description": "Update wallet",
-                "operationId": "put_wallet_detail",
-                "parameters": [
-                    {
-                        "name": "X-Fields",
-                        "in": "header",
-                        "description": "An optional fields mask",
-                        "schema": {
-                            "type": "string",
-                            "format": "mask"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateWallet"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "tags": [
-                    "wallets"
-                ]
-            }
         }
     },
     "info": {
@@ -5572,8 +6255,8 @@
             "description": "Subscription and usage limit operations"
         },
         {
-            "name": "wallets",
-            "description": "Wallet management operations"
+            "name": "promo-codes",
+            "description": "Promo code management and validation"
         },
         {
             "name": "ai-copilot",
@@ -5606,6 +6289,22 @@
         {
             "name": "batch",
             "description": "Batch job tracking and notifications"
+        },
+        {
+            "name": "defi",
+            "description": "DeFi analytics -- protocol TVL, chain TVL, stablecoin metrics (DeFiLlama)"
+        },
+        {
+            "name": "social",
+            "description": "Social signals -- sentiment, mentions, influence (X/Twitter)"
+        },
+        {
+            "name": "on-chain",
+            "description": "On-chain intelligence -- smart money, whale transactions, exchange flows (Nansen + WhaleAlert)"
+        },
+        {
+            "name": "config",
+            "description": "Read-only server configuration — trading defaults + flattened execution config. Source of truth for SDK consumers; closes issue #437."
         }
     ],
     "servers": [
@@ -5864,7 +6563,7 @@
                 },
                 "type": "object"
             },
-            "ProfileErrorResponse": {
+            "ProfileUpdateErrorResponse": {
                 "properties": {
                     "error": {
                         "type": "string",
@@ -5873,7 +6572,7 @@
                 },
                 "type": "object"
             },
-            "ProfileUpdateErrorResponse": {
+            "ProfileErrorResponse": {
                 "properties": {
                     "error": {
                         "type": "string",
@@ -6404,6 +7103,9 @@
                     "total_return": {
                         "type": "number"
                     },
+                    "irr_annualized": {
+                        "type": "number"
+                    },
                     "sharpe_ratio": {
                         "type": "number"
                     },
@@ -6705,6 +7407,27 @@
                 },
                 "type": "object"
             },
+            "RateLimitResetResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "description": "Operation success"
+                    },
+                    "provider": {
+                        "type": "string",
+                        "description": "Provider whose bucket was cleared"
+                    },
+                    "key": {
+                        "type": "string",
+                        "description": "Redis key deleted"
+                    },
+                    "existed": {
+                        "type": "boolean",
+                        "description": "Whether the key existed before deletion"
+                    }
+                },
+                "type": "object"
+            },
             "ResourceUtilization": {
                 "properties": {
                     "strategies": {
@@ -6761,103 +7484,6 @@
                         "type": "string",
                         "format": "date-time",
                         "description": "Current billing period end"
-                    }
-                },
-                "type": "object"
-            },
-            "CreateWallet": {
-                "required": [
-                    "name",
-                    "wallet_type"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Wallet name"
-                    },
-                    "wallet_type": {
-                        "type": "string",
-                        "description": "Wallet type"
-                    },
-                    "address": {
-                        "type": "string",
-                        "description": "Wallet address"
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "description": "Additional metadata"
-                    }
-                },
-                "type": "object"
-            },
-            "Wallet": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "Wallet UUID"
-                    },
-                    "org_id": {
-                        "type": "string",
-                        "description": "Organization UUID"
-                    },
-                    "user_id": {
-                        "type": "string",
-                        "description": "User UUID"
-                    },
-                    "name": {
-                        "type": "string",
-                        "description": "Wallet name"
-                    },
-                    "wallet_type": {
-                        "type": "string",
-                        "description": "Wallet type (exchange, hardware, self_custody, metamask, walletconnect, etc.)"
-                    },
-                    "address": {
-                        "type": "string",
-                        "description": "Wallet address"
-                    },
-                    "is_active": {
-                        "type": "boolean",
-                        "description": "Whether wallet is active"
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "description": "Additional metadata"
-                    },
-                    "created_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Creation timestamp"
-                    },
-                    "updated_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Last update timestamp"
-                    }
-                },
-                "type": "object"
-            },
-            "UpdateWallet": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "Wallet name"
-                    },
-                    "wallet_type": {
-                        "type": "string",
-                        "description": "Wallet type"
-                    },
-                    "address": {
-                        "type": "string",
-                        "description": "Wallet address"
-                    },
-                    "is_active": {
-                        "type": "boolean",
-                        "description": "Whether wallet is active"
-                    },
-                    "metadata": {
-                        "type": "object",
-                        "description": "Additional metadata"
                     }
                 },
                 "type": "object"
@@ -7185,11 +7811,11 @@
                     },
                     "slippage_pct": {
                         "type": "number",
-                        "description": "Max slippage per leg as decimal (e.g., 0.0075 = 0.75%). Random slippage drawn from uniform(0, slippage_pct) independently for entry and exit. Default from trading_defaults.json: 0.0075."
+                        "description": "Max slippage per leg as decimal (e.g., 0.004 = 0.4%). Random slippage drawn from uniform(0, slippage_pct) independently for entry and exit. Default from trading_defaults.json: 0.004."
                     },
                     "fee_pct": {
                         "type": "number",
-                        "description": "Fee as decimal (e.g., 0.0085 = 0.85%). Applied only to profitable trades, on sale proceeds. Default from trading_defaults.json: 0.0085."
+                        "description": "Max fee rate as decimal (default 0.0085 = 0.85%). Size-dependent linear schedule: $10K trades pay full rate, $1M+ trades pay 0.0589%. Applied only to profitable trades. Default from trading_defaults.json."
                     },
                     "hourly_data_file": {
                         "type": "string",
@@ -7357,11 +7983,11 @@
                     },
                     "slippage_pct": {
                         "type": "number",
-                        "description": "Max slippage per leg as decimal (default from trading_defaults.json: 0.0075)"
+                        "description": "Max slippage per leg as decimal (default from trading_defaults.json: 0.004)"
                     },
                     "fee_pct": {
                         "type": "number",
-                        "description": "Fee as decimal, applied only to profitable trades (default from trading_defaults.json: 0.0085)"
+                        "description": "Max fee rate as decimal (default 0.0085). Size-dependent linear schedule, profitable trades only."
                     }
                 },
                 "type": "object"
@@ -7448,14 +8074,14 @@
                     },
                     "entry": {
                         "type": "array",
-                        "description": "Entry rules array (must have 1 TRIGGER + 1 FILTER)",
+                        "description": "Entry rules array (exactly 1 TRIGGER, 0+ FILTERs)",
                         "items": {
                             "type": "object"
                         }
                     },
                     "exit": {
                         "type": "array",
-                        "description": "Exit rules array (optional, max 1 TRIGGER + 1 FILTER)",
+                        "description": "Exit rules array (optional, 0-1 TRIGGER + 0+ FILTERs)",
                         "items": {
                             "type": "object"
                         }
@@ -7490,6 +8116,14 @@
                     "parent_strategy_id": {
                         "type": "string",
                         "description": "Parent strategy ID for derived strategies (optional)"
+                    },
+                    "strategy_type": {
+                        "type": "string",
+                        "description": "Strategy type (trend_following, momentum, volatility, breakout, mean_reversion)"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable strategy description"
                     }
                 },
                 "type": "object"
@@ -7558,6 +8192,22 @@
                     "content_hash": {
                         "type": "string",
                         "description": "Content hash for deduplication"
+                    },
+                    "strategy_type": {
+                        "type": "string",
+                        "description": "Strategy type (trend_following, momentum, volatility, breakout, mean_reversion)"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable strategy description"
+                    },
+                    "last_evaluated_at": {
+                        "type": "string",
+                        "description": "Timestamp of last evaluation (ISO format, null if never evaluated)"
+                    },
+                    "evaluation_count": {
+                        "type": "integer",
+                        "description": "Total number of evaluations performed"
                     }
                 },
                 "type": "object"
@@ -7606,17 +8256,14 @@
                     "created_at": {
                         "type": "string",
                         "description": "Creation timestamp"
-                    }
-                },
-                "type": "object"
-            },
-            "GetStrategyResponse": {
-                "properties": {
-                    "success": {
-                        "type": "boolean"
                     },
-                    "strategy": {
-                        "$ref": "#/components/schemas/StrategyDetail"
+                    "strategy_type": {
+                        "type": "string",
+                        "description": "Strategy type"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Human-readable strategy description"
                     }
                 },
                 "type": "object"
@@ -7633,6 +8280,17 @@
                 "type": "object"
             },
             "UpdateStrategyResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "strategy": {
+                        "$ref": "#/components/schemas/StrategyDetail"
+                    }
+                },
+                "type": "object"
+            },
+            "GetStrategyResponse": {
                 "properties": {
                     "success": {
                         "type": "boolean"
@@ -8852,6 +9510,111 @@
                 },
                 "type": "object"
             },
+            "PortfolioResponse": {
+                "properties": {
+                    "results": {
+                        "type": "array",
+                        "description": "Portfolio entries in the order requested (missing ones omitted)",
+                        "items": {
+                            "$ref": "#/components/schemas/PortfolioEntry"
+                        }
+                    },
+                    "missing": {
+                        "type": "array",
+                        "description": "Strategy IDs that were not found",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "PortfolioEntry": {
+                "properties": {
+                    "strategy_id": {
+                        "type": "string",
+                        "description": "Strategy UUID"
+                    },
+                    "strategy_name": {
+                        "type": "string",
+                        "description": "Strategy name"
+                    },
+                    "asset": {
+                        "type": "string",
+                        "description": "Asset symbol"
+                    },
+                    "execution_state": {
+                        "description": "Execution state snapshot",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PortfolioExecutionState"
+                            }
+                        ]
+                    },
+                    "last_evaluated_at": {
+                        "type": "string",
+                        "description": "Last evaluation timestamp (ISO 8601, nullable)"
+                    },
+                    "open_positions_count": {
+                        "type": "integer",
+                        "description": "Number of currently open positions (from DB)"
+                    },
+                    "recent_trades": {
+                        "type": "array",
+                        "description": "Last 5 trades, newest first",
+                        "items": {
+                            "$ref": "#/components/schemas/RecentTradeEntry"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "PortfolioExecutionState": {
+                "properties": {
+                    "cash_balance": {
+                        "type": "number",
+                        "description": "Current cash balance"
+                    },
+                    "account_value": {
+                        "type": "number",
+                        "description": "Total account value"
+                    },
+                    "total_trades": {
+                        "type": "integer",
+                        "description": "Total completed trades"
+                    },
+                    "num_open_positions": {
+                        "type": "integer",
+                        "description": "Number of currently open positions"
+                    }
+                },
+                "type": "object"
+            },
+            "RecentTradeEntry": {
+                "properties": {
+                    "closed_at": {
+                        "type": "string",
+                        "description": "Trade close timestamp (ISO 8601, nullable)"
+                    },
+                    "outcome": {
+                        "type": "string",
+                        "description": "Trade outcome (win or loss)"
+                    },
+                    "profit_loss": {
+                        "type": "number",
+                        "description": "Profit/loss in dollars"
+                    },
+                    "profit_loss_pct": {
+                        "type": "number",
+                        "description": "Profit/loss as percentage"
+                    },
+                    "asset": {
+                        "type": "string",
+                        "description": "Asset symbol"
+                    }
+                },
+                "type": "object"
+            },
             "ExchangeListResponse": {
                 "properties": {
                     "success": {
@@ -9371,6 +10134,327 @@
                     "result_data": {
                         "type": "object",
                         "description": "Structured output from completed batch job"
+                    }
+                },
+                "type": "object"
+            },
+            "DefiError": {
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "ProtocolTVLResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "protocol": {
+                        "type": "string"
+                    },
+                    "tvl_usd": {
+                        "type": "number"
+                    },
+                    "chains": {
+                        "type": "object",
+                        "description": "Chain name -> TVL breakdown"
+                    },
+                    "data": {
+                        "type": "object",
+                        "description": "Full provider response"
+                    }
+                },
+                "type": "object"
+            },
+            "ChainTVLResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "chain": {
+                        "type": "string"
+                    },
+                    "tvl_usd": {
+                        "type": "number"
+                    },
+                    "top_protocols": {
+                        "type": "array",
+                        "description": "Top 10 protocols on this chain",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "data": {
+                        "type": "object",
+                        "description": "Full provider response"
+                    }
+                },
+                "type": "object"
+            },
+            "StablecoinMetricsResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "total_supply_usd": {
+                        "type": "number"
+                    },
+                    "supply_by_chain": {
+                        "type": "object",
+                        "description": "Chain name -> stablecoin supply"
+                    },
+                    "data": {
+                        "type": "object",
+                        "description": "Top stablecoins and metadata"
+                    }
+                },
+                "type": "object"
+            },
+            "SocialError": {
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "SentimentResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "sentiment": {
+                        "type": "string",
+                        "description": "bullish, bearish, or neutral"
+                    },
+                    "score": {
+                        "type": "number",
+                        "description": "Sentiment score 0-100"
+                    },
+                    "mentions": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "description": "Full provider response"
+                    }
+                },
+                "type": "object"
+            },
+            "MentionsResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "topic": {
+                        "type": "string"
+                    },
+                    "count": {
+                        "type": "integer"
+                    },
+                    "posts": {
+                        "type": "array",
+                        "description": "Recent posts matching topic",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "InfluenceScoreResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "username": {
+                        "type": "string"
+                    },
+                    "score": {
+                        "type": "number",
+                        "description": "Influence score 0-100"
+                    },
+                    "followers": {
+                        "type": "integer"
+                    },
+                    "data": {
+                        "type": "object",
+                        "description": "Full user metrics"
+                    }
+                },
+                "type": "object"
+            },
+            "OnChainError": {
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "code": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "SmartMoneySentimentResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "symbol": {
+                        "type": "string"
+                    },
+                    "chain": {
+                        "type": "string"
+                    },
+                    "sentiment": {
+                        "type": "string",
+                        "description": "accumulating, distributing, or neutral"
+                    },
+                    "smart_money_inflow_usd": {
+                        "type": "number"
+                    },
+                    "smart_money_outflow_usd": {
+                        "type": "number"
+                    },
+                    "net_flow_usd": {
+                        "type": "number"
+                    },
+                    "trend_7d": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "SmartMoneyScreenResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "count": {
+                        "type": "integer"
+                    },
+                    "chains": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "timeframe": {
+                        "type": "string"
+                    },
+                    "tokens": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "OnChainTokenHoldersResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "symbol": {
+                        "type": "string"
+                    },
+                    "holder_count": {
+                        "type": "integer"
+                    },
+                    "top_10_holders_pct": {
+                        "type": "number"
+                    },
+                    "concentration_score": {
+                        "type": "number"
+                    },
+                    "data": {
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "WhaleTransactionsResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "count": {
+                        "type": "integer"
+                    },
+                    "min_value_usd": {
+                        "type": "number"
+                    },
+                    "transactions": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "ExchangeFlowsResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "symbol": {
+                        "type": "string"
+                    },
+                    "timeframe": {
+                        "type": "string"
+                    },
+                    "net_flow_usd": {
+                        "type": "number"
+                    },
+                    "flows": {
+                        "type": "array",
+                        "description": "Per-exchange flow data",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "WhaleActivityResponse": {
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "symbol": {
+                        "type": "string"
+                    },
+                    "hours_back": {
+                        "type": "integer"
+                    },
+                    "summary": {
+                        "type": "object",
+                        "description": "Aggregated whale activity metrics"
                     }
                 },
                 "type": "object"

--- a/docs/signals/catalog.mdx
+++ b/docs/signals/catalog.mdx
@@ -24,229 +24,229 @@ See [Signals Overview](/signals/overview) for an introduction to how signals wor
 
 | Name | Type | Category | Requires |
 |------|------|----------|----------|
-| [`ao_bearish`](/signals/catalog/momentum#ao-bearish) | FILTER | Momentum | High, Low |
-| [`ao_bullish`](/signals/catalog/momentum#ao-bullish) | FILTER | Momentum | High, Low |
-| [`ao_zero_cross`](/signals/catalog/momentum#ao-zero-cross) | TRIGGER | Momentum | High, Low |
-| [`apo_bearish`](/signals/catalog/momentum#apo-bearish) | FILTER | Momentum | Close |
-| [`apo_bullish`](/signals/catalog/momentum#apo-bullish) | FILTER | Momentum | Close |
-| [`apo_cross_down`](/signals/catalog/momentum#apo-cross-down) | TRIGGER | Momentum | Close |
-| [`apo_cross_up`](/signals/catalog/momentum#apo-cross-up) | TRIGGER | Momentum | Close |
-| [`bop_bearish`](/signals/catalog/momentum#bop-bearish) | FILTER | Momentum | Open, High, Low, Close |
-| [`bop_bullish`](/signals/catalog/momentum#bop-bullish) | FILTER | Momentum | Open, High, Low, Close |
-| [`bop_cross_down`](/signals/catalog/momentum#bop-cross-down) | TRIGGER | Momentum | Open, High, Low, Close |
-| [`bop_cross_up`](/signals/catalog/momentum#bop-cross-up) | TRIGGER | Momentum | Open, High, Low, Close |
-| [`cmo_cross_down`](/signals/catalog/momentum#cmo-cross-down) | TRIGGER | Momentum | Close |
-| [`cmo_cross_up`](/signals/catalog/momentum#cmo-cross-up) | TRIGGER | Momentum | Close |
-| [`cmo_overbought`](/signals/catalog/momentum#cmo-overbought) | FILTER | Momentum | Close |
-| [`cmo_oversold`](/signals/catalog/momentum#cmo-oversold) | FILTER | Momentum | Close |
-| [`kama_cross_down`](/signals/catalog/momentum#kama-cross-down) | TRIGGER | Momentum | Close |
-| [`kama_cross_up`](/signals/catalog/momentum#kama-cross-up) | TRIGGER | Momentum | Close |
-| [`mom_bearish`](/signals/catalog/momentum#mom-bearish) | FILTER | Momentum | Close |
-| [`mom_bullish`](/signals/catalog/momentum#mom-bullish) | FILTER | Momentum | Close |
-| [`mom_cross_down`](/signals/catalog/momentum#mom-cross-down) | TRIGGER | Momentum | Close |
-| [`mom_cross_up`](/signals/catalog/momentum#mom-cross-up) | TRIGGER | Momentum | Close |
-| [`ppo_bearish_cross`](/signals/catalog/momentum#ppo-bearish-cross) | TRIGGER | Momentum | Close |
-| [`ppo_bullish_cross`](/signals/catalog/momentum#ppo-bullish-cross) | TRIGGER | Momentum | Close |
-| [`pvo_bearish_cross`](/signals/catalog/momentum#pvo-bearish-cross) | TRIGGER | Momentum | Volume |
-| [`pvo_bullish_cross`](/signals/catalog/momentum#pvo-bullish-cross) | TRIGGER | Momentum | Volume |
-| [`roc_momentum_shift`](/signals/catalog/momentum#roc-momentum-shift) | TRIGGER | Momentum | Close |
-| [`roc_negative`](/signals/catalog/momentum#roc-negative) | FILTER | Momentum | Close |
-| [`roc_positive`](/signals/catalog/momentum#roc-positive) | FILTER | Momentum | Close |
-| [`rsi_cross_down`](/signals/catalog/momentum#rsi-cross-down) | TRIGGER | Momentum | Close |
-| [`rsi_cross_up`](/signals/catalog/momentum#rsi-cross-up) | TRIGGER | Momentum | Close |
-| [`rsi_overbought`](/signals/catalog/momentum#rsi-overbought) | FILTER | Momentum | Close |
-| [`rsi_oversold`](/signals/catalog/momentum#rsi-oversold) | FILTER | Momentum | Close |
-| [`stoch_overbought`](/signals/catalog/momentum#stoch-overbought) | FILTER | Momentum | High, Low, Close |
-| [`stoch_oversold`](/signals/catalog/momentum#stoch-oversold) | FILTER | Momentum | High, Low, Close |
-| [`stochrsi_overbought`](/signals/catalog/momentum#stochrsi-overbought) | FILTER | Momentum | Close |
-| [`stochrsi_oversold`](/signals/catalog/momentum#stochrsi-oversold) | FILTER | Momentum | Close |
-| [`tsi_bearish`](/signals/catalog/momentum#tsi-bearish) | FILTER | Momentum | Close |
-| [`tsi_bullish`](/signals/catalog/momentum#tsi-bullish) | FILTER | Momentum | Close |
-| [`uo_overbought`](/signals/catalog/momentum#uo-overbought) | FILTER | Momentum | High, Low, Close |
-| [`uo_oversold`](/signals/catalog/momentum#uo-oversold) | FILTER | Momentum | High, Low, Close |
-| [`williams_r_overbought`](/signals/catalog/momentum#williams-r-overbought) | FILTER | Momentum | High, Low, Close |
-| [`williams_r_oversold`](/signals/catalog/momentum#williams-r-oversold) | FILTER | Momentum | High, Low, Close |
-| [`adx_bullish_di`](/signals/catalog/trend#adx-bullish-di) | FILTER | Trend | High, Low, Close |
-| [`adx_strong_trend`](/signals/catalog/trend#adx-strong-trend) | FILTER | Trend | High, Low, Close |
-| [`alligator_bearish`](/signals/catalog/trend#alligator-bearish) | FILTER | Trend | High, Low |
-| [`alligator_bullish`](/signals/catalog/trend#alligator-bullish) | FILTER | Trend | High, Low |
-| [`alligator_sleeping`](/signals/catalog/trend#alligator-sleeping) | FILTER | Trend | High, Low |
-| [`alma_cross_down`](/signals/catalog/trend#alma-cross-down) | TRIGGER | Trend | Close |
-| [`alma_cross_up`](/signals/catalog/trend#alma-cross-up) | TRIGGER | Trend | Close |
-| [`aroon_crossover`](/signals/catalog/trend#aroon-crossover) | TRIGGER | Trend | High, Low |
-| [`aroon_down_trend`](/signals/catalog/trend#aroon-down-trend) | FILTER | Trend | High, Low |
-| [`aroon_up_trend`](/signals/catalog/trend#aroon-up-trend) | FILTER | Trend | High, Low |
-| [`cci_overbought`](/signals/catalog/trend#cci-overbought) | FILTER | Trend | High, Low, Close |
-| [`cci_oversold`](/signals/catalog/trend#cci-oversold) | FILTER | Trend | High, Low, Close |
-| [`chandelier_long_stop_hit`](/signals/catalog/trend#chandelier-long-stop-hit) | FILTER | Trend | High, Low, Close |
-| [`chandelier_short_stop_hit`](/signals/catalog/trend#chandelier-short-stop-hit) | FILTER | Trend | High, Low, Close |
-| [`dema_cross_down`](/signals/catalog/trend#dema-cross-down) | TRIGGER | Trend | Close |
-| [`dema_cross_up`](/signals/catalog/trend#dema-cross-up) | TRIGGER | Trend | Close |
-| [`dpo_negative`](/signals/catalog/trend#dpo-negative) | FILTER | Trend | Close |
-| [`dpo_positive`](/signals/catalog/trend#dpo-positive) | FILTER | Trend | Close |
-| [`ema_cross_down`](/signals/catalog/trend#ema-cross-down) | TRIGGER | Trend | Close |
-| [`ema_cross_up`](/signals/catalog/trend#ema-cross-up) | TRIGGER | Trend | Close |
-| [`ema_crossover`](/signals/catalog/trend#ema-crossover) | TRIGGER | Trend | Close |
-| [`epma_cross_down`](/signals/catalog/trend#epma-cross-down) | TRIGGER | Trend | Close |
-| [`epma_cross_up`](/signals/catalog/trend#epma-cross-up) | TRIGGER | Trend | Close |
-| [`heikin_ashi_bearish`](/signals/catalog/trend#heikin-ashi-bearish) | FILTER | Trend | Open, High, Low, Close |
-| [`heikin_ashi_bullish`](/signals/catalog/trend#heikin-ashi-bullish) | FILTER | Trend | Open, High, Low, Close |
-| [`hma_cross_down`](/signals/catalog/trend#hma-cross-down) | TRIGGER | Trend | Close |
-| [`hma_cross_up`](/signals/catalog/trend#hma-cross-up) | TRIGGER | Trend | Close |
-| [`ichimoku_bearish`](/signals/catalog/trend#ichimoku-bearish) | FILTER | Trend | High, Low |
-| [`ichimoku_bullish`](/signals/catalog/trend#ichimoku-bullish) | FILTER | Trend | High, Low |
-| [`ichimoku_tk_cross`](/signals/catalog/trend#ichimoku-tk-cross) | TRIGGER | Trend | High, Low |
-| [`is_above_alma`](/signals/catalog/trend#is-above-alma) | FILTER | Trend | Close |
-| [`is_above_dema`](/signals/catalog/trend#is-above-dema) | FILTER | Trend | Close |
-| [`is_above_epma`](/signals/catalog/trend#is-above-epma) | FILTER | Trend | Close |
-| [`is_above_hma`](/signals/catalog/trend#is-above-hma) | FILTER | Trend | Close |
-| [`is_above_mama`](/signals/catalog/trend#is-above-mama) | FILTER | Trend | Close |
-| [`is_above_sma`](/signals/catalog/trend#is-above-sma) | FILTER | Trend | Close |
-| [`is_above_smma`](/signals/catalog/trend#is-above-smma) | FILTER | Trend | Close |
-| [`is_above_t3`](/signals/catalog/trend#is-above-t3) | FILTER | Trend | Close |
-| [`is_above_tema`](/signals/catalog/trend#is-above-tema) | FILTER | Trend | Close |
-| [`is_above_trima`](/signals/catalog/trend#is-above-trima) | FILTER | Trend | Close |
-| [`kst_bearish_cross`](/signals/catalog/trend#kst-bearish-cross) | TRIGGER | Trend | Close |
-| [`kst_bullish_cross`](/signals/catalog/trend#kst-bullish-cross) | TRIGGER | Trend | Close |
-| [`ma_ribbon_bearish`](/signals/catalog/trend#ma-ribbon-bearish) | FILTER | Trend | Close |
-| [`ma_ribbon_bullish`](/signals/catalog/trend#ma-ribbon-bullish) | FILTER | Trend | Close |
-| [`ma_ribbon_tangled`](/signals/catalog/trend#ma-ribbon-tangled) | FILTER | Trend | Close |
-| [`macd_bearish_cross`](/signals/catalog/trend#macd-bearish-cross) | TRIGGER | Trend | Close |
-| [`macd_bullish_cross`](/signals/catalog/trend#macd-bullish-cross) | TRIGGER | Trend | Close |
-| [`macd_positive`](/signals/catalog/trend#macd-positive) | FILTER | Trend | Close |
-| [`mama_cross_down`](/signals/catalog/trend#mama-cross-down) | TRIGGER | Trend | Close |
-| [`mama_cross_up`](/signals/catalog/trend#mama-cross-up) | TRIGGER | Trend | Close |
-| [`mass_reversal_signal`](/signals/catalog/trend#mass-reversal-signal) | TRIGGER | Trend | High, Low |
-| [`multi_tf_trend_bearish`](/signals/catalog/trend#multi-tf-trend-bearish) | FILTER | Trend | Close |
-| [`multi_tf_trend_bullish`](/signals/catalog/trend#multi-tf-trend-bullish) | FILTER | Trend | Close |
-| [`price_above_ema`](/signals/catalog/trend#price-above-ema) | FILTER | Trend | Close |
-| [`psar_bearish`](/signals/catalog/trend#psar-bearish) | FILTER | Trend | High, Low, Close |
-| [`psar_bullish`](/signals/catalog/trend#psar-bullish) | FILTER | Trend | High, Low, Close |
-| [`psar_reversal`](/signals/catalog/trend#psar-reversal) | TRIGGER | Trend | High, Low, Close |
-| [`rsi_bearish_divergence`](/signals/catalog/trend#rsi-bearish-divergence) | TRIGGER | Trend | Close |
-| [`rsi_bullish_divergence`](/signals/catalog/trend#rsi-bullish-divergence) | TRIGGER | Trend | Close |
-| [`rsi_hidden_bearish_divergence`](/signals/catalog/trend#rsi-hidden-bearish-divergence) | TRIGGER | Trend | Close |
-| [`rsi_hidden_bullish_divergence`](/signals/catalog/trend#rsi-hidden-bullish-divergence) | TRIGGER | Trend | Close |
-| [`sma_cross_down`](/signals/catalog/trend#sma-cross-down) | TRIGGER | Trend | Close |
-| [`sma_cross_up`](/signals/catalog/trend#sma-cross-up) | TRIGGER | Trend | Close |
-| [`sma_crossover`](/signals/catalog/trend#sma-crossover) | TRIGGER | Trend | Close |
-| [`smma_cross_down`](/signals/catalog/trend#smma-cross-down) | TRIGGER | Trend | Close |
-| [`smma_cross_up`](/signals/catalog/trend#smma-cross-up) | TRIGGER | Trend | Close |
-| [`stc_overbought`](/signals/catalog/trend#stc-overbought) | FILTER | Trend | Close |
-| [`stc_oversold`](/signals/catalog/trend#stc-oversold) | FILTER | Trend | Close |
-| [`supertrend_flip_down`](/signals/catalog/trend#supertrend-flip-down) | TRIGGER | Trend | High, Low, Close |
-| [`supertrend_flip_up`](/signals/catalog/trend#supertrend-flip-up) | TRIGGER | Trend | High, Low, Close |
-| [`supertrend_long`](/signals/catalog/trend#supertrend-long) | FILTER | Trend | High, Low, Close |
-| [`supertrend_short`](/signals/catalog/trend#supertrend-short) | FILTER | Trend | High, Low, Close |
-| [`t3_cross_down`](/signals/catalog/trend#t3-cross-down) | TRIGGER | Trend | Close |
-| [`t3_cross_up`](/signals/catalog/trend#t3-cross-up) | TRIGGER | Trend | Close |
-| [`tema_cross_down`](/signals/catalog/trend#tema-cross-down) | TRIGGER | Trend | Close |
-| [`tema_cross_up`](/signals/catalog/trend#tema-cross-up) | TRIGGER | Trend | Close |
-| [`trima_cross_down`](/signals/catalog/trend#trima-cross-down) | TRIGGER | Trend | Close |
-| [`trima_cross_up`](/signals/catalog/trend#trima-cross-up) | TRIGGER | Trend | Close |
-| [`trix_bearish`](/signals/catalog/trend#trix-bearish) | FILTER | Trend | Close |
-| [`trix_bullish`](/signals/catalog/trend#trix-bullish) | FILTER | Trend | Close |
-| [`ttm_squeeze_active`](/signals/catalog/trend#ttm-squeeze-active) | FILTER | Trend | High, Low, Close |
-| [`ttm_squeeze_fired_bearish`](/signals/catalog/trend#ttm-squeeze-fired-bearish) | TRIGGER | Trend | High, Low, Close |
-| [`ttm_squeeze_fired_bullish`](/signals/catalog/trend#ttm-squeeze-fired-bullish) | TRIGGER | Trend | High, Low, Close |
-| [`vortex_bearish`](/signals/catalog/trend#vortex-bearish) | FILTER | Trend | High, Low, Close |
-| [`vortex_bullish`](/signals/catalog/trend#vortex-bullish) | FILTER | Trend | High, Low, Close |
-| [`vortex_crossover`](/signals/catalog/trend#vortex-crossover) | TRIGGER | Trend | High, Low, Close |
-| [`wma_cross_down`](/signals/catalog/trend#wma-cross-down) | TRIGGER | Trend | Close |
-| [`wma_cross_up`](/signals/catalog/trend#wma-cross-up) | TRIGGER | Trend | Close |
-| [`adi_bearish`](/signals/catalog/volume#adi-bearish) | FILTER | Volume | High, Low, Close, Volume |
-| [`adi_bullish`](/signals/catalog/volume#adi-bullish) | FILTER | Volume | High, Low, Close, Volume |
-| [`adosc_bearish`](/signals/catalog/volume#adosc-bearish) | FILTER | Volume | High, Low, Close, Volume |
-| [`adosc_bullish`](/signals/catalog/volume#adosc-bullish) | FILTER | Volume | High, Low, Close, Volume |
-| [`adosc_cross_down`](/signals/catalog/volume#adosc-cross-down) | TRIGGER | Volume | High, Low, Close, Volume |
-| [`adosc_cross_up`](/signals/catalog/volume#adosc-cross-up) | TRIGGER | Volume | High, Low, Close, Volume |
-| [`cmf_bearish`](/signals/catalog/volume#cmf-bearish) | FILTER | Volume | High, Low, Close, Volume |
-| [`cmf_bullish`](/signals/catalog/volume#cmf-bullish) | FILTER | Volume | High, Low, Close, Volume |
-| [`cumulative_return_positive`](/signals/catalog/volume#cumulative-return-positive) | FILTER | Volume | Close |
-| [`cumulative_return_target`](/signals/catalog/volume#cumulative-return-target) | FILTER | Volume | Close |
-| [`daily_return_negative`](/signals/catalog/volume#daily-return-negative) | FILTER | Volume | Close |
-| [`daily_return_positive`](/signals/catalog/volume#daily-return-positive) | FILTER | Volume | Close |
-| [`eom_bearish`](/signals/catalog/volume#eom-bearish) | FILTER | Volume | High, Low, Volume |
-| [`eom_bullish`](/signals/catalog/volume#eom-bullish) | FILTER | Volume | High, Low, Volume |
-| [`force_bearish`](/signals/catalog/volume#force-bearish) | FILTER | Volume | Close, Volume |
-| [`force_bullish`](/signals/catalog/volume#force-bullish) | FILTER | Volume | Close, Volume |
-| [`is_above_vwma`](/signals/catalog/volume#is-above-vwma) | FILTER | Volume | Close, Volume |
-| [`kvo_bearish`](/signals/catalog/volume#kvo-bearish) | FILTER | Volume | High, Low, Close, Volume |
-| [`kvo_bearish_cross`](/signals/catalog/volume#kvo-bearish-cross) | TRIGGER | Volume | High, Low, Close, Volume |
-| [`kvo_bullish`](/signals/catalog/volume#kvo-bullish) | FILTER | Volume | High, Low, Close, Volume |
-| [`kvo_bullish_cross`](/signals/catalog/volume#kvo-bullish-cross) | TRIGGER | Volume | High, Low, Close, Volume |
-| [`mfi_overbought`](/signals/catalog/volume#mfi-overbought) | FILTER | Volume | High, Low, Close, Volume |
-| [`mfi_oversold`](/signals/catalog/volume#mfi-oversold) | FILTER | Volume | High, Low, Close, Volume |
-| [`nvi_bearish`](/signals/catalog/volume#nvi-bearish) | FILTER | Volume | Close, Volume |
-| [`nvi_bullish`](/signals/catalog/volume#nvi-bullish) | FILTER | Volume | Close, Volume |
-| [`obv_bearish`](/signals/catalog/volume#obv-bearish) | FILTER | Volume | Close, Volume |
-| [`obv_bullish`](/signals/catalog/volume#obv-bullish) | FILTER | Volume | Close, Volume |
-| [`vpt_bearish`](/signals/catalog/volume#vpt-bearish) | FILTER | Volume | Close, Volume |
-| [`vpt_bullish`](/signals/catalog/volume#vpt-bullish) | FILTER | Volume | Close, Volume |
-| [`vwap_above`](/signals/catalog/volume#vwap-above) | FILTER | Volume | High, Low, Close, Volume |
-| [`vwap_below`](/signals/catalog/volume#vwap-below) | FILTER | Volume | High, Low, Close, Volume |
-| [`vwma_cross_down`](/signals/catalog/volume#vwma-cross-down) | TRIGGER | Volume | Close, Volume |
-| [`vwma_cross_up`](/signals/catalog/volume#vwma-cross-up) | TRIGGER | Volume | Close, Volume |
-| [`atr_high_volatility`](/signals/catalog/volatility#atr-high-volatility) | FILTER | Volatility | High, Low, Close |
-| [`atr_trailing_stop_flip_down`](/signals/catalog/volatility#atr-trailing-stop-flip-down) | TRIGGER | Volatility | High, Low, Close |
-| [`atr_trailing_stop_flip_up`](/signals/catalog/volatility#atr-trailing-stop-flip-up) | TRIGGER | Volatility | High, Low, Close |
-| [`atr_trailing_stop_long`](/signals/catalog/volatility#atr-trailing-stop-long) | FILTER | Volatility | High, Low, Close |
-| [`atr_trailing_stop_short`](/signals/catalog/volatility#atr-trailing-stop-short) | FILTER | Volatility | High, Low, Close |
-| [`bb_lower_breakout`](/signals/catalog/volatility#bb-lower-breakout) | TRIGGER | Volatility | Close |
-| [`bb_squeeze`](/signals/catalog/volatility#bb-squeeze) | TRIGGER | Volatility | Close |
-| [`bb_upper_breakout`](/signals/catalog/volatility#bb-upper-breakout) | TRIGGER | Volatility | Close |
-| [`dc_lower_breakout`](/signals/catalog/volatility#dc-lower-breakout) | TRIGGER | Volatility | High, Low, Close |
-| [`dc_upper_breakout`](/signals/catalog/volatility#dc-upper-breakout) | TRIGGER | Volatility | High, Low, Close |
-| [`kc_lower_breakout`](/signals/catalog/volatility#kc-lower-breakout) | TRIGGER | Volatility | High, Low, Close |
-| [`kc_upper_breakout`](/signals/catalog/volatility#kc-upper-breakout) | TRIGGER | Volatility | High, Low, Close |
-| [`natr_high_volatility`](/signals/catalog/volatility#natr-high-volatility) | FILTER | Volatility | High, Low, Close |
-| [`natr_low_volatility`](/signals/catalog/volatility#natr-low-volatility) | FILTER | Volatility | High, Low, Close |
-| [`starc_lower_breakout`](/signals/catalog/volatility#starc-lower-breakout) | FILTER | Volatility | High, Low, Close |
-| [`starc_upper_breakout`](/signals/catalog/volatility#starc-upper-breakout) | FILTER | Volatility | High, Low, Close |
-| [`ulcer_high_risk`](/signals/catalog/volatility#ulcer-high-risk) | FILTER | Volatility | Close |
-| [`ulcer_low_risk`](/signals/catalog/volatility#ulcer-low-risk) | FILTER | Volatility | Close |
-| [`volatility_stop_lower`](/signals/catalog/volatility#volatility-stop-lower) | FILTER | Volatility | Close |
-| [`volatility_stop_upper`](/signals/catalog/volatility#volatility-stop-upper) | FILTER | Volatility | Close |
-| [`bearish_engulfing_trigger`](/signals/catalog/patterns#bearish-engulfing-trigger) | TRIGGER | Patterns | Open, Close |
-| [`bearish_harami_trigger`](/signals/catalog/patterns#bearish-harami-trigger) | TRIGGER | Patterns | Open, Close |
-| [`bearish_pattern_recent`](/signals/catalog/patterns#bearish-pattern-recent) | FILTER | Patterns | Open, High, Low, Close |
-| [`bearish_pin_bar_trigger`](/signals/catalog/patterns#bearish-pin-bar-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`bullish_engulfing_trigger`](/signals/catalog/patterns#bullish-engulfing-trigger) | TRIGGER | Patterns | Open, Close |
-| [`bullish_harami_trigger`](/signals/catalog/patterns#bullish-harami-trigger) | TRIGGER | Patterns | Open, Close |
-| [`bullish_pattern_recent`](/signals/catalog/patterns#bullish-pattern-recent) | FILTER | Patterns | Open, High, Low, Close |
-| [`bullish_pin_bar_trigger`](/signals/catalog/patterns#bullish-pin-bar-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`continuation_pattern_bearish`](/signals/catalog/patterns#continuation-pattern-bearish) | FILTER | Patterns | Open, High, Low, Close |
-| [`continuation_pattern_bullish`](/signals/catalog/patterns#continuation-pattern-bullish) | FILTER | Patterns | Open, High, Low, Close |
-| [`dark_cloud_cover_trigger`](/signals/catalog/patterns#dark-cloud-cover-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`doji_trigger`](/signals/catalog/patterns#doji-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`dragonfly_doji_trigger`](/signals/catalog/patterns#dragonfly-doji-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`evening_star_trigger`](/signals/catalog/patterns#evening-star-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`gravestone_doji_trigger`](/signals/catalog/patterns#gravestone-doji-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`hammer_trigger`](/signals/catalog/patterns#hammer-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`hanging_man_trigger`](/signals/catalog/patterns#hanging-man-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`indecision_pattern_recent`](/signals/catalog/patterns#indecision-pattern-recent) | FILTER | Patterns | Open, High, Low, Close |
-| [`inside_bar_trigger`](/signals/catalog/patterns#inside-bar-trigger) | TRIGGER | Patterns | High, Low |
-| [`inverted_hammer_trigger`](/signals/catalog/patterns#inverted-hammer-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`long_legged_doji_trigger`](/signals/catalog/patterns#long-legged-doji-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`marubozu_bearish_trigger`](/signals/catalog/patterns#marubozu-bearish-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`marubozu_bullish_trigger`](/signals/catalog/patterns#marubozu-bullish-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`morning_star_trigger`](/signals/catalog/patterns#morning-star-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`nr7_trigger`](/signals/catalog/patterns#nr7-trigger) | TRIGGER | Patterns | High, Low |
-| [`outside_bar_trigger`](/signals/catalog/patterns#outside-bar-trigger) | TRIGGER | Patterns | High, Low |
-| [`piercing_line_trigger`](/signals/catalog/patterns#piercing-line-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`reversal_pattern_bearish`](/signals/catalog/patterns#reversal-pattern-bearish) | FILTER | Patterns | Open, High, Low, Close |
-| [`reversal_pattern_bullish`](/signals/catalog/patterns#reversal-pattern-bullish) | FILTER | Patterns | Open, High, Low, Close |
-| [`shooting_star_trigger`](/signals/catalog/patterns#shooting-star-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`spinning_top_trigger`](/signals/catalog/patterns#spinning-top-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`strong_body_recent`](/signals/catalog/patterns#strong-body-recent) | FILTER | Patterns | Open, High, Low, Close |
-| [`three_black_crows_trigger`](/signals/catalog/patterns#three-black-crows-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`three_inside_down_trigger`](/signals/catalog/patterns#three-inside-down-trigger) | TRIGGER | Patterns | Open, Close |
-| [`three_inside_up_trigger`](/signals/catalog/patterns#three-inside-up-trigger) | TRIGGER | Patterns | Open, Close |
-| [`three_white_soldiers_trigger`](/signals/catalog/patterns#three-white-soldiers-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`tweezer_bottoms_trigger`](/signals/catalog/patterns#tweezer-bottoms-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`tweezer_tops_trigger`](/signals/catalog/patterns#tweezer-tops-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`two_bar_reversal_bearish_trigger`](/signals/catalog/patterns#two-bar-reversal-bearish-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
-| [`two_bar_reversal_bullish_trigger`](/signals/catalog/patterns#two-bar-reversal-bullish-trigger) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`ao_bearish`](/signals/catalog/momentum) | FILTER | Momentum | High, Low |
+| [`ao_bullish`](/signals/catalog/momentum) | FILTER | Momentum | High, Low |
+| [`ao_zero_cross`](/signals/catalog/momentum) | TRIGGER | Momentum | High, Low |
+| [`apo_bearish`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`apo_bullish`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`apo_cross_down`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`apo_cross_up`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`bop_bearish`](/signals/catalog/momentum) | FILTER | Momentum | Open, High, Low, Close |
+| [`bop_bullish`](/signals/catalog/momentum) | FILTER | Momentum | Open, High, Low, Close |
+| [`bop_cross_down`](/signals/catalog/momentum) | TRIGGER | Momentum | Open, High, Low, Close |
+| [`bop_cross_up`](/signals/catalog/momentum) | TRIGGER | Momentum | Open, High, Low, Close |
+| [`cmo_cross_down`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`cmo_cross_up`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`cmo_overbought`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`cmo_oversold`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`kama_cross_down`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`kama_cross_up`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`mom_bearish`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`mom_bullish`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`mom_cross_down`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`mom_cross_up`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`ppo_bearish_cross`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`ppo_bullish_cross`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`pvo_bearish_cross`](/signals/catalog/momentum) | TRIGGER | Momentum | Volume |
+| [`pvo_bullish_cross`](/signals/catalog/momentum) | TRIGGER | Momentum | Volume |
+| [`roc_momentum_shift`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`roc_negative`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`roc_positive`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`rsi_cross_down`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`rsi_cross_up`](/signals/catalog/momentum) | TRIGGER | Momentum | Close |
+| [`rsi_overbought`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`rsi_oversold`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`stoch_overbought`](/signals/catalog/momentum) | FILTER | Momentum | High, Low, Close |
+| [`stoch_oversold`](/signals/catalog/momentum) | FILTER | Momentum | High, Low, Close |
+| [`stochrsi_overbought`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`stochrsi_oversold`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`tsi_bearish`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`tsi_bullish`](/signals/catalog/momentum) | FILTER | Momentum | Close |
+| [`uo_overbought`](/signals/catalog/momentum) | FILTER | Momentum | High, Low, Close |
+| [`uo_oversold`](/signals/catalog/momentum) | FILTER | Momentum | High, Low, Close |
+| [`williams_r_overbought`](/signals/catalog/momentum) | FILTER | Momentum | High, Low, Close |
+| [`williams_r_oversold`](/signals/catalog/momentum) | FILTER | Momentum | High, Low, Close |
+| [`adx_bullish_di`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`adx_strong_trend`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`alligator_bearish`](/signals/catalog/trend) | FILTER | Trend | High, Low |
+| [`alligator_bullish`](/signals/catalog/trend) | FILTER | Trend | High, Low |
+| [`alligator_sleeping`](/signals/catalog/trend) | FILTER | Trend | High, Low |
+| [`alma_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`alma_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`aroon_crossover`](/signals/catalog/trend) | TRIGGER | Trend | High, Low |
+| [`aroon_down_trend`](/signals/catalog/trend) | FILTER | Trend | High, Low |
+| [`aroon_up_trend`](/signals/catalog/trend) | FILTER | Trend | High, Low |
+| [`cci_overbought`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`cci_oversold`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`chandelier_long_stop_hit`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`chandelier_short_stop_hit`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`dema_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`dema_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`dpo_negative`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`dpo_positive`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`ema_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`ema_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`ema_crossover`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`epma_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`epma_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`heikin_ashi_bearish`](/signals/catalog/trend) | FILTER | Trend | Open, High, Low, Close |
+| [`heikin_ashi_bullish`](/signals/catalog/trend) | FILTER | Trend | Open, High, Low, Close |
+| [`hma_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`hma_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`ichimoku_bearish`](/signals/catalog/trend) | FILTER | Trend | High, Low |
+| [`ichimoku_bullish`](/signals/catalog/trend) | FILTER | Trend | High, Low |
+| [`ichimoku_tk_cross`](/signals/catalog/trend) | TRIGGER | Trend | High, Low |
+| [`is_above_alma`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_dema`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_epma`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_hma`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_mama`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_sma`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_smma`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_t3`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_tema`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`is_above_trima`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`kst_bearish_cross`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`kst_bullish_cross`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`ma_ribbon_bearish`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`ma_ribbon_bullish`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`ma_ribbon_tangled`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`macd_bearish_cross`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`macd_bullish_cross`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`macd_positive`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`mama_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`mama_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`mass_reversal_signal`](/signals/catalog/trend) | TRIGGER | Trend | High, Low |
+| [`multi_tf_trend_bearish`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`multi_tf_trend_bullish`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`price_above_ema`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`psar_bearish`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`psar_bullish`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`psar_reversal`](/signals/catalog/trend) | TRIGGER | Trend | High, Low, Close |
+| [`rsi_bearish_divergence`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`rsi_bullish_divergence`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`rsi_hidden_bearish_divergence`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`rsi_hidden_bullish_divergence`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`sma_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`sma_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`sma_crossover`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`smma_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`smma_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`stc_overbought`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`stc_oversold`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`supertrend_flip_down`](/signals/catalog/trend) | TRIGGER | Trend | High, Low, Close |
+| [`supertrend_flip_up`](/signals/catalog/trend) | TRIGGER | Trend | High, Low, Close |
+| [`supertrend_long`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`supertrend_short`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`t3_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`t3_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`tema_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`tema_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`trima_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`trima_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`trix_bearish`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`trix_bullish`](/signals/catalog/trend) | FILTER | Trend | Close |
+| [`ttm_squeeze_active`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`ttm_squeeze_fired_bearish`](/signals/catalog/trend) | TRIGGER | Trend | High, Low, Close |
+| [`ttm_squeeze_fired_bullish`](/signals/catalog/trend) | TRIGGER | Trend | High, Low, Close |
+| [`vortex_bearish`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`vortex_bullish`](/signals/catalog/trend) | FILTER | Trend | High, Low, Close |
+| [`vortex_crossover`](/signals/catalog/trend) | TRIGGER | Trend | High, Low, Close |
+| [`wma_cross_down`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`wma_cross_up`](/signals/catalog/trend) | TRIGGER | Trend | Close |
+| [`adi_bearish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`adi_bullish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`adosc_bearish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`adosc_bullish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`adosc_cross_down`](/signals/catalog/volume) | TRIGGER | Volume | High, Low, Close, Volume |
+| [`adosc_cross_up`](/signals/catalog/volume) | TRIGGER | Volume | High, Low, Close, Volume |
+| [`cmf_bearish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`cmf_bullish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`cumulative_return_positive`](/signals/catalog/volume) | FILTER | Volume | Close |
+| [`cumulative_return_target`](/signals/catalog/volume) | FILTER | Volume | Close |
+| [`daily_return_negative`](/signals/catalog/volume) | FILTER | Volume | Close |
+| [`daily_return_positive`](/signals/catalog/volume) | FILTER | Volume | Close |
+| [`eom_bearish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Volume |
+| [`eom_bullish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Volume |
+| [`force_bearish`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`force_bullish`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`is_above_vwma`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`kvo_bearish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`kvo_bearish_cross`](/signals/catalog/volume) | TRIGGER | Volume | High, Low, Close, Volume |
+| [`kvo_bullish`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`kvo_bullish_cross`](/signals/catalog/volume) | TRIGGER | Volume | High, Low, Close, Volume |
+| [`mfi_overbought`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`mfi_oversold`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`nvi_bearish`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`nvi_bullish`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`obv_bearish`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`obv_bullish`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`vpt_bearish`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`vpt_bullish`](/signals/catalog/volume) | FILTER | Volume | Close, Volume |
+| [`vwap_above`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`vwap_below`](/signals/catalog/volume) | FILTER | Volume | High, Low, Close, Volume |
+| [`vwma_cross_down`](/signals/catalog/volume) | TRIGGER | Volume | Close, Volume |
+| [`vwma_cross_up`](/signals/catalog/volume) | TRIGGER | Volume | Close, Volume |
+| [`atr_high_volatility`](/signals/catalog/volatility) | FILTER | Volatility | High, Low, Close |
+| [`atr_trailing_stop_flip_down`](/signals/catalog/volatility) | TRIGGER | Volatility | High, Low, Close |
+| [`atr_trailing_stop_flip_up`](/signals/catalog/volatility) | TRIGGER | Volatility | High, Low, Close |
+| [`atr_trailing_stop_long`](/signals/catalog/volatility) | FILTER | Volatility | High, Low, Close |
+| [`atr_trailing_stop_short`](/signals/catalog/volatility) | FILTER | Volatility | High, Low, Close |
+| [`bb_lower_breakout`](/signals/catalog/volatility) | TRIGGER | Volatility | Close |
+| [`bb_squeeze`](/signals/catalog/volatility) | TRIGGER | Volatility | Close |
+| [`bb_upper_breakout`](/signals/catalog/volatility) | TRIGGER | Volatility | Close |
+| [`dc_lower_breakout`](/signals/catalog/volatility) | TRIGGER | Volatility | High, Low, Close |
+| [`dc_upper_breakout`](/signals/catalog/volatility) | TRIGGER | Volatility | High, Low, Close |
+| [`kc_lower_breakout`](/signals/catalog/volatility) | TRIGGER | Volatility | High, Low, Close |
+| [`kc_upper_breakout`](/signals/catalog/volatility) | TRIGGER | Volatility | High, Low, Close |
+| [`natr_high_volatility`](/signals/catalog/volatility) | FILTER | Volatility | High, Low, Close |
+| [`natr_low_volatility`](/signals/catalog/volatility) | FILTER | Volatility | High, Low, Close |
+| [`starc_lower_breakout`](/signals/catalog/volatility) | FILTER | Volatility | High, Low, Close |
+| [`starc_upper_breakout`](/signals/catalog/volatility) | FILTER | Volatility | High, Low, Close |
+| [`ulcer_high_risk`](/signals/catalog/volatility) | FILTER | Volatility | Close |
+| [`ulcer_low_risk`](/signals/catalog/volatility) | FILTER | Volatility | Close |
+| [`volatility_stop_lower`](/signals/catalog/volatility) | FILTER | Volatility | Close |
+| [`volatility_stop_upper`](/signals/catalog/volatility) | FILTER | Volatility | Close |
+| [`bearish_engulfing_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, Close |
+| [`bearish_harami_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, Close |
+| [`bearish_pattern_recent`](/signals/catalog/patterns) | FILTER | Patterns | Open, High, Low, Close |
+| [`bearish_pin_bar_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`bullish_engulfing_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, Close |
+| [`bullish_harami_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, Close |
+| [`bullish_pattern_recent`](/signals/catalog/patterns) | FILTER | Patterns | Open, High, Low, Close |
+| [`bullish_pin_bar_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`continuation_pattern_bearish`](/signals/catalog/patterns) | FILTER | Patterns | Open, High, Low, Close |
+| [`continuation_pattern_bullish`](/signals/catalog/patterns) | FILTER | Patterns | Open, High, Low, Close |
+| [`dark_cloud_cover_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`doji_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`dragonfly_doji_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`evening_star_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`gravestone_doji_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`hammer_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`hanging_man_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`indecision_pattern_recent`](/signals/catalog/patterns) | FILTER | Patterns | Open, High, Low, Close |
+| [`inside_bar_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | High, Low |
+| [`inverted_hammer_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`long_legged_doji_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`marubozu_bearish_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`marubozu_bullish_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`morning_star_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`nr7_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | High, Low |
+| [`outside_bar_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | High, Low |
+| [`piercing_line_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`reversal_pattern_bearish`](/signals/catalog/patterns) | FILTER | Patterns | Open, High, Low, Close |
+| [`reversal_pattern_bullish`](/signals/catalog/patterns) | FILTER | Patterns | Open, High, Low, Close |
+| [`shooting_star_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`spinning_top_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`strong_body_recent`](/signals/catalog/patterns) | FILTER | Patterns | Open, High, Low, Close |
+| [`three_black_crows_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`three_inside_down_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, Close |
+| [`three_inside_up_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, Close |
+| [`three_white_soldiers_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`tweezer_bottoms_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`tweezer_tops_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`two_bar_reversal_bearish_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`two_bar_reversal_bullish_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
 
 ---
 

--- a/docs/signals/catalog/momentum.mdx
+++ b/docs/signals/catalog/momentum.mdx
@@ -9,13 +9,15 @@ _42 signals in this category._
 
 See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.
 
-### ao_bearish
+Click a signal to expand parameters and examples.
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<AccordionGroup>
+
+<Accordion title="ao_bearish" description="FILTER - requires High, Low">
 
 Check if Awesome Oscillator indicates bearish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -23,7 +25,7 @@ Check if Awesome Oscillator indicates bearish momentum.
 | `window_slow` | `int` | 20 -- 60 | `34` | Slow SMA window |
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Bearish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -58,13 +60,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ao_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="ao_bullish" description="FILTER - requires High, Low">
 
 Check if Awesome Oscillator indicates bullish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -72,7 +74,7 @@ Check if Awesome Oscillator indicates bullish momentum.
 | `window_slow` | `int` | 20 -- 60 | `34` | Slow SMA window |
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Bullish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -107,13 +109,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ao_zero_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="ao_zero_cross" description="TRIGGER - requires High, Low">
 
 Check if Awesome Oscillator crosses zero line.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -121,7 +123,7 @@ Check if Awesome Oscillator crosses zero line.
 | `window_slow` | `int` | 20 -- 60 | `34` | Slow SMA window |
 | `direction` | `str` | - | `bullish` | Direction: 'bullish' for cross above, 'bearish' for cross below |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -156,20 +158,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### apo_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="apo_bearish" description="FILTER - requires Close">
 
 Check if the Absolute Price Oscillator is negative (bearish regime).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `12` | Fast EMA period |
 | `window_slow` | `int` | 5 -- 200 | `26` | Slow EMA period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -202,20 +204,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### apo_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="apo_bullish" description="FILTER - requires Close">
 
 Check if the Absolute Price Oscillator (EMA fast - EMA slow) is positive. Equivalent to the MACD line being above zero (bullish momentum regime).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `12` | Fast EMA period |
 | `window_slow` | `int` | 5 -- 200 | `26` | Slow EMA period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -248,20 +250,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### apo_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="apo_cross_down" description="TRIGGER - requires Close">
 
 Detect APO crossing below zero (bearish momentum onset).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `12` | Fast EMA period |
 | `window_slow` | `int` | 5 -- 200 | `26` | Slow EMA period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -294,20 +296,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### apo_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="apo_cross_up" description="TRIGGER - requires Close">
 
 Detect APO crossing above zero (bullish momentum onset).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `12` | Fast EMA period |
 | `window_slow` | `int` | 5 -- 200 | `26` | Slow EMA period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -340,15 +342,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bop_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="bop_bearish" description="FILTER - requires Open, High, Low, Close">
 
 Check if Balance of Power indicates sellers in control on the current bar.
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -375,15 +377,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bop_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="bop_bullish" description="FILTER - requires Open, High, Low, Close">
 
 Check if Balance of Power indicates buyers in control on the current bar. BOP = (close - open) / (high - low). Positive = buyers dominated the bar.
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -410,15 +412,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bop_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="bop_cross_down" description="TRIGGER - requires Open, High, Low, Close">
 
 Detect Balance of Power crossing below zero (buyers -&gt; sellers).
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -445,15 +447,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bop_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="bop_cross_up" description="TRIGGER - requires Open, High, Low, Close">
 
 Detect Balance of Power crossing above zero (sellers -&gt; buyers).
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -480,20 +482,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cmo_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="cmo_cross_down" description="TRIGGER - requires Close">
 
 Detect CMO crossing below the overbought threshold (bearish momentum onset). Analogous to RSI crossing below 70.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 100 | `14` | CMO lookback |
 | `threshold` | `float` | 20.0 -- 90.0 | `50.0` | Overbought threshold to cross below |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -526,20 +528,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cmo_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="cmo_cross_up" description="TRIGGER - requires Close">
 
 Detect CMO crossing above the oversold threshold (bullish momentum return). Analogous to RSI crossing above 30.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 100 | `14` | CMO lookback |
 | `threshold` | `float` | -90.0 -- -20.0 | `-50.0` | Oversold threshold to cross above |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -572,20 +574,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cmo_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="cmo_overbought" description="FILTER - requires Close">
 
 Check if Chande Momentum Oscillator is above the overbought threshold. CMO ranges from -100 to +100; default threshold of +50 is standard (analogous to RSI 70).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 100 | `14` | CMO lookback |
 | `threshold` | `float` | 20.0 -- 90.0 | `50.0` | Overbought threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -618,20 +620,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cmo_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="cmo_oversold" description="FILTER - requires Close">
 
 Check if Chande Momentum Oscillator is below the oversold threshold. Default threshold of -50 is standard (analogous to RSI 30).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 100 | `14` | CMO lookback |
 | `threshold` | `float` | -90.0 -- -20.0 | `-50.0` | Oversold threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -664,13 +666,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kama_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="kama_cross_down" description="TRIGGER - requires Close">
 
 Check if price crosses below KAMA (bearish signal).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -678,7 +680,7 @@ Check if price crosses below KAMA (bearish signal).
 | `pow1` | `int` | 1 -- 10 | `2` | Fast smoothing constant |
 | `pow2` | `int` | 10 -- 50 | `30` | Slow smoothing constant |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -713,13 +715,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kama_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="kama_cross_up" description="TRIGGER - requires Close">
 
 Check if price crosses above KAMA (bullish signal).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -727,7 +729,7 @@ Check if price crosses above KAMA (bullish signal).
 | `pow1` | `int` | 1 -- 10 | `2` | Fast smoothing constant |
 | `pow2` | `int` | 10 -- 50 | `30` | Slow smoothing constant |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -762,19 +764,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mom_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="mom_bearish" description="FILTER - requires Close">
 
 Check if Momentum (close - close[-n]) is negative. Indicates downward price momentum over the lookback window.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 200 | `10` | Lookback period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -805,19 +807,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mom_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="mom_bullish" description="FILTER - requires Close">
 
 Check if Momentum (close - close[-n]) is positive. Indicates upward price momentum over the lookback window.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 200 | `10` | Lookback period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -848,19 +850,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mom_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="mom_cross_down" description="TRIGGER - requires Close">
 
 Detect Momentum crossing below zero (bearish zero-line cross).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 200 | `10` | Lookback period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -891,19 +893,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mom_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="mom_cross_up" description="TRIGGER - requires Close">
 
 Detect Momentum crossing above zero (bullish zero-line cross).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 200 | `10` | Lookback period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -934,13 +936,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ppo_bearish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ppo_bearish_cross" description="TRIGGER - requires Close">
 
 Check if PPO crosses below signal line (bearish).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -948,7 +950,7 @@ Check if PPO crosses below signal line (bearish).
 | `window_fast` | `int` | 5 -- 20 | `12` | Fast EMA period |
 | `window_sign` | `int` | 3 -- 15 | `9` | Signal line period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -983,13 +985,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ppo_bullish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ppo_bullish_cross" description="TRIGGER - requires Close">
 
 Check if PPO crosses above signal line (bullish).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -997,7 +999,7 @@ Check if PPO crosses above signal line (bullish).
 | `window_fast` | `int` | 5 -- 20 | `12` | Fast EMA period |
 | `window_sign` | `int` | 3 -- 15 | `9` | Signal line period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1032,13 +1034,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### pvo_bearish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Volume
+<Accordion title="pvo_bearish_cross" description="TRIGGER - requires Volume">
 
 Check if PVO crosses below signal line (bearish volume).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1046,7 +1048,7 @@ Check if PVO crosses below signal line (bearish volume).
 | `window_fast` | `int` | 5 -- 20 | `12` | Fast EMA period |
 | `window_sign` | `int` | 3 -- 15 | `9` | Signal line period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1081,13 +1083,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### pvo_bullish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Volume
+<Accordion title="pvo_bullish_cross" description="TRIGGER - requires Volume">
 
 Check if PVO crosses above signal line (bullish volume).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1095,7 +1097,7 @@ Check if PVO crosses above signal line (bullish volume).
 | `window_fast` | `int` | 5 -- 20 | `12` | Fast EMA period |
 | `window_sign` | `int` | 3 -- 15 | `9` | Signal line period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1130,20 +1132,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### roc_momentum_shift
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="roc_momentum_shift" description="TRIGGER - requires Close">
 
 Check if ROC crosses zero (momentum shift).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 50 | `12` | ROC period |
 | `direction` | `str` | - | `bullish` | Direction: 'bullish' for cross above zero, 'bearish' for cross below |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1176,20 +1178,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### roc_negative
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="roc_negative" description="FILTER - requires Close">
 
 Check if Rate of Change indicates negative momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 50 | `12` | ROC period |
 | `threshold` | `float` | -10.0 -- 10.0 | `0.0` | Negative momentum threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1222,20 +1224,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### roc_positive
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="roc_positive" description="FILTER - requires Close">
 
 Check if Rate of Change indicates positive momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 50 | `12` | ROC period |
 | `threshold` | `float` | -10.0 -- 10.0 | `0.0` | Positive momentum threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1268,20 +1270,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### rsi_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="rsi_cross_down" description="TRIGGER - requires Close">
 
 Check if RSI crosses below a threshold level. Returns True when RSI was at or above the threshold in the previous bar and is now below the threshold in the current bar. In crypto markets, consider higher thresholds (80/20) during strong trends.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 100 | `14` | RSI calculation window |
 | `threshold` | `float` | 0.0 -- 100.0 | `50.0` | Threshold level to cross below |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1314,20 +1316,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### rsi_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="rsi_cross_up" description="TRIGGER - requires Close">
 
 Check if RSI crosses above a threshold level. Returns True when RSI was at or below the threshold in the previous bar and is now above the threshold in the current bar. In crypto markets, consider higher thresholds (80/20) during strong trends.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 100 | `14` | RSI calculation window |
 | `threshold` | `float` | 0.0 -- 100.0 | `50.0` | Threshold level to cross above |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1360,20 +1362,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### rsi_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="rsi_overbought" description="FILTER - requires Close">
 
 Check if RSI is above the overbought threshold. RSI values above 70 typically indicate overbought conditions, suggesting the asset may be due for a pullback. In crypto markets, consider higher thresholds (80/20) during strong trends.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 100 | `14` | RSI calculation window |
 | `threshold` | `float` | 50.0 -- 100.0 | `70.0` | Overbought threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1406,20 +1408,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### rsi_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="rsi_oversold" description="FILTER - requires Close">
 
 Check if RSI is below the oversold threshold. RSI values below 30 typically indicate oversold conditions, suggesting the asset may be due for a bounce. In crypto markets, consider higher thresholds (80/20) during strong trends.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 100 | `14` | RSI calculation window |
 | `threshold` | `float` | 0.0 -- 50.0 | `30.0` | Oversold threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1452,13 +1454,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### stoch_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="stoch_overbought" description="FILTER - requires High, Low, Close">
 
 Check if Stochastic %K is above the overbought threshold.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1466,7 +1468,7 @@ Check if Stochastic %K is above the overbought threshold.
 | `smooth_window` | `int` | 1 -- 10 | `3` | %K smoothing period |
 | `threshold` | `float` | 70.0 -- 100.0 | `80.0` | Overbought threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1501,13 +1503,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### stoch_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="stoch_oversold" description="FILTER - requires High, Low, Close">
 
 Check if Stochastic %K is below the oversold threshold.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1515,7 +1517,7 @@ Check if Stochastic %K is below the oversold threshold.
 | `smooth_window` | `int` | 1 -- 10 | `3` | %K smoothing period |
 | `threshold` | `float` | 0.0 -- 30.0 | `20.0` | Oversold threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1550,13 +1552,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### stochrsi_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="stochrsi_overbought" description="FILTER - requires Close">
 
 Check if Stochastic RSI indicates overbought condition. In crypto markets, consider adjusting thresholds during strong trends.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1565,7 +1567,7 @@ Check if Stochastic RSI indicates overbought condition. In crypto markets, consi
 | `smooth2` | `int` | 1 -- 10 | `3` | Stochastic %D smoothing |
 | `threshold` | `float` | 0.6 -- 1.0 | `0.8` | Overbought threshold (0-1 scale) |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1602,13 +1604,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### stochrsi_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="stochrsi_oversold" description="FILTER - requires Close">
 
 Check if Stochastic RSI indicates oversold condition. In crypto markets, consider adjusting thresholds during strong trends.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1617,7 +1619,7 @@ Check if Stochastic RSI indicates oversold condition. In crypto markets, conside
 | `smooth2` | `int` | 1 -- 10 | `3` | Stochastic %D smoothing |
 | `threshold` | `float` | 0.0 -- 0.4 | `0.2` | Oversold threshold (0-1 scale) |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1654,13 +1656,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### tsi_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="tsi_bearish" description="FILTER - requires Close">
 
 Check if True Strength Index indicates bearish momentum. TSI below zero indicates bearish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1668,7 +1670,7 @@ Check if True Strength Index indicates bearish momentum. TSI below zero indicate
 | `window_fast` | `int` | 5 -- 25 | `13` | Fast EMA period |
 | `threshold` | `float` | -50.0 -- 50.0 | `0.0` | Bearish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1703,13 +1705,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### tsi_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="tsi_bullish" description="FILTER - requires Close">
 
 Check if True Strength Index indicates bullish momentum. TSI above zero indicates bullish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1717,7 +1719,7 @@ Check if True Strength Index indicates bullish momentum. TSI above zero indicate
 | `window_fast` | `int` | 5 -- 25 | `13` | Fast EMA period |
 | `threshold` | `float` | -50.0 -- 50.0 | `0.0` | Bullish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1752,13 +1754,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### uo_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="uo_overbought" description="FILTER - requires High, Low, Close">
 
 Check if Ultimate Oscillator indicates overbought condition.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1767,7 +1769,7 @@ Check if Ultimate Oscillator indicates overbought condition.
 | `window_long` | `int` | 14 -- 50 | `28` | Long window |
 | `threshold` | `float` | 60.0 -- 90.0 | `70.0` | Overbought threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1804,13 +1806,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### uo_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="uo_oversold" description="FILTER - requires High, Low, Close">
 
 Check if Ultimate Oscillator indicates oversold condition.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1819,7 +1821,7 @@ Check if Ultimate Oscillator indicates oversold condition.
 | `window_long` | `int` | 14 -- 50 | `28` | Long window |
 | `threshold` | `float` | 10.0 -- 40.0 | `30.0` | Oversold threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1856,20 +1858,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### williams_r_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="williams_r_overbought" description="FILTER - requires High, Low, Close">
 
 Check if Williams %R is above the overbought threshold. Williams %R ranges from -100 to 0. Values above -20 indicate overbought.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | Lookback window |
 | `threshold` | `float` | -30.0 -- 0.0 | `-20.0` | Overbought threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1902,20 +1904,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### williams_r_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="williams_r_oversold" description="FILTER - requires High, Low, Close">
 
 Check if Williams %R is below the oversold threshold. Williams %R ranges from -100 to 0. Values below -80 indicate oversold.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | Lookback window |
 | `threshold` | `float` | -100.0 -- -70.0 | `-80.0` | Oversold threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1947,3 +1949,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 ```
 
 </CodeGroup>
+
+</Accordion>
+
+</AccordionGroup>

--- a/docs/signals/catalog/patterns.mdx
+++ b/docs/signals/catalog/patterns.mdx
@@ -9,15 +9,17 @@ _40 signals in this category._
 
 See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.
 
-### bearish_engulfing_trigger
+Click a signal to expand parameters and examples.
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, Close
+<AccordionGroup>
+
+<Accordion title="bearish_engulfing_trigger" description="TRIGGER - requires Open, Close">
 
 Check if a bearish engulfing pattern completed on the current bar. Current bearish candle's body completely contains the previous bullish candle's body. Strong bearish reversal. References: [NISON], [KB-07], [STOCKCHARTS].
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -44,15 +46,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bearish_harami_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, Close
+<Accordion title="bearish_harami_trigger" description="TRIGGER - requires Open, Close">
 
 Check if a bearish harami pattern completed on the current bar. Current small bearish candle's body is inside the previous large bullish candle's body. Potential bearish reversal. References: [NISON], [STOCKCHARTS].
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -79,19 +81,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bearish_pattern_recent
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="bearish_pattern_recent" description="FILTER - requires Open, High, Low, Close">
 
 Check if any bearish candlestick pattern was detected within recent window. Scans for hanging man, shooting star, bearish engulfing, bearish harami, dark cloud cover, evening star, gravestone doji, three black crows, three inside down, tweezer tops, and bearish pin bar within the recent window.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 20 | `5` | Number of recent bars to check |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -122,20 +124,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bearish_pin_bar_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="bearish_pin_bar_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a bearish pin bar is detected on the current bar. Long upper wick with body in the lower portion of the range. Bearish reversal at resistance. References: [KB-07], [TSR], [PRICEACTION].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `wick_ratio` | `float` | 1.5 -- 5.0 | `2.0` | Minimum dominant wick to body ratio |
 | `body_position` | `float` | 0.1 -- 0.5 | `0.33` | Maximum body distance from end as fraction of range |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -168,15 +170,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bullish_engulfing_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, Close
+<Accordion title="bullish_engulfing_trigger" description="TRIGGER - requires Open, Close">
 
 Check if a bullish engulfing pattern completed on the current bar. Current bullish candle's body completely contains the previous bearish candle's body. Strong bullish reversal. References: [NISON], [KB-07], [STOCKCHARTS].
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -203,15 +205,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bullish_harami_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, Close
+<Accordion title="bullish_harami_trigger" description="TRIGGER - requires Open, Close">
 
 Check if a bullish harami pattern completed on the current bar. Current small bullish candle's body is inside the previous large bearish candle's body. Potential bullish reversal. References: [NISON], [STOCKCHARTS].
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -238,19 +240,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bullish_pattern_recent
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="bullish_pattern_recent" description="FILTER - requires Open, High, Low, Close">
 
 Check if any bullish candlestick pattern was detected within recent window. Scans for hammer, inverted hammer, bullish engulfing, bullish harami, piercing line, morning star, dragonfly doji, three white soldiers, three inside up, tweezer bottoms, and bullish pin bar within the recent window.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 20 | `5` | Number of recent bars to check |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -281,20 +283,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bullish_pin_bar_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="bullish_pin_bar_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a bullish pin bar is detected on the current bar. Long lower wick with body in the upper portion of the range. Bullish reversal at support. References: [KB-07], [TSR], [PRICEACTION].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `wick_ratio` | `float` | 1.5 -- 5.0 | `2.0` | Minimum dominant wick to body ratio |
 | `body_position` | `float` | 0.1 -- 0.5 | `0.33` | Maximum body distance from end as fraction of range |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -327,19 +329,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### continuation_pattern_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="continuation_pattern_bearish" description="FILTER - requires Open, High, Low, Close">
 
 Check if a bearish continuation pattern was detected within recent window. Scans for three black crows and three inside down.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 20 | `5` | Number of recent bars to check |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -370,19 +372,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### continuation_pattern_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="continuation_pattern_bullish" description="FILTER - requires Open, High, Low, Close">
 
 Check if a bullish continuation pattern was detected within recent window. Scans for three white soldiers and three inside up.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 20 | `5` | Number of recent bars to check |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -413,20 +415,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### dark_cloud_cover_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="dark_cloud_cover_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a dark cloud cover pattern completed on the current bar. Bearish reversal: bullish candle followed by bearish candle opening above prior high (classic) or prior close (relaxed) and closing below midpoint of prior body. The classic definition requires a price gap, which is rare in 24/7 crypto/forex markets. Set require_gap=False for those markets. References: [NISON], [KB-07].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `min_penetration` | `float` | 0.3 -- 0.8 | `0.5` | Minimum penetration into previous body |
 | `require_gap` | `bool` | - | `True` | If True, requires open above previous high (classic Nison). If False, requires open above previous close (relaxed for 24/7 markets) |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -459,19 +461,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### doji_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="doji_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a doji pattern is detected on the current bar. A doji forms when open and close are nearly equal relative to the candle's range, signaling indecision. References: [NISON], [KB-07], [CM45T3R].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `body_threshold` | `float` | 0.01 -- 0.3 | `0.1` | Maximum body-to-range ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -502,20 +504,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### dragonfly_doji_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="dragonfly_doji_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a dragonfly doji is detected on the current bar. A doji with open/close near the high and a long lower shadow. Bullish signal at support. References: [NISON], [STOCKCHARTS], [TRENDSPIDER].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `body_threshold` | `float` | 0.01 -- 0.3 | `0.1` | Maximum body-to-range ratio |
 | `upper_wick_max` | `float` | 0.01 -- 0.2 | `0.1` | Maximum upper wick-to-range ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -548,19 +550,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### evening_star_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="evening_star_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if an evening star pattern completed on the current bar. Three-candle bearish reversal: bullish candle, small-bodied star, then bearish candle closing below midpoint of first. References: [NISON], [KB-07].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `body_threshold` | `float` | 0.1 -- 0.5 | `0.3` | Maximum body-to-range ratio for middle candle |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -591,20 +593,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### gravestone_doji_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="gravestone_doji_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a gravestone doji is detected on the current bar. A doji with open/close near the low and a long upper shadow. Bearish signal at resistance. References: [NISON], [STOCKCHARTS], [TRENDSPIDER].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `body_threshold` | `float` | 0.01 -- 0.3 | `0.1` | Maximum body-to-range ratio |
 | `lower_wick_max` | `float` | 0.01 -- 0.2 | `0.1` | Maximum lower wick-to-range ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -637,20 +639,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### hammer_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="hammer_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a hammer shape is detected on the current bar. Small body at upper end with long lower wick and minimal upper wick. Bullish reversal after downtrend. References: [NISON], [KB-07], [CM45T3R].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `wick_ratio` | `float` | 1.5 -- 5.0 | `2.0` | Minimum lower wick to body ratio |
 | `upper_wick_max` | `float` | 0.01 -- 0.5 | `0.1` | Maximum upper wick to body ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -683,20 +685,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### hanging_man_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="hanging_man_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a hanging man shape is detected on the current bar. Same shape as hammer (small body, long lower wick) but interpreted as a bearish reversal when appearing after an uptrend. References: [NISON], [STOCKCHARTS].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `wick_ratio` | `float` | 1.5 -- 5.0 | `2.0` | Minimum lower wick to body ratio |
 | `upper_wick_max` | `float` | 0.01 -- 0.5 | `0.1` | Maximum upper wick to body ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -729,19 +731,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### indecision_pattern_recent
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="indecision_pattern_recent" description="FILTER - requires Open, High, Low, Close">
 
 Check if an indecision pattern was detected within recent window. Scans for doji, spinning top, inside bar, and NR7.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 20 | `5` | Number of recent bars to check |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -772,15 +774,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### inside_bar_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="inside_bar_trigger" description="TRIGGER - requires High, Low">
 
 Check if an inside bar is detected on the current bar. Current bar's range is completely contained within the previous bar's range. Signals consolidation and potential breakout. References: [KB-07], [TSR].
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -807,20 +809,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### inverted_hammer_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="inverted_hammer_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if an inverted hammer shape is detected on the current bar. Same shape as shooting star (small body, long upper wick) but interpreted as a bullish reversal when appearing after a downtrend. References: [NISON], [STOCKCHARTS].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `wick_ratio` | `float` | 1.5 -- 5.0 | `2.0` | Minimum upper wick to body ratio |
 | `lower_wick_max` | `float` | 0.01 -- 0.5 | `0.1` | Maximum lower wick to body ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -853,20 +855,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### long_legged_doji_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="long_legged_doji_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a long-legged doji is detected on the current bar. A doji with both upper and lower wicks at least wick_threshold of the total range, indicating extreme indecision. References: [NISON], [STOCKCHARTS].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `body_threshold` | `float` | 0.01 -- 0.3 | `0.1` | Maximum body-to-range ratio |
 | `wick_threshold` | `float` | 0.1 -- 0.5 | `0.25` | Minimum wick-to-range ratio for both wicks |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -899,19 +901,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### marubozu_bearish_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="marubozu_bearish_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a bearish marubozu is detected on the current bar. Full-bodied bearish candle with minimal or no wicks. Signals strong selling conviction. References: [NISON], [KB-07], [CM45T3R].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `wick_tolerance` | `float` | 0.0 -- 0.1 | `0.05` | Maximum wick-to-range ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -942,19 +944,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### marubozu_bullish_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="marubozu_bullish_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a bullish marubozu is detected on the current bar. Full-bodied bullish candle with minimal or no wicks. Signals strong buying conviction. References: [NISON], [KB-07], [CM45T3R].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `wick_tolerance` | `float` | 0.0 -- 0.1 | `0.05` | Maximum wick-to-range ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -985,19 +987,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### morning_star_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="morning_star_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a morning star pattern completed on the current bar. Three-candle bullish reversal: bearish candle, small-bodied star, then bullish candle closing above midpoint of first. References: [NISON], [KB-07].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `body_threshold` | `float` | 0.1 -- 0.5 | `0.3` | Maximum body-to-range ratio for middle candle |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1028,19 +1030,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### nr7_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="nr7_trigger" description="TRIGGER - requires High, Low">
 
 Check if a narrow range day is detected on the current bar. Current bar has the smallest range within the window period. Signals volatility compression and imminent breakout. Default window=7 for NR7; use 4 for NR4. References: [CRABEL], [KB-07], [BULKOWSKI].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 4 -- 20 | `7` | Number of bars to compare range against |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1071,15 +1073,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### outside_bar_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="outside_bar_trigger" description="TRIGGER - requires High, Low">
 
 Check if an outside bar is detected on the current bar. Current bar's range completely engulfs the previous bar's range. Signals increased volatility. References: [KB-07], [TSR].
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1106,20 +1108,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### piercing_line_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="piercing_line_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a piercing line pattern completed on the current bar. Bullish reversal: bearish candle followed by bullish candle opening below prior low (classic) or prior close (relaxed) and closing above midpoint of prior body. The classic definition requires a price gap, which is rare in 24/7 crypto/forex markets. Set require_gap=False for those markets. References: [NISON], [KB-07].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `min_penetration` | `float` | 0.3 -- 0.8 | `0.5` | Minimum penetration into previous body |
 | `require_gap` | `bool` | - | `True` | If True, requires open below previous low (classic Nison). If False, requires open below previous close (relaxed for 24/7 markets) |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1152,19 +1154,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### reversal_pattern_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="reversal_pattern_bearish" description="FILTER - requires Open, High, Low, Close">
 
 Check if a bearish reversal pattern was detected within recent window. Scans for hanging man, shooting star, bearish engulfing, evening star, dark cloud cover, and gravestone doji -- the classic bearish reversal patterns.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 20 | `5` | Number of recent bars to check |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1195,19 +1197,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### reversal_pattern_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="reversal_pattern_bullish" description="FILTER - requires Open, High, Low, Close">
 
 Check if a bullish reversal pattern was detected within recent window. Scans for hammer, inverted hammer, bullish engulfing, morning star, piercing line, and dragonfly doji -- the classic bullish reversal patterns.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 20 | `5` | Number of recent bars to check |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1238,20 +1240,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### shooting_star_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="shooting_star_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a shooting star shape is detected on the current bar. Small body at lower end with long upper wick and minimal lower wick. Bearish reversal after uptrend. References: [NISON], [STOCKCHARTS].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `wick_ratio` | `float` | 1.5 -- 5.0 | `2.0` | Minimum upper wick to body ratio |
 | `lower_wick_max` | `float` | 0.01 -- 0.5 | `0.1` | Maximum lower wick to body ratio |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1284,20 +1286,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### spinning_top_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="spinning_top_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a spinning top is detected on the current bar. Small body with significant wicks on both sides, signaling indecision. References: [NISON], [CM45T3R], [STOCKCHARTS].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `body_max` | `float` | 0.1 -- 0.5 | `0.3` | Maximum body-to-range ratio |
 | `wick_min` | `float` | 0.1 -- 0.5 | `0.2` | Minimum wick-to-range ratio for both wicks |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1330,19 +1332,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### strong_body_recent
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="strong_body_recent" description="FILTER - requires Open, High, Low, Close">
 
 Check if a marubozu (strong body) was detected within recent window. Scans for both bullish and bearish marubozu patterns.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 20 | `5` | Number of recent bars to check |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1373,19 +1375,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### three_black_crows_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="three_black_crows_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if three black crows pattern completed on the current bar. Three consecutive bearish candles with lower closes, each opening within the previous body. Strong bearish signal. References: [NISON], [KB-07], [STOCKCHARTS].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `min_body_ratio` | `float` | 0.3 -- 0.8 | `0.5` | Minimum body-to-range ratio per candle |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1416,15 +1418,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### three_inside_down_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, Close
+<Accordion title="three_inside_down_trigger" description="TRIGGER - requires Open, Close">
 
 Check if three inside down pattern completed on the current bar. Bullish candle, bearish harami, then bearish close below first candle's open. Confirmed bearish reversal. References: [NISON], [KB-07], [TRENDSPIDER].
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1451,15 +1453,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### three_inside_up_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, Close
+<Accordion title="three_inside_up_trigger" description="TRIGGER - requires Open, Close">
 
 Check if three inside up pattern completed on the current bar. Bearish candle, bullish harami, then bullish close above first candle's open. Confirmed bullish reversal. References: [NISON], [KB-07], [TRENDSPIDER].
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1486,19 +1488,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### three_white_soldiers_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="three_white_soldiers_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if three white soldiers pattern completed on the current bar. Three consecutive bullish candles with higher closes, each opening within the previous body. Strong bullish signal. References: [NISON], [KB-07], [STOCKCHARTS].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `min_body_ratio` | `float` | 0.3 -- 0.8 | `0.5` | Minimum body-to-range ratio per candle |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1529,19 +1531,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### tweezer_bottoms_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="tweezer_bottoms_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a tweezer bottoms pattern completed on the current bar. Two consecutive candles with approximately equal lows, first bearish and second bullish. Bullish reversal. References: [NISON], [CM45T3R].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `tolerance` | `float` | 0.001 -- 0.05 | `0.01` | Maximum low-to-low difference as fraction of average range |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1572,19 +1574,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### tweezer_tops_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="tweezer_tops_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a tweezer tops pattern completed on the current bar. Two consecutive candles with approximately equal highs, first bullish and second bearish. Bearish reversal. References: [NISON], [CM45T3R].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `tolerance` | `float` | 0.001 -- 0.05 | `0.01` | Maximum high-to-high difference as fraction of average range |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1615,19 +1617,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### two_bar_reversal_bearish_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="two_bar_reversal_bearish_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a bearish two-bar reversal completed on the current bar. Bullish bar followed by bearish bar that takes out the high then closes below the prior open. The close_proximity parameter controls how close the close must be to the high/low extreme. References: [KB-07], [TSR], [DAILYFOREX].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `close_proximity` | `float` | 0.1 -- 0.5 | `0.25` | How close the close must be to the extreme, as a fraction of range. Lower is stricter |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1658,19 +1660,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### two_bar_reversal_bullish_trigger
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="two_bar_reversal_bullish_trigger" description="TRIGGER - requires Open, High, Low, Close">
 
 Check if a bullish two-bar reversal completed on the current bar. Bearish bar followed by bullish bar that takes out the low then closes above the prior open. The close_proximity parameter controls how close the close must be to the high/low extreme. References: [KB-07], [TSR], [DAILYFOREX].
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `close_proximity` | `float` | 0.1 -- 0.5 | `0.25` | How close the close must be to the extreme, as a fraction of range. Lower is stricter |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1700,3 +1702,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 ```
 
 </CodeGroup>
+
+</Accordion>
+
+</AccordionGroup>

--- a/docs/signals/catalog/trend.mdx
+++ b/docs/signals/catalog/trend.mdx
@@ -9,19 +9,21 @@ _88 signals in this category._
 
 See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.
 
-### adx_bullish_di
+Click a signal to expand parameters and examples.
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<AccordionGroup>
+
+<Accordion title="adx_bullish_di" description="FILTER - requires High, Low, Close">
 
 Check if +DI is greater than -DI (bullish directional movement). When +DI &gt; -DI, bulls have the upper hand.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | ADX period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -52,20 +54,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### adx_strong_trend
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="adx_strong_trend" description="FILTER - requires High, Low, Close">
 
 Check if ADX indicates a strong trend. ADX values above 25 typically indicate a strong trend (either up or down).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | ADX period |
 | `threshold` | `float` | 15.0 -- 50.0 | `25.0` | Trend strength threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -98,13 +100,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### alligator_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="alligator_bearish" description="FILTER - requires High, Low">
 
 Check if Williams Alligator lines are in bearish alignment (lips &lt; teeth &lt; jaw). Strong downtrend, all lines spreading downward.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -115,7 +117,7 @@ Check if Williams Alligator lines are in bearish alignment (lips &lt; teeth &lt;
 | `teeth_offset` | `int` | 0 -- 15 | `5` | Teeth forward shift |
 | `lips_offset` | `int` | 0 -- 10 | `3` | Lips forward shift |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -156,13 +158,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### alligator_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="alligator_bullish" description="FILTER - requires High, Low">
 
 Check if Williams Alligator lines are in bullish alignment (lips &gt; teeth &gt; jaw). Bill Williams's "hungry alligator" state: strong uptrend, all lines spreading upward.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -173,7 +175,7 @@ Check if Williams Alligator lines are in bullish alignment (lips &gt; teeth &gt;
 | `teeth_offset` | `int` | 0 -- 15 | `5` | Teeth forward shift |
 | `lips_offset` | `int` | 0 -- 10 | `3` | Lips forward shift |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -214,13 +216,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### alligator_sleeping
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="alligator_sleeping" description="FILTER - requires High, Low">
 
 Check if the Williams Alligator is sleeping (lines tangled, no trend). True when lines are neither strictly bullish-aligned nor bearish-aligned. Used as a no-trade filter during consolidation.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -231,7 +233,7 @@ Check if the Williams Alligator is sleeping (lines tangled, no trend). True when
 | `teeth_offset` | `int` | 0 -- 15 | `5` | Teeth forward shift |
 | `lips_offset` | `int` | 0 -- 10 | `3` | Lips forward shift |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -272,13 +274,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### alma_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="alma_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish ALMA crossover (fast ALMA crosses below slow ALMA).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -287,7 +289,7 @@ Detect a bearish ALMA crossover (fast ALMA crosses below slow ALMA).
 | `offset` | `float` | 0.0 -- 1.0 | `0.85` | Weight center |
 | `sigma` | `float` | 0.1 -- 20.0 | `6.0` | Gaussian spread |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -324,13 +326,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### alma_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="alma_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish ALMA crossover (fast ALMA crosses above slow ALMA). Both ALMAs use the same offset and sigma; only the window differs.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -339,7 +341,7 @@ Detect a bullish ALMA crossover (fast ALMA crosses above slow ALMA). Both ALMAs 
 | `offset` | `float` | 0.0 -- 1.0 | `0.85` | Weight center |
 | `sigma` | `float` | 0.1 -- 20.0 | `6.0` | Gaussian spread |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -376,20 +378,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### aroon_crossover
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="aroon_crossover" description="TRIGGER - requires High, Low">
 
 Check if Aroon lines cross (trend change signal).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 10 -- 50 | `25` | Lookback period |
 | `direction` | `str` | - | `bullish` | Crossover direction, 'bullish' or 'bearish' |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -422,20 +424,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### aroon_down_trend
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="aroon_down_trend" description="FILTER - requires High, Low">
 
 Check if Aroon Down indicates strong downtrend.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 10 -- 50 | `25` | Lookback period |
 | `threshold` | `float` | 50.0 -- 100.0 | `70.0` | Strong trend threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -468,20 +470,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### aroon_up_trend
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="aroon_up_trend" description="FILTER - requires High, Low">
 
 Check if Aroon Up indicates strong uptrend.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 10 -- 50 | `25` | Lookback period |
 | `threshold` | `float` | 50.0 -- 100.0 | `70.0` | Strong trend threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -514,13 +516,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cci_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="cci_overbought" description="FILTER - requires High, Low, Close">
 
 Check if CCI indicates overbought condition.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -528,7 +530,7 @@ Check if CCI indicates overbought condition.
 | `constant` | `float` | 0.001 -- 0.1 | `0.015` | CCI constant |
 | `threshold` | `float` | 50.0 -- 200.0 | `100.0` | Overbought threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -563,13 +565,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cci_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="cci_oversold" description="FILTER - requires High, Low, Close">
 
 Check if CCI indicates oversold condition.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -577,7 +579,7 @@ Check if CCI indicates oversold condition.
 | `constant` | `float` | 0.001 -- 0.1 | `0.015` | CCI constant |
 | `threshold` | `float` | -200.0 -- -50.0 | `-100.0` | Oversold threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -612,20 +614,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### chandelier_long_stop_hit
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="chandelier_long_stop_hit" description="FILTER - requires High, Low, Close">
 
 Check if close has breached the Chandelier long stop (close &lt; long_stop). If holding a long position, this is your exit trigger.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `22` | Rolling high/ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -658,20 +660,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### chandelier_short_stop_hit
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="chandelier_short_stop_hit" description="FILTER - requires High, Low, Close">
 
 Check if close has breached the Chandelier short stop (close &gt; short_stop). If holding a short position, this is your exit trigger.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `22` | Rolling low/ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -704,20 +706,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### dema_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="dema_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish DEMA crossover (fast DEMA crosses below slow DEMA). Lower-lag equivalent of an SMA/EMA death cross.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `9` | Fast DEMA window |
 | `window_slow` | `int` | 2 -- 200 | `21` | Slow DEMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -750,20 +752,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### dema_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="dema_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish DEMA crossover (fast DEMA crosses above slow DEMA). Lower-lag equivalent of an SMA/EMA golden cross.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `9` | Fast DEMA window |
 | `window_slow` | `int` | 2 -- 200 | `21` | Slow DEMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -796,19 +798,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### dpo_negative
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="dpo_negative" description="FILTER - requires Close">
 
 Check if DPO is negative (price below detrended average).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 10 -- 50 | `20` | DPO period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -839,19 +841,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### dpo_positive
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="dpo_positive" description="FILTER - requires Close">
 
 Check if DPO is positive (price above detrended average).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 10 -- 50 | `20` | DPO period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -882,20 +884,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ema_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ema_cross_down" description="TRIGGER - requires Close">
 
 Detect bearish EMA crossover (fast EMA crosses below slow EMA). Common periods: 9/21 (short-term), 50/200 (long-term). Adjust for crypto's 24/7 markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `9` | Fast EMA window |
 | `window_slow` | `int` | 5 -- 200 | `21` | Slow EMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -928,20 +930,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ema_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ema_cross_up" description="TRIGGER - requires Close">
 
 Detect bullish EMA crossover (fast EMA crosses above slow EMA). Common periods: 9/21 (short-term), 50/200 (long-term). Adjust for crypto's 24/7 markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `9` | Fast EMA window |
 | `window_slow` | `int` | 5 -- 200 | `21` | Slow EMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -974,13 +976,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ema_crossover
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ema_crossover" description="TRIGGER - requires Close">
 
 Detect an EMA crossover signal with configurable direction (bullish or bearish). Uses EMA indicator to calculate window_fast and window_slow EMAs. Returns True when a crossover is detected in the specified direction. Bullish crossover: window_fast EMA crosses above window_slow EMA Bearish crossover: window_fast EMA crosses below window_slow EMA The crossover detection compares the previous and current bars: - Bullish: prev window_fast &lt;= prev window_slow AND current window_fast &gt; current window_slow - Bearish: prev window_fast &gt;= prev window_slow AND current window_fast &lt; current window_slow Common periods: 9/21 (short-term), 50/200 (long-term). Adjust for crypto's 24/7 markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -988,7 +990,7 @@ Detect an EMA crossover signal with configurable direction (bullish or bearish).
 | `window_slow` | `int` | 1 -- 200 | _required_ | Slow EMA window in bars |
 | `direction` | `str` | - | `bullish` | Crossover direction, 'bullish' or 'bearish' |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1023,20 +1025,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### epma_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="epma_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish EPMA crossover (fast EPMA crosses below slow EPMA).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `10` | Fast EPMA window |
 | `window_slow` | `int` | 2 -- 200 | `30` | Slow EPMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1069,20 +1071,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### epma_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="epma_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish EPMA crossover (fast EPMA crosses above slow EPMA).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `10` | Fast EPMA window |
 | `window_slow` | `int` | 2 -- 200 | `30` | Slow EPMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1115,15 +1117,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### heikin_ashi_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="heikin_ashi_bearish" description="FILTER - requires Open, High, Low, Close">
 
 Check if the current Heikin-Ashi candle is bearish (HA_close &lt; HA_open).
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1150,15 +1152,15 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### heikin_ashi_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Open, High, Low, Close
+<Accordion title="heikin_ashi_bullish" description="FILTER - requires Open, High, Low, Close">
 
 Check if the current Heikin-Ashi candle is bullish (HA_close &gt; HA_open). A bullish HA candle indicates buying pressure on the smoothed bar. Strings of bullish HA candles indicate a sustained uptrend.
 
 _No configurable parameters._
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1185,20 +1187,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### hma_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="hma_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish HMA crossover (fast HMA crosses below slow HMA). Low-lag crossover; fires earlier than SMA/EMA equivalents.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 4 -- 100 | `9` | Fast HMA window |
 | `window_slow` | `int` | 4 -- 200 | `25` | Slow HMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1231,20 +1233,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### hma_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="hma_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish HMA crossover (fast HMA crosses above slow HMA). Low-lag crossover; fires earlier than SMA/EMA equivalents.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 4 -- 100 | `9` | Fast HMA window |
 | `window_slow` | `int` | 4 -- 200 | `25` | Slow HMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1277,13 +1279,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ichimoku_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="ichimoku_bearish" description="FILTER - requires High, Low">
 
 Check if Ichimoku indicates bearish signal (price below cloud).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1291,7 +1293,7 @@ Check if Ichimoku indicates bearish signal (price below cloud).
 | `window_kijun` | `int` | 15 -- 40 | `26` | Kijun-sen (base line) window |
 | `window_senkou` | `int` | 30 -- 70 | `52` | Senkou Span B (leading span B) window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1326,13 +1328,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ichimoku_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="ichimoku_bullish" description="FILTER - requires High, Low">
 
 Check if Ichimoku indicates bullish signal (price above cloud).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1340,7 +1342,7 @@ Check if Ichimoku indicates bullish signal (price above cloud).
 | `window_kijun` | `int` | 15 -- 40 | `26` | Kijun-sen (base line) window |
 | `window_senkou` | `int` | 30 -- 70 | `52` | Senkou Span B (leading span B) window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1375,13 +1377,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ichimoku_tk_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="ichimoku_tk_cross" description="TRIGGER - requires High, Low">
 
 Check if Tenkan-sen crosses Kijun-sen (TK cross).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1390,7 +1392,7 @@ Check if Tenkan-sen crosses Kijun-sen (TK cross).
 | `window_senkou` | `int` | 30 -- 70 | `52` | Senkou Span B (leading span B) window |
 | `direction` | `str` | - | `bullish` | Crossover direction, 'bullish' or 'bearish' |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1427,13 +1429,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_alma
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_alma" description="FILTER - requires Close">
 
 Check if the current price is above the Arnaud Legoux Moving Average (ALMA). ALMA is a Gaussian-weighted MA that can be tuned to react faster (offset near 1, lower sigma) or smoother (offset near 0, higher sigma).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1441,7 +1443,7 @@ Check if the current price is above the Arnaud Legoux Moving Average (ALMA). ALM
 | `offset` | `float` | 0.0 -- 1.0 | `0.85` | Weight center, 0=oldest, 1=newest |
 | `sigma` | `float` | 0.1 -- 20.0 | `6.0` | Gaussian spread. Higher = smoother |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1476,19 +1478,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_dema
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_dema" description="FILTER - requires Close">
 
 Check if the current price is above the Double Exponential Moving Average (DEMA). DEMA reduces lag compared to a standard EMA by combining two EMA passes. Useful for trend-following filters where responsiveness matters.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 200 | `21` | DEMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1519,19 +1521,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_epma
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_epma" description="FILTER - requires Close">
 
 Check if the current price is above the End Point Moving Average (EPMA / LSMA). EPMA is the endpoint of a linear regression over the window, projecting the trend to "now" rather than averaging past values.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 200 | `20` | EPMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1562,19 +1564,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_hma
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_hma" description="FILTER - requires Close">
 
 Check if the current price is above the Hull Moving Average (HMA). HMA tracks price with very low lag while remaining smoother than WMA. A common crypto trend filter.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 4 -- 200 | `16` | HMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1605,20 +1607,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_mama
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_mama" description="FILTER - requires Close">
 
 Check if the current price is above the MESA Adaptive Moving Average (MAMA). MAMA adapts its smoothing to volatility via a Hilbert transform.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `fast_limit` | `float` | 0.1 -- 1.0 | `0.5` | Upper alpha bound (fast response) |
 | `slow_limit` | `float` | 0.01 -- 0.5 | `0.05` | Lower alpha bound (slow response) |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1651,19 +1653,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_sma
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_sma" description="FILTER - requires Close">
 
 Check if the current price is above the Simple Moving Average. Uses SMA indicator to calculate the SMA for the given window and returns True if the most recent close price is strictly greater than the SMA value. Returns False if insufficient data is available. Common periods: 9/21 (short-term), 50/200 (long-term). Adjust for crypto's 24/7 markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 1 -- 200 | _required_ | SMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1694,19 +1696,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_smma
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_smma" description="FILTER - requires Close">
 
 Check if the current price is above the Smoothed Moving Average (SMMA / Wilder's). SMMA uses Wilder's smoothing (alpha=1/n) rather than EMA's 2/(n+1), producing a slower, more stable trend line. Same family used inside RSI and ATR.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 200 | `14` | SMMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1737,20 +1739,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_t3
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_t3" description="FILTER - requires Close">
 
 Check if the current price is above the Tillson T3 moving average. T3 is a smooth low-lag MA that combines 6 EMAs via the volume factor.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 200 | `10` | T3 window in bars |
 | `volume_factor` | `float` | 0.0 -- 1.0 | `0.7` | Tillson volume factor, controls smoothness |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1783,19 +1785,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_tema
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_tema" description="FILTER - requires Close">
 
 Check if the current price is above the Triple Exponential Moving Average (TEMA). TEMA has even less lag than DEMA by combining three EMA passes.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 200 | `21` | TEMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1826,19 +1828,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_trima
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="is_above_trima" description="FILTER - requires Close">
 
 Check if the current price is above the Triangular Moving Average (TRIMA). TRIMA is a double-smoothed SMA that weights the middle of the window more heavily, producing a smoother trend line than SMA.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 200 | `20` | TRIMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1869,13 +1871,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kst_bearish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="kst_bearish_cross" description="TRIGGER - requires Close">
 
 Check if KST crosses below signal line (bearish).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1889,7 +1891,7 @@ Check if KST crosses below signal line (bearish).
 | `window_sma4` | `int` | 2 -- 200 | `15` | SMA4 smoothing window for ROC4 |
 | `nsig` | `int` | 1 -- 200 | `9` | Signal line period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1936,13 +1938,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kst_bullish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="kst_bullish_cross" description="TRIGGER - requires Close">
 
 Check if KST crosses above signal line (bullish).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -1956,7 +1958,7 @@ Check if KST crosses above signal line (bullish).
 | `window_sma4` | `int` | 2 -- 200 | `15` | SMA4 smoothing window for ROC4 |
 | `nsig` | `int` | 1 -- 200 | `9` | Signal line period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2003,19 +2005,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ma_ribbon_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ma_ribbon_bearish" description="FILTER - requires Close">
 
 Check if all MAs in the ribbon are in strict bearish alignment (faster below slower).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `windows` | `tuple` | 2.0 -- 1000.0 | `(5, 8, 13, 21, 34, 55, 89, 144)` | Strictly increasing tuple of SMA periods |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2046,19 +2048,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ma_ribbon_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ma_ribbon_bullish" description="FILTER - requires Close">
 
 Check if all MAs in the ribbon are in strict bullish alignment (faster above slower). Uses 8 Fibonacci-spaced SMAs by default. Strict alignment means SMA(5) &gt; SMA(8) &gt; SMA(13) &gt; ... &gt; SMA(144). This is a strong trend filter -- when true, the market is in a clear uptrend across all horizons.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `windows` | `tuple` | 2.0 -- 1000.0 | `(5, 8, 13, 21, 34, 55, 89, 144)` | Strictly increasing tuple of SMA periods |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2089,19 +2091,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ma_ribbon_tangled
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ma_ribbon_tangled" description="FILTER - requires Close">
 
 Check if MAs in the ribbon are tangled (no strict alignment -- consolidation filter). Useful as a no-trade filter during choppy markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `windows` | `tuple` | 2.0 -- 1000.0 | `(5, 8, 13, 21, 34, 55, 89, 144)` | Strictly increasing tuple of SMA periods |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2132,13 +2134,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### macd_bearish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="macd_bearish_cross" description="TRIGGER - requires Close">
 
 Detect MACD bearish crossover (MACD line crosses below signal line). A bearish MACD crossover occurs when the MACD line crosses below the signal line, indicating potential downward momentum. Crypto's high volatility may produce frequent signals; use with trend confirmation.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2146,7 +2148,7 @@ Detect MACD bearish crossover (MACD line crosses below signal line). A bearish M
 | `window_slow` | `int` | 10 -- 100 | `26` | Slow EMA window |
 | `window_sign` | `int` | 2 -- 50 | `9` | Signal line EMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2181,13 +2183,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### macd_bullish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="macd_bullish_cross" description="TRIGGER - requires Close">
 
 Detect MACD bullish crossover (MACD line crosses above signal line). A bullish MACD crossover occurs when the MACD line crosses above the signal line, indicating potential upward momentum. Crypto's high volatility may produce frequent signals; use with trend confirmation.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2195,7 +2197,7 @@ Detect MACD bullish crossover (MACD line crosses above signal line). A bullish M
 | `window_slow` | `int` | 10 -- 100 | `26` | Slow EMA window |
 | `window_sign` | `int` | 2 -- 50 | `9` | Signal line EMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2230,13 +2232,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### macd_positive
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="macd_positive" description="FILTER - requires Close">
 
 Check if MACD histogram is positive (bullish momentum). Crypto's high volatility may produce frequent signals; use with trend confirmation.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2244,7 +2246,7 @@ Check if MACD histogram is positive (bullish momentum). Crypto's high volatility
 | `window_slow` | `int` | 10 -- 100 | `26` | Slow EMA window |
 | `window_sign` | `int` | 2 -- 50 | `9` | Signal line EMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2279,20 +2281,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mama_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="mama_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish MAMA/FAMA crossover (MAMA crosses below FAMA). Classic Ehlers exit signal: MAMA falling below FAMA signals a downtrend.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `fast_limit` | `float` | 0.1 -- 1.0 | `0.5` | Upper alpha bound |
 | `slow_limit` | `float` | 0.01 -- 0.5 | `0.05` | Lower alpha bound |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2325,20 +2327,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mama_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="mama_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish MAMA/FAMA crossover (MAMA crosses above FAMA). Classic Ehlers entry signal: MAMA rising above FAMA signals an uptrend.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `fast_limit` | `float` | 0.1 -- 1.0 | `0.5` | Upper alpha bound |
 | `slow_limit` | `float` | 0.01 -- 0.5 | `0.05` | Lower alpha bound |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2371,13 +2373,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mass_reversal_signal
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low
+<Accordion title="mass_reversal_signal" description="TRIGGER - requires High, Low">
 
 Check if Mass Index signals potential reversal (reversal bulge). A reversal bulge occurs when Mass Index rises above 27 then falls below 26.5.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2386,7 +2388,7 @@ Check if Mass Index signals potential reversal (reversal bulge). A reversal bulg
 | `threshold_high` | `float` | 25.0 -- 30.0 | `27.0` | Upper threshold |
 | `threshold_low` | `float` | 24.0 -- 27.0 | `26.5` | Lower threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2423,13 +2425,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### multi_tf_trend_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="multi_tf_trend_bearish" description="FILTER - requires Close">
 
 Check if the higher-timeframe EMA is falling.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2437,7 +2439,7 @@ Check if the higher-timeframe EMA is falling.
 | `window` | `int` | 2 -- 100 | `10` | EMA period |
 | `slope_threshold` | `float` | 0.0 -- 0.5 | `0.0` | Slope threshold for non-flat |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2472,13 +2474,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### multi_tf_trend_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="multi_tf_trend_bullish" description="FILTER - requires Close">
 
 Check if the higher-timeframe EMA is rising (trend confirmation filter). Requires a DatetimeIndex. Resamples to the specified higher timeframe, computes an EMA on the resampled closes, and returns True if the EMA slope is positive. Broadcasts back to the current bar's timestamp so lower-TF signals can be filtered by higher-TF trend.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2486,7 +2488,7 @@ Check if the higher-timeframe EMA is rising (trend confirmation filter). Require
 | `window` | `int` | 2 -- 100 | `10` | EMA period on the resampled close |
 | `slope_threshold` | `float` | 0.0 -- 0.5 | `0.0` | Relative slope threshold for non-flat classification |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2521,19 +2523,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### price_above_ema
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="price_above_ema" description="FILTER - requires Close">
 
 Check if price is above the EMA. Common periods: 9/21 (short-term), 50/200 (long-term). Adjust for crypto's 24/7 markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 200 | `20` | EMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2564,20 +2566,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### psar_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="psar_bearish" description="FILTER - requires High, Low, Close">
 
 Check if PSAR indicates bearish trend (PSAR above price).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `step` | `float` | 0.01 -- 0.1 | `0.02` | PSAR acceleration factor step |
 | `max_step` | `float` | 0.1 -- 0.5 | `0.2` | PSAR max acceleration factor |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2610,20 +2612,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### psar_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="psar_bullish" description="FILTER - requires High, Low, Close">
 
 Check if PSAR indicates bullish trend (PSAR below price).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `step` | `float` | 0.01 -- 0.1 | `0.02` | PSAR acceleration factor step |
 | `max_step` | `float` | 0.1 -- 0.5 | `0.2` | PSAR max acceleration factor |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2656,13 +2658,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### psar_reversal
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="psar_reversal" description="TRIGGER - requires High, Low, Close">
 
 Check if PSAR flips sides (potential reversal).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2670,7 +2672,7 @@ Check if PSAR flips sides (potential reversal).
 | `max_step` | `float` | 0.1 -- 0.5 | `0.2` | PSAR max acceleration factor |
 | `direction` | `str` | - | `bullish` | Reversal direction, 'bullish' (flip to below price) or 'bearish' |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2705,13 +2707,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### rsi_bearish_divergence
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="rsi_bearish_divergence" description="TRIGGER - requires Close">
 
 Detect a regular bearish RSI divergence: price higher high, RSI lower high. Classic reversal signal indicating bullish momentum is weakening.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2719,7 +2721,7 @@ Detect a regular bearish RSI divergence: price higher high, RSI lower high. Clas
 | `swing_window` | `int` | 2 -- 20 | `5` | Bars on each side to confirm swing extremum |
 | `min_swing_distance` | `int` | 3 -- 50 | `10` | Min bars between the two swing points compared |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2754,13 +2756,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### rsi_bullish_divergence
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="rsi_bullish_divergence" description="TRIGGER - requires Close">
 
 Detect a regular bullish RSI divergence: price lower low, RSI higher low. Classic reversal signal indicating bearish momentum is weakening.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2768,7 +2770,7 @@ Detect a regular bullish RSI divergence: price lower low, RSI higher low. Classi
 | `swing_window` | `int` | 2 -- 20 | `5` | Bars on each side to confirm swing extremum |
 | `min_swing_distance` | `int` | 3 -- 50 | `10` | Min bars between the two swing points compared |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2803,13 +2805,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### rsi_hidden_bearish_divergence
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="rsi_hidden_bearish_divergence" description="TRIGGER - requires Close">
 
 Detect a hidden bearish RSI divergence: price lower high, RSI higher high. Continuation signal in a downtrend.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2817,7 +2819,7 @@ Detect a hidden bearish RSI divergence: price lower high, RSI higher high. Conti
 | `swing_window` | `int` | 2 -- 20 | `5` | Bars on each side to confirm swing extremum |
 | `min_swing_distance` | `int` | 3 -- 50 | `10` | Min bars between swings |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2852,13 +2854,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### rsi_hidden_bullish_divergence
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="rsi_hidden_bullish_divergence" description="TRIGGER - requires Close">
 
 Detect a hidden bullish RSI divergence: price higher low, RSI lower low. Continuation signal in an uptrend -- indicates the uptrend is still intact despite a pullback.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -2866,7 +2868,7 @@ Detect a hidden bullish RSI divergence: price higher low, RSI lower low. Continu
 | `swing_window` | `int` | 2 -- 20 | `5` | Bars on each side to confirm swing extremum |
 | `min_swing_distance` | `int` | 3 -- 50 | `10` | Min bars between swings |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2901,20 +2903,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### sma_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="sma_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish SMA crossover as an exit signal. Returns True when the window_fast SMA crosses below the window_slow SMA (death cross). This is a momentum-driven exit signal, indicating a transition from bullish to bearish momentum. Common periods: 9/21 (short-term), 50/200 (long-term). Adjust for crypto's 24/7 markets. Note: This is a backwards-compatible wrapper around sma_crossover.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 1 -- 200 | _required_ | Fast SMA window in bars |
 | `window_slow` | `int` | 1 -- 200 | _required_ | Slow SMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2947,20 +2949,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### sma_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="sma_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish SMA crossover as an entry signal. Returns True when the window_fast SMA crosses above the window_slow SMA (golden cross). This is a momentum-driven entry signal, indicating a transition from bearish to bullish momentum. Common periods: 9/21 (short-term), 50/200 (long-term). Adjust for crypto's 24/7 markets. Note: This is a backwards-compatible wrapper around sma_crossover.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 1 -- 200 | _required_ | Fast SMA window in bars |
 | `window_slow` | `int` | 1 -- 200 | _required_ | Slow SMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -2993,13 +2995,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### sma_crossover
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="sma_crossover" description="TRIGGER - requires Close">
 
 Detect an SMA crossover signal with configurable direction (bullish or bearish). Uses SMA indicator to calculate window_fast and window_slow SMAs. Returns True when a crossover is detected in the specified direction. Bullish crossover (golden cross): window_fast SMA crosses above window_slow SMA Bearish crossover (death cross): window_fast SMA crosses below window_slow SMA The crossover detection compares the previous and current bars: - Bullish: prev window_fast &lt;= prev window_slow AND current window_fast &gt; current window_slow - Bearish: prev window_fast &gt;= prev window_slow AND current window_fast &lt; current window_slow Common periods: 9/21 (short-term), 50/200 (long-term). Adjust for crypto's 24/7 markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -3007,7 +3009,7 @@ Detect an SMA crossover signal with configurable direction (bullish or bearish).
 | `window_slow` | `int` | 1 -- 200 | _required_ | Slow SMA window in bars |
 | `direction` | `str` | - | `bullish` | Crossover direction, 'bullish' or 'bearish' |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3042,20 +3044,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### smma_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="smma_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish SMMA crossover (fast SMMA crosses below slow SMMA). Slower, more stable crossover than EMA cross; fewer false triggers.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `14` | Fast SMMA window |
 | `window_slow` | `int` | 2 -- 200 | `50` | Slow SMMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3088,20 +3090,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### smma_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="smma_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish SMMA crossover (fast SMMA crosses above slow SMMA). Slower, more stable crossover than EMA cross; fewer false triggers.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `14` | Fast SMMA window |
 | `window_slow` | `int` | 2 -- 200 | `50` | Slow SMMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3134,13 +3136,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### stc_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="stc_overbought" description="FILTER - requires Close">
 
 Check if STC indicates overbought condition.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -3151,7 +3153,7 @@ Check if STC indicates overbought condition.
 | `smooth2` | `int` | 1 -- 200 | `3` | Second smoothing period |
 | `threshold` | `float` | 0.0 -- 100.0 | `75.0` | Overbought threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3192,13 +3194,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### stc_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="stc_oversold" description="FILTER - requires Close">
 
 Check if STC indicates oversold condition.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -3209,7 +3211,7 @@ Check if STC indicates oversold condition.
 | `smooth2` | `int` | 1 -- 200 | `3` | Second smoothing period |
 | `threshold` | `float` | 0.0 -- 100.0 | `25.0` | Oversold threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3250,20 +3252,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### supertrend_flip_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="supertrend_flip_down" description="TRIGGER - requires High, Low, Close">
 
 Detect SuperTrend flipping from long (+1) to short (-1). Classic SuperTrend bearish entry signal.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `10` | ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3296,20 +3298,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### supertrend_flip_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="supertrend_flip_up" description="TRIGGER - requires High, Low, Close">
 
 Detect SuperTrend flipping from short (-1) to long (+1). Classic SuperTrend bullish entry signal.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `10` | ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3342,20 +3344,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### supertrend_long
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="supertrend_long" description="FILTER - requires High, Low, Close">
 
 Check if SuperTrend is in the long regime (+1 direction).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `10` | ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3388,20 +3390,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### supertrend_short
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="supertrend_short" description="FILTER - requires High, Low, Close">
 
 Check if SuperTrend is in the short regime (-1 direction).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `10` | ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3434,13 +3436,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### t3_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="t3_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish T3 crossover (fast T3 crosses below slow T3).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -3448,7 +3450,7 @@ Detect a bearish T3 crossover (fast T3 crosses below slow T3).
 | `window_slow` | `int` | 2 -- 200 | `10` | Slow T3 window |
 | `volume_factor` | `float` | 0.0 -- 1.0 | `0.7` | Tillson volume factor |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3483,13 +3485,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### t3_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="t3_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish T3 crossover (fast T3 crosses above slow T3). Very smooth, low-lag crossover. Both T3s share the same volume_factor.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -3497,7 +3499,7 @@ Detect a bullish T3 crossover (fast T3 crosses above slow T3). Very smooth, low-
 | `window_slow` | `int` | 2 -- 200 | `10` | Slow T3 window |
 | `volume_factor` | `float` | 0.0 -- 1.0 | `0.7` | Tillson volume factor |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3532,20 +3534,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### tema_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="tema_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish TEMA crossover (fast TEMA crosses below slow TEMA). Very low-lag cross signal; expect more whipsaw in noisy markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `9` | Fast TEMA window |
 | `window_slow` | `int` | 2 -- 200 | `21` | Slow TEMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3578,20 +3580,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### tema_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="tema_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish TEMA crossover (fast TEMA crosses above slow TEMA). Very low-lag cross signal; expect more whipsaw in noisy markets.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `9` | Fast TEMA window |
 | `window_slow` | `int` | 2 -- 200 | `21` | Slow TEMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3624,20 +3626,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### trima_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="trima_cross_down" description="TRIGGER - requires Close">
 
 Detect a bearish TRIMA crossover (fast TRIMA crosses below slow TRIMA).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `10` | Fast TRIMA window |
 | `window_slow` | `int` | 2 -- 200 | `30` | Slow TRIMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3670,20 +3672,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### trima_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="trima_cross_up" description="TRIGGER - requires Close">
 
 Detect a bullish TRIMA crossover (fast TRIMA crosses above slow TRIMA).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `10` | Fast TRIMA window |
 | `window_slow` | `int` | 2 -- 200 | `30` | Slow TRIMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3716,20 +3718,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### trix_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="trix_bearish" description="FILTER - requires Close">
 
 Check if TRIX indicates bearish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `15` | TRIX period |
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Bearish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3762,20 +3764,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### trix_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="trix_bullish" description="FILTER - requires Close">
 
 Check if TRIX indicates bullish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `15` | TRIX period |
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Bullish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3808,13 +3810,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ttm_squeeze_active
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="ttm_squeeze_active" description="FILTER - requires High, Low, Close">
 
 Check if the TTM Squeeze is active (BB inside KC -- volatility contraction). Use as a no-breakout filter: when true, market is coiled and waiting for a directional move.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -3824,7 +3826,7 @@ Check if the TTM Squeeze is active (BB inside KC -- volatility contraction). Use
 | `kc_atr_mult` | `float` | 0.5 -- 3.0 | `1.5` | Keltner ATR multiplier |
 | `mom_window` | `int` | 5 -- 50 | `12` | Momentum regression window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3863,13 +3865,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ttm_squeeze_fired_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="ttm_squeeze_fired_bearish" description="TRIGGER - requires High, Low, Close">
 
 Detect TTM Squeeze release with bearish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -3879,7 +3881,7 @@ Detect TTM Squeeze release with bearish momentum.
 | `kc_atr_mult` | `float` | 0.5 -- 3.0 | `1.5` | Keltner ATR multiplier |
 | `mom_window` | `int` | 5 -- 50 | `12` | Momentum regression window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3918,13 +3920,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ttm_squeeze_fired_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="ttm_squeeze_fired_bullish" description="TRIGGER - requires High, Low, Close">
 
 Detect TTM Squeeze release with bullish momentum. Fires when the squeeze just ended (was on previous bar, off now) AND momentum is positive. Classic Carter entry signal.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -3934,7 +3936,7 @@ Detect TTM Squeeze release with bullish momentum. Fires when the squeeze just en
 | `kc_atr_mult` | `float` | 0.5 -- 3.0 | `1.5` | Keltner ATR multiplier |
 | `mom_window` | `int` | 5 -- 50 | `12` | Momentum regression window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -3973,19 +3975,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vortex_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="vortex_bearish" description="FILTER - requires High, Low, Close">
 
 Check if Vortex Indicator shows bearish trend (-VI &gt; +VI).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `14` | Vortex period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -4016,19 +4018,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vortex_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="vortex_bullish" description="FILTER - requires High, Low, Close">
 
 Check if Vortex Indicator shows bullish trend (+VI &gt; -VI).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `14` | Vortex period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -4059,20 +4061,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vortex_crossover
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="vortex_crossover" description="TRIGGER - requires High, Low, Close">
 
 Check if Vortex lines cross (trend change).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `14` | Vortex period |
 | `direction` | `str` | - | `bullish` | Crossover direction, 'bullish' (+VI crosses above -VI) or 'bearish' |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -4105,20 +4107,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### wma_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="wma_cross_down" description="TRIGGER - requires Close">
 
 Check if fast WMA crosses below slow WMA (bearish).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 50 | `9` | Fast WMA window |
 | `window_slow` | `int` | 10 -- 100 | `21` | Slow WMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -4151,20 +4153,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### wma_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="wma_cross_up" description="TRIGGER - requires Close">
 
 Check if fast WMA crosses above slow WMA (bullish).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 50 | `9` | Fast WMA window |
 | `window_slow` | `int` | 10 -- 100 | `21` | Slow WMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -4196,3 +4198,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 ```
 
 </CodeGroup>
+
+</Accordion>
+
+</AccordionGroup>

--- a/docs/signals/catalog/volatility.mdx
+++ b/docs/signals/catalog/volatility.mdx
@@ -9,20 +9,22 @@ _20 signals in this category._
 
 See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.
 
-### atr_high_volatility
+Click a signal to expand parameters and examples.
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<AccordionGroup>
+
+<Accordion title="atr_high_volatility" description="FILTER - requires High, Low, Close">
 
 Check if ATR indicates high volatility relative to price. High volatility (ATR as % of close &gt; threshold) can indicate potential trading opportunities or increased risk.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | ATR period |
 | `threshold_pct` | `float` | 0.5 -- 10.0 | `3.0` | ATR as percentage of close threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -55,20 +57,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### atr_trailing_stop_flip_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="atr_trailing_stop_flip_down" description="TRIGGER - requires High, Low, Close">
 
 Detect ATR Trailing Stop flipping from long (+1) to short (-1). Bearish trend-following entry signal.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `14` | ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -101,20 +103,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### atr_trailing_stop_flip_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="atr_trailing_stop_flip_up" description="TRIGGER - requires High, Low, Close">
 
 Detect ATR Trailing Stop flipping from short (-1) to long (+1). Bullish trend-following entry signal.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `14` | ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -147,20 +149,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### atr_trailing_stop_long
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="atr_trailing_stop_long" description="FILTER - requires High, Low, Close">
 
 Check if ATR Trailing Stop is in the long regime (+1 direction).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `14` | ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier for stop distance |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -193,20 +195,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### atr_trailing_stop_short
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="atr_trailing_stop_short" description="FILTER - requires High, Low, Close">
 
 Check if ATR Trailing Stop is in the short regime (-1 direction).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `14` | ATR window |
 | `multiplier` | `float` | 0.5 -- 10.0 | `3.0` | ATR multiplier for stop distance |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -239,20 +241,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bb_lower_breakout
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="bb_lower_breakout" description="TRIGGER - requires Close">
 
 Detect price breaking below the lower Bollinger Band. Fires on the bar where price crosses below the lower band, not while price remains below it. Crypto assets frequently test bands during high volatility; use with volume confirmation.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `20` | MA period for center band |
 | `window_dev` | `int` | 1 -- 5 | `2` | Standard deviation multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -285,13 +287,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bb_squeeze
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="bb_squeeze" description="TRIGGER - requires Close">
 
 Detect Bollinger Band squeeze onset (low volatility, potential breakout). Fires on the bar where band width drops below the threshold, not while it remains below.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -299,7 +301,7 @@ Detect Bollinger Band squeeze onset (low volatility, potential breakout). Fires 
 | `window_dev` | `int` | 1 -- 5 | `2` | Standard deviation multiplier |
 | `threshold` | `float` | 1.0 -- 20.0 | `5.0` | Band width percentage threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -334,20 +336,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### bb_upper_breakout
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="bb_upper_breakout" description="TRIGGER - requires Close">
 
 Detect price breaking above the upper Bollinger Band. Fires on the bar where price crosses above the upper band, not while price remains above it. Crypto assets frequently test bands during high volatility; use with volume confirmation.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `20` | MA period for center band |
 | `window_dev` | `int` | 1 -- 5 | `2` | Standard deviation multiplier |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -380,19 +382,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### dc_lower_breakout
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="dc_lower_breakout" description="TRIGGER - requires High, Low, Close">
 
 Detect price breaking below lower Donchian Channel (new low). Fires on the bar where close drops below the prior period's lower band. The channel is computed from the N bars BEFORE the current bar (offset=1) so the current bar's low doesn't deflate the band it's compared against.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `20` | Lookback period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -423,19 +425,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### dc_upper_breakout
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="dc_upper_breakout" description="TRIGGER - requires High, Low, Close">
 
 Detect price breaking above upper Donchian Channel (new high). Fires on the bar where close exceeds the prior period's upper band. The channel is computed from the N bars BEFORE the current bar (offset=1) so the current bar's high doesn't inflate the band it's compared against.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `20` | Lookback period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -466,13 +468,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kc_lower_breakout
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="kc_lower_breakout" description="TRIGGER - requires High, Low, Close">
 
 Detect price breaking below lower Keltner Channel band. Fires on the bar where price crosses below the lower band.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -481,7 +483,7 @@ Detect price breaking below lower Keltner Channel band. Fires on the bar where p
 | `multiplier` | `float` | 0.5 -- 5.0 | `2.0` | ATR multiplier for band width |
 | `original_version` | `bool` | - | `False` | Use original Keltner Channel formula instead of EMA+ATR |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -518,13 +520,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kc_upper_breakout
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="kc_upper_breakout" description="TRIGGER - requires High, Low, Close">
 
 Detect price breaking above upper Keltner Channel band. Fires on the bar where price crosses above the upper band.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -533,7 +535,7 @@ Detect price breaking above upper Keltner Channel band. Fires on the bar where p
 | `multiplier` | `float` | 0.5 -- 5.0 | `2.0` | ATR multiplier for band width |
 | `original_version` | `bool` | - | `False` | Use original Keltner Channel formula instead of EMA+ATR |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -570,20 +572,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### natr_high_volatility
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="natr_high_volatility" description="FILTER - requires High, Low, Close">
 
 Check if normalized ATR is above a high-volatility threshold. NATR = 100 * ATR / close, so the threshold is a percentage. Values above ~2-3% typically indicate elevated volatility in equities; crypto markets can run 4-6%+ routinely.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `14` | NATR window |
 | `threshold` | `float` | 0.5 -- 20.0 | `2.0` | High volatility threshold as percentage |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -616,20 +618,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### natr_low_volatility
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="natr_low_volatility" description="FILTER - requires High, Low, Close">
 
 Check if normalized ATR is below a low-volatility threshold. Useful as a squeeze / consolidation filter.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `14` | NATR window |
 | `threshold` | `float` | 0.1 -- 5.0 | `1.0` | Low volatility threshold as percentage |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -662,13 +664,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### starc_lower_breakout
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="starc_lower_breakout" description="FILTER - requires High, Low, Close">
 
 Check if close is below the STARC lower band (breakdown).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -676,7 +678,7 @@ Check if close is below the STARC lower band (breakdown).
 | `window_atr` | `int` | 5 -- 100 | `15` | ATR window |
 | `multiplier` | `float` | 0.5 -- 5.0 | `2.0` | ATR multiplier for band width |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -711,13 +713,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### starc_upper_breakout
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close
+<Accordion title="starc_upper_breakout" description="FILTER - requires High, Low, Close">
 
 Check if close is above the STARC upper band (breakout).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -725,7 +727,7 @@ Check if close is above the STARC upper band (breakout).
 | `window_atr` | `int` | 5 -- 100 | `15` | ATR window |
 | `multiplier` | `float` | 0.5 -- 5.0 | `2.0` | ATR multiplier for band width |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -760,20 +762,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ulcer_high_risk
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ulcer_high_risk" description="FILTER - requires Close">
 
 Check if Ulcer Index indicates high downside risk. Higher Ulcer Index values indicate greater downside volatility.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | Lookback period |
 | `threshold` | `float` | 5.0 -- 30.0 | `10.0` | High risk threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -806,20 +808,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### ulcer_low_risk
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="ulcer_low_risk" description="FILTER - requires Close">
 
 Check if Ulcer Index indicates low downside risk. Lower Ulcer Index values indicate lower downside volatility.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | Lookback period |
 | `threshold` | `float` | 1.0 -- 15.0 | `5.0` | Low risk threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -852,20 +854,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### volatility_stop_lower
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="volatility_stop_lower" description="FILTER - requires Close">
 
 Check if close has reached or fallen below the stdev-based volatility lower stop.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `20` | Rolling stdev window |
 | `multiplier` | `float` | 0.5 -- 5.0 | `2.0` | Stdev multiplier for stop distance |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -898,20 +900,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### volatility_stop_upper
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="volatility_stop_upper" description="FILTER - requires Close">
 
 Check if close has reached or exceeded the stdev-based volatility upper stop. Indicates the price has moved multiplier standard deviations above the current bar -- a potential exhaustion / mean-reversion signal.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 100 | `20` | Rolling stdev window |
 | `multiplier` | `float` | 0.5 -- 5.0 | `2.0` | Stdev multiplier for stop distance |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -943,3 +945,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 ```
 
 </CodeGroup>
+
+</Accordion>
+
+</AccordionGroup>

--- a/docs/signals/catalog/volume.mdx
+++ b/docs/signals/catalog/volume.mdx
@@ -9,19 +9,21 @@ _33 signals in this category._
 
 See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.
 
-### adi_bearish
+Click a signal to expand parameters and examples.
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<AccordionGroup>
+
+<Accordion title="adi_bearish" description="FILTER - requires High, Low, Close, Volume">
 
 Check if ADI (Accumulation/Distribution) is falling (bearish volume).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `20` | Lookback for trend |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -52,19 +54,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### adi_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="adi_bullish" description="FILTER - requires High, Low, Close, Volume">
 
 Check if ADI (Accumulation/Distribution) is rising (bullish volume).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `20` | Lookback for trend |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -95,20 +97,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### adosc_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="adosc_bearish" description="FILTER - requires High, Low, Close, Volume">
 
 Check if Chaikin A/D Oscillator is negative (distribution regime).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `fast` | `int` | 2 -- 20 | `3` | Fast EMA period for AD |
 | `slow` | `int` | 5 -- 50 | `10` | Slow EMA period for AD |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -141,20 +143,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### adosc_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="adosc_bullish" description="FILTER - requires High, Low, Close, Volume">
 
 Check if Chaikin A/D Oscillator is positive (accumulation regime). Positive ADOSC = AD line's fast EMA above its slow EMA, indicating short-term buying pressure relative to longer-term trend.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `fast` | `int` | 2 -- 20 | `3` | Fast EMA period for AD |
 | `slow` | `int` | 5 -- 50 | `10` | Slow EMA period for AD |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -187,20 +189,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### adosc_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="adosc_cross_down" description="TRIGGER - requires High, Low, Close, Volume">
 
 Detect ADOSC crossing below zero (distribution onset).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `fast` | `int` | 2 -- 20 | `3` | Fast EMA period for AD |
 | `slow` | `int` | 5 -- 50 | `10` | Slow EMA period for AD |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -233,20 +235,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### adosc_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="adosc_cross_up" description="TRIGGER - requires High, Low, Close, Volume">
 
 Detect ADOSC crossing above zero (accumulation onset).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `fast` | `int` | 2 -- 20 | `3` | Fast EMA period for AD |
 | `slow` | `int` | 5 -- 50 | `10` | Slow EMA period for AD |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -279,20 +281,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cmf_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="cmf_bearish" description="FILTER - requires High, Low, Close, Volume">
 
 Check if CMF (Chaikin Money Flow) indicates selling pressure.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 10 -- 50 | `20` | CMF period |
 | `threshold` | `float` | -1.0 -- 1.0 | `0.0` | Bearish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -325,20 +327,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cmf_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="cmf_bullish" description="FILTER - requires High, Low, Close, Volume">
 
 Check if CMF (Chaikin Money Flow) indicates buying pressure.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 10 -- 50 | `20` | CMF period |
 | `threshold` | `float` | -1.0 -- 1.0 | `0.0` | Bullish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -371,19 +373,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cumulative_return_positive
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="cumulative_return_positive" description="FILTER - requires Close">
 
 Check if cumulative return from start is positive.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Minimum cumulative return in percent |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -414,19 +416,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### cumulative_return_target
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="cumulative_return_target" description="FILTER - requires Close">
 
 Check if cumulative return has reached target.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `target` | `float` | 1.0 -- 100.0 | `10.0` | Target cumulative return in percent |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -457,19 +459,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### daily_return_negative
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="daily_return_negative" description="FILTER - requires Close">
 
 Check if daily return is negative.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Maximum return threshold in percent |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -500,19 +502,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### daily_return_positive
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close
+<Accordion title="daily_return_positive" description="FILTER - requires Close">
 
 Check if daily return is positive.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Minimum return threshold in percent |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -543,20 +545,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### eom_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Volume
+<Accordion title="eom_bearish" description="FILTER - requires High, Low, Volume">
 
 Check if Ease of Movement indicates bearish (easy downward movement).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `14` | EOM period |
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Bearish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -589,20 +591,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### eom_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Volume
+<Accordion title="eom_bullish" description="FILTER - requires High, Low, Volume">
 
 Check if Ease of Movement indicates bullish (easy upward movement).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `14` | EOM period |
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Bullish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -635,20 +637,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### force_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="force_bearish" description="FILTER - requires Close, Volume">
 
 Check if Force Index indicates bearish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `13` | EMA period for smoothing |
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Bearish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -681,20 +683,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### force_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="force_bullish" description="FILTER - requires Close, Volume">
 
 Check if Force Index indicates bullish momentum.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `13` | EMA period for smoothing |
 | `threshold` | `float` | 0.0 -- 100.0 | `0.0` | Bullish threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -727,19 +729,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### is_above_vwma
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="is_above_vwma" description="FILTER - requires Close, Volume">
 
 Check if the current price is above the Volume-Weighted Moving Average (VWMA). VWMA weights each bar's close by its volume, emphasizing high-participation bars. Useful as a filter that incorporates conviction from volume.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 2 -- 200 | `20` | VWMA window in bars |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -770,13 +772,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kvo_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="kvo_bearish" description="FILTER - requires High, Low, Close, Volume">
 
 Check if KVO is below its signal line (bearish volume regime).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -784,7 +786,7 @@ Check if KVO is below its signal line (bearish volume regime).
 | `slow` | `int` | 10 -- 200 | `55` | Slow EMA period |
 | `signal_window` | `int` | 2 -- 50 | `13` | Signal-line EMA period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -819,13 +821,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kvo_bearish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="kvo_bearish_cross" description="TRIGGER - requires High, Low, Close, Volume">
 
 Detect KVO crossing below its signal line (bearish volume onset).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -833,7 +835,7 @@ Detect KVO crossing below its signal line (bearish volume onset).
 | `slow` | `int` | 10 -- 200 | `55` | Slow EMA period |
 | `signal_window` | `int` | 2 -- 50 | `13` | Signal-line EMA period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -868,13 +870,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kvo_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="kvo_bullish" description="FILTER - requires High, Low, Close, Volume">
 
 Check if KVO is above its signal line (bullish volume regime).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -882,7 +884,7 @@ Check if KVO is above its signal line (bullish volume regime).
 | `slow` | `int` | 10 -- 200 | `55` | Slow EMA period |
 | `signal_window` | `int` | 2 -- 50 | `13` | Signal-line EMA period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -917,13 +919,13 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### kvo_bullish_cross
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="kvo_bullish_cross" description="TRIGGER - requires High, Low, Close, Volume">
 
 Detect KVO crossing above its signal line (bullish volume onset). Classic Klinger entry trigger; often confirms a price divergence.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
@@ -931,7 +933,7 @@ Detect KVO crossing above its signal line (bullish volume onset). Classic Klinge
 | `slow` | `int` | 10 -- 200 | `55` | Slow EMA period for signed volume |
 | `signal_window` | `int` | 2 -- 50 | `13` | Signal-line EMA period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -966,20 +968,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mfi_overbought
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="mfi_overbought" description="FILTER - requires High, Low, Close, Volume">
 
 Check if MFI (Money Flow Index) indicates overbought condition.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `14` | MFI period |
 | `threshold` | `float` | 70.0 -- 95.0 | `80.0` | Overbought threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1012,20 +1014,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### mfi_oversold
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="mfi_oversold" description="FILTER - requires High, Low, Close, Volume">
 
 Check if MFI (Money Flow Index) indicates oversold condition.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 30 | `14` | MFI period |
 | `threshold` | `float` | 5.0 -- 30.0 | `20.0` | Oversold threshold |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1058,19 +1060,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### nvi_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="nvi_bearish" description="FILTER - requires Close, Volume">
 
 Check if NVI (Negative Volume Index) indicates smart money selling. NVI below its moving average suggests smart money distribution.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 100 -- 200 | `255` | EMA period for signal |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1101,19 +1103,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### nvi_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="nvi_bullish" description="FILTER - requires Close, Volume">
 
 Check if NVI (Negative Volume Index) indicates smart money buying. NVI above its moving average suggests smart money accumulation.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 100 -- 200 | `255` | EMA period for signal |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1144,19 +1146,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### obv_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="obv_bearish" description="FILTER - requires Close, Volume">
 
 Check if OBV is falling (bearish volume confirmation).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `20` | Lookback for trend |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1187,19 +1189,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### obv_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="obv_bullish" description="FILTER - requires Close, Volume">
 
 Check if OBV is rising (bullish volume confirmation).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `20` | Lookback for trend |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1230,19 +1232,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vpt_bearish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="vpt_bearish" description="FILTER - requires Close, Volume">
 
 Check if VPT (Volume Price Trend) is falling.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `20` | Window for trend comparison |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1273,19 +1275,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vpt_bullish
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="vpt_bullish" description="FILTER - requires Close, Volume">
 
 Check if VPT (Volume Price Trend) is rising.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `20` | Window for trend comparison |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1316,19 +1318,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vwap_above
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="vwap_above" description="FILTER - requires High, Low, Close, Volume">
 
 Check if price is above VWAP (bullish bias).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | VWAP period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1359,19 +1361,19 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vwap_below
+</Accordion>
 
-**Type:** <span style={{color: "#3498db", fontWeight: "bold"}}>FILTER</span> &nbsp;&nbsp; **Requires:** High, Low, Close, Volume
+<Accordion title="vwap_below" description="FILTER - requires High, Low, Close, Volume">
 
 Check if price is below VWAP (bearish bias).
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window` | `int` | 5 -- 50 | `14` | VWAP period |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1402,20 +1404,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vwma_cross_down
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="vwma_cross_down" description="TRIGGER - requires Close, Volume">
 
 Detect a bearish VWMA crossover (fast VWMA crosses below slow VWMA). Volume-weighted version of the classic SMA death cross.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `9` | Fast VWMA window |
 | `window_slow` | `int` | 2 -- 200 | `21` | Slow VWMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1448,20 +1450,20 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 
 </CodeGroup>
 
-### vwma_cross_up
+</Accordion>
 
-**Type:** <span style={{color: "#e67e22", fontWeight: "bold"}}>TRIGGER</span> &nbsp;&nbsp; **Requires:** Close, Volume
+<Accordion title="vwma_cross_up" description="TRIGGER - requires Close, Volume">
 
 Detect a bullish VWMA crossover (fast VWMA crosses above slow VWMA). Volume-weighted version of the classic SMA golden cross. High-volume bars carry more weight, so the signal is less susceptible to low-volume noise.
 
-#### Parameters
+**Parameters**
 
 | Name | Type | Range | Default | Description |
 |------|------|-------|---------|-------------|
 | `window_fast` | `int` | 2 -- 100 | `9` | Fast VWMA window |
 | `window_slow` | `int` | 2 -- 200 | `21` | Slow VWMA window |
 
-#### Example
+**Example**
 
 <CodeGroup>
 
@@ -1493,3 +1495,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
 ```
 
 </CodeGroup>
+
+</Accordion>
+
+</AccordionGroup>

--- a/scripts/generate-api-reference.py
+++ b/scripts/generate-api-reference.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Generate Mintlify API reference mdx files for one or more domains in
+docs/openapi3.json.
+
+Each domain becomes a single mdx page under docs/api-reference/<domain>.mdx
+listing every operation in that path-prefix, with a curl example built from
+the spec parameters / requestBody schema.
+
+Intended for the 5 domains that exist in the live MangroveAI API but had no
+hand-written mdx page when this was added: config, defi, on-chain,
+promo-codes, social.
+
+Usage:
+    python scripts/generate-api-reference.py [domain ...]
+
+If no domains are given, generates the default set above. Run from the repo
+root.
+"""
+
+import json
+import os
+import sys
+from collections import OrderedDict
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.dirname(SCRIPT_DIR)
+SPEC_PATH = os.path.join(PROJECT_ROOT, "docs", "openapi3.json")
+OUTPUT_DIR = os.path.join(PROJECT_ROOT, "docs", "api-reference")
+
+DEFAULT_DOMAINS = ["config", "defi", "on-chain", "promo-codes", "social"]
+BASE_URL = "https://api.mangrovedeveloper.ai/api/v1"
+HTTP_METHODS = {"get", "post", "put", "patch", "delete"}
+
+
+def _resolve_ref(spec, ref):
+    """Resolve a $ref string against the spec dict. Returns the dereferenced
+    object or None if not resolvable."""
+    if not ref or not ref.startswith("#/"):
+        return None
+    parts = ref[2:].split("/")
+    cur = spec
+    for p in parts:
+        if not isinstance(cur, dict) or p not in cur:
+            return None
+        cur = cur[p]
+    return cur
+
+
+def _example_for_schema(schema, spec, depth=0):
+    """Return a Python value that's a reasonable example for the given JSON
+    schema. Handles $ref, type-based defaults, and nested objects/arrays."""
+    if depth > 5 or not schema:
+        return None
+    if isinstance(schema, dict) and "$ref" in schema:
+        return _example_for_schema(_resolve_ref(spec, schema["$ref"]), spec, depth + 1)
+    if "example" in schema:
+        return schema["example"]
+    if "default" in schema:
+        return schema["default"]
+    if "enum" in schema and schema["enum"]:
+        return schema["enum"][0]
+    t = schema.get("type")
+    if t == "object" or "properties" in schema:
+        out = {}
+        for pname, pschema in (schema.get("properties") or {}).items():
+            out[pname] = _example_for_schema(pschema, spec, depth + 1)
+        return out
+    if t == "array":
+        item = _example_for_schema(schema.get("items") or {}, spec, depth + 1)
+        return [item] if item is not None else []
+    if t == "integer":
+        return 0
+    if t == "number":
+        return 0
+    if t == "boolean":
+        return False
+    if t == "string":
+        fmt = schema.get("format")
+        if fmt == "date-time":
+            return "2026-01-01T00:00:00Z"
+        if fmt == "date":
+            return "2026-01-01"
+        if fmt == "uuid":
+            return "00000000-0000-0000-0000-000000000000"
+        return "string"
+    return None
+
+
+def _example_for_param(param, spec):
+    """Pick a sample value for a parameter to embed in a curl URL. Falls back
+    to the parameter name as a placeholder so the URL stays readable when
+    the spec has no defaults / examples."""
+    schema = param.get("schema") or {}
+    if "example" in param:
+        return param["example"]
+    ex = _example_for_schema(schema, spec)
+    if ex is None or ex == "" or ex == "string":
+        return "<" + param.get("name", "value") + ">"
+    return ex
+
+
+def _substitute_path_params(path, params, spec):
+    """Replace {name} placeholders in a path with example values from the
+    parameter list."""
+    out = path
+    for p in params:
+        if p.get("in") != "path":
+            continue
+        name = p.get("name", "")
+        if not name:
+            continue
+        ex = _example_for_param(p, spec)
+        out = out.replace("{" + name + "}", str(ex))
+    return out
+
+
+def _path_with_query(path, params, spec):
+    """Append example query params to a path for curl examples."""
+    qs = []
+    for p in params:
+        if p.get("in") != "query":
+            continue
+        name = p.get("name")
+        if not name:
+            continue
+        ex = _example_for_param(p, spec)
+        qs.append(f"{name}={ex}")
+    return path + ("?" + "&".join(qs) if qs else "")
+
+
+def _build_curl(method, path, params, request_body, spec):
+    """Construct a curl command string for an operation."""
+    lines = []
+    sub_path = _substitute_path_params(path, params or [], spec)
+    full_path = _path_with_query(sub_path, params or [], spec)
+    method_u = method.upper()
+    url = f"{BASE_URL}{full_path}"
+    if method_u == "GET":
+        lines.append(f'curl -H "Authorization: Bearer $TOKEN" \\')
+        lines.append(f'  "{url}"')
+    else:
+        lines.append(f'curl -X {method_u} "{url}" \\')
+        lines.append('  -H "Authorization: Bearer $TOKEN" \\')
+        if request_body:
+            content = request_body.get("content") or {}
+            json_schema = (content.get("application/json") or {}).get("schema")
+            if json_schema:
+                example = _example_for_schema(json_schema, spec)
+                if example is not None:
+                    body_str = json.dumps(example, indent=2)
+                    lines.append('  -H "Content-Type: application/json" \\')
+                    lines.append(f"  -d '{body_str}'")
+                    return "\n".join(lines)
+        # No JSON body — drop trailing backslash
+        lines[-1] = lines[-1].rstrip(" \\")
+    return "\n".join(lines)
+
+
+def _operation_section(method, path, op, path_item, spec):
+    """Build mdx lines for a single operation. `path_item` is the parent
+    object in spec.paths so we can pick up shared path-level parameters."""
+    out = []
+    summary = op.get("summary") or f"{method.upper()} {path}"
+    description = op.get("description") or ""
+
+    out.append(f"### {summary}")
+    out.append("")
+    out.append(f"`{method.upper()} /api/v1{path}`")
+    out.append("")
+    if description and description != summary:
+        out.append(description.strip())
+        out.append("")
+
+    # Merge path-level + operation-level parameters; op-level wins on name.
+    raw_params = (path_item.get("parameters") or []) + (op.get("parameters") or [])
+    seen = set()
+    params = []
+    for p in reversed(raw_params):
+        key = (p.get("name"), p.get("in"))
+        if key in seen:
+            continue
+        seen.add(key)
+        params.insert(0, p)
+
+    path_params = [p for p in params if p.get("in") == "path"]
+    query_params = [p for p in params if p.get("in") == "query"]
+    if path_params or query_params:
+        out.append("**Parameters**")
+        out.append("")
+        out.append("| Name | In | Type | Required | Description |")
+        out.append("|------|----|------|----------|-------------|")
+        for p in path_params + query_params:
+            schema = p.get("schema") or {}
+            ptype = schema.get("type", "string")
+            required = "yes" if p.get("required") else "no"
+            desc = (p.get("description") or "").replace("|", "\\|").replace("\n", " ")
+            out.append(f"| `{p.get('name', '')}` | {p.get('in')} | `{ptype}` | {required} | {desc} |")
+        out.append("")
+
+    # Request body schema (just note; the curl shows the example)
+    if op.get("requestBody"):
+        rb = op["requestBody"]
+        content = rb.get("content") or {}
+        json_schema = (content.get("application/json") or {}).get("schema")
+        if json_schema:
+            out.append("**Request body** (JSON)")
+            out.append("")
+
+    out.append("**Example**")
+    out.append("")
+    out.append("```bash cURL")
+    out.append(_build_curl(method, path, params, op.get("requestBody"), spec))
+    out.append("```")
+    out.append("")
+    return out
+
+
+def _domain_to_title(domain):
+    return domain.replace("-", " ").title() + " API"
+
+
+def _domain_description(domain):
+    blurbs = {
+        "config": "Trading defaults and execution-config endpoints used by the strategy engine.",
+        "defi": "DeFi metrics — protocol TVL, chain TVL, stablecoin supply.",
+        "on-chain": "On-chain analytics — wallet activity, transaction flows, holders, network metrics.",
+        "promo-codes": "Admin-managed promotional codes for subscription discounts.",
+        "social": "Social-data endpoints — sentiment, mention volume, influence scoring.",
+    }
+    return blurbs.get(domain, f"{_domain_to_title(domain)} endpoints.")
+
+
+def generate_for_domain(spec, domain):
+    """Emit docs/api-reference/<domain>.mdx for the given path-prefix."""
+    paths = spec.get("paths", {})
+
+    # All paths whose first segment matches the domain
+    matching = OrderedDict()
+    prefix = "/" + domain
+    for p in sorted(paths.keys()):
+        first = p.split("/")[1] if p.startswith("/") and len(p) > 1 else ""
+        if first == domain:
+            matching[p] = paths[p]
+    if not matching:
+        print(f"  WARN: no paths matched /{domain}/* — skipping")
+        return None
+
+    title = _domain_to_title(domain)
+    description = _domain_description(domain)
+
+    out = []
+    out.append("---")
+    out.append(f'title: "{title}"')
+    out.append(f'description: "{description}"')
+    out.append("---")
+    out.append("")
+    out.append(f"# {title}")
+    out.append("")
+    out.append(description)
+    out.append("")
+    out.append("## Base URL")
+    out.append("")
+    out.append("```")
+    out.append(f"{BASE_URL}/{domain}")
+    out.append("```")
+    out.append("")
+    out.append("## Authentication")
+    out.append("")
+    out.append("All endpoints require a JWT bearer token.")
+    out.append("")
+    out.append("```")
+    out.append("Authorization: Bearer YOUR_JWT_TOKEN")
+    out.append("```")
+    out.append("")
+    out.append("## Endpoints")
+    out.append("")
+    for path, path_item in matching.items():
+        for method, op in path_item.items():
+            if method.lower() not in HTTP_METHODS:
+                continue
+            out.extend(_operation_section(method.lower(), path, op, path_item, spec))
+
+    out_path = os.path.join(OUTPUT_DIR, f"{domain}.mdx")
+    with open(out_path, "w") as f:
+        f.write("\n".join(out))
+    op_count = sum(1 for _, methods in matching.items()
+                   for m in methods if m.lower() in HTTP_METHODS)
+    print(f"  Generated {out_path} ({op_count} operations across {len(matching)} paths)")
+    return out_path
+
+
+def main():
+    domains = sys.argv[1:] or DEFAULT_DOMAINS
+
+    if not os.path.exists(SPEC_PATH):
+        print(f"ERROR: spec not found at {SPEC_PATH}")
+        sys.exit(1)
+    with open(SPEC_PATH) as f:
+        spec = json.load(f)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    print(f"Generating from {SPEC_PATH}")
+    for d in domains:
+        generate_for_domain(spec, d)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-signal-catalog.py
+++ b/scripts/generate-signal-catalog.py
@@ -188,6 +188,11 @@ def generate_catalog():
 
     # ---------------------------------------------------------------------------
     # Helpers to build per-signal MDX
+    #
+    # Each signal is wrapped in a Mintlify <Accordion> so the catalog page
+    # renders fast (~tens of KB instead of MBs) and users expand only the
+    # signals they care about. Mintlify wraps these inside an <AccordionGroup>
+    # at the per-category level.
     # ---------------------------------------------------------------------------
     def _signal_mdx(sig):
         out = []
@@ -197,16 +202,19 @@ def generate_catalog():
         description = sig.get("description", "")
         params = sig.get("params", {})
 
-        out.append(f"### {signal_name}")
-        out.append("")
-        out.append(f"**Type:** {_badge(signal_type)} &nbsp;&nbsp; **Requires:** {', '.join(requires) if requires else 'None'}")
+        requires_str = ", ".join(requires) if requires else "None"
+        # Build a short description label for the accordion header
+        # (visible while collapsed). Keep it terse.
+        header_desc = f"{signal_type} - requires {requires_str}"
+
+        out.append(f'<Accordion title="{signal_name}" description="{header_desc}">')
         out.append("")
         if description:
             safe_desc = description.replace("<", "&lt;").replace(">", "&gt;")
             out.append(safe_desc)
             out.append("")
         if params:
-            out.append("#### Parameters")
+            out.append("**Parameters**")
             out.append("")
             out.append("| Name | Type | Range | Default | Description |")
             out.append("|------|------|-------|---------|-------------|")
@@ -220,7 +228,7 @@ def generate_catalog():
         else:
             out.append("_No configurable parameters._")
             out.append("")
-        out.append("#### Example")
+        out.append("**Example**")
         out.append("")
         out.append("<CodeGroup>")
         out.append("")
@@ -233,6 +241,8 @@ def generate_catalog():
         out.append("```")
         out.append("")
         out.append("</CodeGroup>")
+        out.append("")
+        out.append("</Accordion>")
         out.append("")
         return out
 
@@ -269,7 +279,7 @@ def generate_catalog():
         sig_type = sig.get("type", "")
         slug = sig["category"].lower()
         index_lines.append(
-            f"| [`{sig['name']}`](/signals/catalog/{slug}#{_anchor_id(sig['name'])}) "
+            f"| [`{sig['name']}`](/signals/catalog/{slug}) "
             f"| {sig_type} | {sig['category']} | {requires_str} |"
         )
     index_lines.append("")
@@ -304,8 +314,14 @@ def generate_catalog():
         cat_lines.append("")
         cat_lines.append(f"See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.")
         cat_lines.append("")
+        cat_lines.append("Click a signal to expand parameters and examples.")
+        cat_lines.append("")
+        cat_lines.append("<AccordionGroup>")
+        cat_lines.append("")
         for sig in sigs:
             cat_lines.extend(_signal_mdx(sig))
+        cat_lines.append("</AccordionGroup>")
+        cat_lines.append("")
 
         cat_path = os.path.join(category_dir, f"{slug}.mdx")
         with open(cat_path, "w") as f:


### PR DESCRIPTION
Fixes the docs.mangrovedeveloper.ai usability complaints in one branch. 4 commits, can be reviewed individually or as a block.

## Commits

### 1. `bee9662` — Make API Reference the landing page
Reorders `mint.json` so API Reference is the first nav group. After deploy, `docs.mangrovedeveloper.ai/` redirects to `/api-reference/overview` instead of the ecosystem cards on `/introduction`. Single-file change, no content edits.

### 2. `268f74b` — Refresh `openapi3.json` from the live API
Pulls the current Swagger 2.0 from `https://api.mangrovedeveloper.ai/api/v1/swagger.json` and converts to OpenAPI 3.0 via `swagger2openapi`. Static spec was committed once on Mar 7 (commit `bdba1ab`) and never refreshed. 112 → 131 paths.

### 3. `973eb74` — Wrap signal catalog entries in accordions
Each signal in `/signals/catalog/<category>` is now in a Mintlify `<Accordion>` inside an `<AccordionGroup>`, closed by default. Targets the 12s+ TTFB on `/signals/catalog/trend` (88 signals, 2.2 MB rendered HTML). Source line counts are similar but rendered HTML drops by an order of magnitude since closed accordions are header-only at first paint.

### 4. `9a77878` — Add stub pages for 5 missing API domains
Generated from the refreshed spec: `config`, `defi`, `on-chain`, `promo-codes`, `social` — 19 endpoints that existed in the live API but were invisible on the docs site. Each page has a parameter table (path + query) and a curl example with `<placeholder>` values. New `scripts/generate-api-reference.py` makes regeneration cheap when the spec changes.

## After-merge verification

```bash
# 1. Landing page redirect
curl -I https://docs.mangrovedeveloper.ai/   # expect 307 → /api-reference/overview

# 2. Accordion catalog perf
time curl -sSL https://docs.mangrovedeveloper.ai/signals/catalog/trend > /dev/null
# was ~12s, expect <3s

# 3. New API pages
for d in config defi on-chain social promo-codes; do
  curl -sS -o /dev/null -w "%{http_code} $d\n" https://docs.mangrovedeveloper.ai/api-reference/$d
done
```

## Out of scope (next PRs)

- Hand-author richer examples on the 5 stub pages (request body schemas, response examples) where the spec is sparse.
- Mintlify `openapi:` frontmatter integration so the playground works for these endpoints.
- Trim or rewrite `introduction.mdx` since it's no longer the landing page.
- Delete or refresh `mint.template.json` (stale; PR #39 abandoned the template workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)