### PR TITLE
docs(api-ref): replace stubs with full hand-authored pages for 5 domains

### DIFF
--- a/docs/api-reference/config.mdx
+++ b/docs/api-reference/config.mdx
@@ -1,11 +1,15 @@
 ---
 title: "Config API"
-description: "Trading defaults and execution-config endpoints used by the strategy engine."
+description: "Read-only server defaults — trading defaults and the flattened execution config the engine applies when a request omits one."
 ---
 
 # Config API
 
-Trading defaults and execution-config endpoints used by the strategy engine.
+Read-only access to the server's trading defaults. SDK consumers use these to build strategies that match server behavior without maintaining a parallel copy of `trading_defaults.json`.
+
+Two views of the same source:
+- `/trading-defaults` returns the full nested structure (signal, backtest, risk, position, volatility, trading rules, time-based exits).
+- `/execution-defaults` returns the flattened `execution_config` exactly as the strategies service applies it when a `POST /strategies` request omits its own `execution_config`.
 
 ## Base URL
 
@@ -15,44 +19,146 @@ https://api.mangrovedeveloper.ai/api/v1/config
 
 ## Authentication
 
-All endpoints require a JWT bearer token.
-
-```
-Authorization: Bearer YOUR_JWT_TOKEN
-```
+These endpoints are public — no bearer token required.
 
 ## Endpoints
 
-### Return the flattened `execution_config` the server builds from defaults
-
-`GET /api/v1/config/execution-defaults`
-
-Matches exactly what `domains/strategies/services.py` uses when a
-request omits `execution_config`. Sections `risk_management`,
-`position_limits`, `volatility_settings`, `trading_rules`,
-`time_based_exits` are merged into one dict; `signal_defaults` and
-`backtest_defaults` are intentionally excluded (same as the legacy
-flattening).
-
-**Example**
-
-```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/config/execution-defaults"
-```
-
-### Return the full trading defaults, nested sections intact
+### Get trading defaults
 
 `GET /api/v1/config/trading-defaults`
 
-Shape mirrors `trading_defaults.json` one-to-one: `signal_defaults`,
-`backtest_defaults`, `risk_management`, `position_limits`,
-`volatility_settings`, `trading_rules`, `time_based_exits`, plus the
-top-level `description` field.
+Returns the complete `trading_defaults.json` structure, nested sections intact.
 
-**Example**
-
+<CodeGroup>
 ```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/config/trading-defaults"
+curl "https://api.mangrovedeveloper.ai/api/v1/config/trading-defaults"
 ```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/config/trading-defaults"
+)
+defaults = response.json()
+print(defaults["risk_management"]["max_risk_per_trade"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "description": "Default values for trading system configuration",
+  "signal_defaults": {},
+  "backtest_defaults": {
+    "slippage_pct": 0.004,
+    "fee_pct": 0.0085
+  },
+  "risk_management": {
+    "max_risk_per_trade": 0.01,
+    "reward_factor": 2,
+    "atr_period": 14,
+    "atr_volatility_factor": 2.0,
+    "atr_short_weight": 0.95,
+    "atr_long_weight": 0.05,
+    "atr_cap_multiplier": 2.1
+  },
+  "position_limits": {
+    "initial_balance": 10000,
+    "min_balance_threshold": 0.1,
+    "min_trade_amount": 25,
+    "max_open_positions": 10,
+    "max_trades_per_day": 50,
+    "max_units_per_trade": 1000000,
+    "max_trade_amount": 10000000
+  },
+  "volatility_settings": {
+    "volatility_window": 24,
+    "target_volatility": 0.10,
+    "volatility_mode": "stddev",
+    "enable_volatility_adjustment": false
+  },
+  "trading_rules": {
+    "max_hold_time_hours": null,
+    "cooldown_bars": 24,
+    "daily_momentum_limit": 3,
+    "weekly_momentum_limit": 3,
+    "cooldown_config": {
+      "5m":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+      "15m": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+      "1h":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+      "1d":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+    }
+  },
+  "time_based_exits": {
+    "max_hold_bars": 1000,
+    "exit_on_loss_after_bars": 1000,
+    "exit_on_profit_after_bars": 1000,
+    "profit_threshold_pct": 0.05
+  }
+}
+```
+
+### Get execution defaults (flattened)
+
+`GET /api/v1/config/execution-defaults`
+
+Returns the flattened `execution_config` the server applies when a strategy is created without one. Sections `risk_management`, `position_limits`, `volatility_settings`, `trading_rules`, and `time_based_exits` are merged into a single dict; `signal_defaults` and `backtest_defaults` are excluded by design.
+
+<CodeGroup>
+```bash cURL
+curl "https://api.mangrovedeveloper.ai/api/v1/config/execution-defaults"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/config/execution-defaults"
+)
+exec_config = response.json()
+print(exec_config["max_open_positions"], exec_config["atr_period"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "max_risk_per_trade": 0.01,
+  "reward_factor": 2,
+  "atr_period": 14,
+  "atr_volatility_factor": 2.0,
+  "atr_short_weight": 0.95,
+  "atr_long_weight": 0.05,
+  "atr_cap_multiplier": 2.1,
+  "initial_balance": 10000,
+  "min_balance_threshold": 0.1,
+  "min_trade_amount": 25,
+  "max_open_positions": 10,
+  "max_trades_per_day": 50,
+  "max_units_per_trade": 1000000,
+  "max_trade_amount": 10000000,
+  "volatility_window": 24,
+  "target_volatility": 0.10,
+  "volatility_mode": "stddev",
+  "enable_volatility_adjustment": false,
+  "max_hold_time_hours": null,
+  "cooldown_bars": 24,
+  "daily_momentum_limit": 3,
+  "weekly_momentum_limit": 3,
+  "cooldown_config": {
+    "5m":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 180, "long_window_bars": 480},
+    "15m": {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 120, "long_window_bars": 320},
+    "1h":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 48,  "long_window_bars": 144},
+    "1d":  {"short_loss_limit": 4, "long_loss_limit": 6, "short_window_bars": 20,  "long_window_bars": 60}
+  },
+  "max_hold_bars": 1000,
+  "exit_on_loss_after_bars": 1000,
+  "exit_on_profit_after_bars": 1000,
+  "profit_threshold_pct": 0.05
+}
+```
+
+This is exactly what `domains/strategies/services.py` substitutes into a new strategy when the request body omits `execution_config`.

--- a/docs/api-reference/defi.mdx
+++ b/docs/api-reference/defi.mdx
@@ -1,11 +1,12 @@
 ---
-title: "Defi API"
-description: "DeFi metrics — protocol TVL, chain TVL, stablecoin supply."
+title: "DeFi API"
+description: "DeFi metrics — protocol TVL, chain TVL, and stablecoin supply via DeFiLlama."
 ---
 
-# Defi API
+# DeFi API
 
-DeFi metrics — protocol TVL, chain TVL, stablecoin supply.
+Read-only DeFi analytics endpoints. Backed by DeFiLlama; values reflect the
+provider's most recent snapshot.
 
 ## Base URL
 
@@ -23,47 +24,140 @@ Authorization: Bearer YOUR_JWT_TOKEN
 
 ## Endpoints
 
-### Get TVL and top protocols for a blockchain
-
-`GET /api/v1/defi/chain/{chain}/tvl`
-
-**Parameters**
-
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `chain` | path | `string` | yes | Blockchain name (e.g. Ethereum, Solana, Arbitrum) |
-
-**Example**
-
-```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/defi/chain/<chain>/tvl"
-```
-
-### Get TVL and chain breakdown for a DeFi protocol
+### Get protocol TVL
 
 `GET /api/v1/defi/protocol/{protocol}/tvl`
 
-**Parameters**
+Total Value Locked for a single DeFi protocol, broken down by chain.
 
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `protocol` | path | `string` | yes | Protocol name or slug (e.g. aave, uniswap, lido) |
+**Path Parameters:**
+- `protocol` (string, required): Protocol name or slug. Examples: `aave`, `uniswap`, `lido`.
 
-**Example**
-
+<CodeGroup>
 ```bash cURL
 curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/defi/protocol/<protocol>/tvl"
+  "https://api.mangrovedeveloper.ai/api/v1/defi/protocol/aave/tvl"
 ```
 
-### Get stablecoin supply metrics with per-chain breakdown
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/defi/protocol/aave/tvl",
+    headers={"Authorization": f"Bearer {token}"},
+)
+data = response.json()
+print(data["tvl_usd"], data["chains"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "protocol": "aave",
+  "tvl_usd": 12450000000.0,
+  "chains": {
+    "Ethereum": 8200000000.0,
+    "Polygon": 1800000000.0,
+    "Arbitrum": 1200000000.0,
+    "Avalanche": 850000000.0,
+    "Optimism": 400000000.0
+  },
+  "data": {}
+}
+```
+
+### Get chain TVL
+
+`GET /api/v1/defi/chain/{chain}/tvl`
+
+Total Value Locked across all protocols on a blockchain, plus the top 10 protocols on that chain.
+
+**Path Parameters:**
+- `chain` (string, required): Blockchain name. Examples: `Ethereum`, `Solana`, `Arbitrum`, `Polygon`.
+
+<CodeGroup>
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/defi/chain/Ethereum/tvl"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/defi/chain/Ethereum/tvl",
+    headers={"Authorization": f"Bearer {token}"},
+)
+data = response.json()
+for p in data["top_protocols"][:5]:
+    print(p["name"], p["tvl"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "chain": "Ethereum",
+  "tvl_usd": 64500000000.0,
+  "top_protocols": [
+    {"name": "Lido", "tvl": 22100000000.0, "category": "Liquid Staking"},
+    {"name": "EigenLayer", "tvl": 11800000000.0, "category": "Restaking"},
+    {"name": "Aave", "tvl": 8200000000.0, "category": "Lending"}
+  ],
+  "data": {}
+}
+```
+
+### Get stablecoin metrics
 
 `GET /api/v1/defi/stablecoins/metrics`
 
-**Example**
+Total stablecoin supply with per-chain breakdown.
 
+<CodeGroup>
 ```bash cURL
 curl -H "Authorization: Bearer $TOKEN" \
   "https://api.mangrovedeveloper.ai/api/v1/defi/stablecoins/metrics"
 ```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/defi/stablecoins/metrics",
+    headers={"Authorization": f"Bearer {token}"},
+)
+metrics = response.json()
+print(metrics["total_supply_usd"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "total_supply_usd": 215000000000.0,
+  "supply_by_chain": {
+    "Ethereum": 125000000000.0,
+    "Tron": 58000000000.0,
+    "BSC": 8500000000.0,
+    "Solana": 5200000000.0,
+    "Arbitrum": 4800000000.0
+  },
+  "data": {}
+}
+```
+
+## Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `AUTH_REQUIRED` | 401 | Missing or invalid bearer token |
+| `RESOURCE_NOT_FOUND` | 404 | Unknown protocol or chain slug |
+| `INTERNAL_ERROR` | 500 | Upstream provider (DeFiLlama) error |

--- a/docs/api-reference/on-chain.mdx
+++ b/docs/api-reference/on-chain.mdx
@@ -1,11 +1,11 @@
 ---
-title: "On Chain API"
-description: "On-chain analytics — wallet activity, transaction flows, holders, network metrics."
+title: "On-Chain API"
+description: "Smart-money sentiment, whale transactions, exchange flows, and token-holder analytics. Backed by Nansen and WhaleAlert."
 ---
 
-# On Chain API
+# On-Chain API
 
-On-chain analytics — wallet activity, transaction flows, holders, network metrics.
+On-chain intelligence endpoints sourced from Nansen (smart money, holders) and WhaleAlert (whale transactions, exchange flows).
 
 ## Base URL
 
@@ -23,111 +23,295 @@ Authorization: Bearer YOUR_JWT_TOKEN
 
 ## Endpoints
 
-### Get aggregated exchange inflows/outflows, optionally filtered by token
-
-`GET /api/v1/on-chain/exchange-flows`
-
-**Parameters**
-
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `hours_back` | query | `int` | no | Lookback hours (default: 24) |
-| `symbol` | query | `string` | no | Token symbol (e.g. btc, eth). Omit for all currencies. |
-
-**Example**
-
-```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/on-chain/exchange-flows?hours_back=<hours_back>&symbol=<symbol>"
-```
-
-### Screen for tokens with high smart money activity
-
-`GET /api/v1/on-chain/smart-money/screen`
-
-**Parameters**
-
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `limit` | query | `int` | no | Max results (default: 50) |
-| `timeframe` | query | `string` | no | 5m, 1h, 6h, 24h, 7d, 30d (default: 24h) |
-| `chains` | query | `string` | no | Comma-separated chains (default: ethereum) |
-
-**Example**
-
-```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/on-chain/smart-money/screen?limit=<limit>&timeframe=<timeframe>&chains=<chains>"
-```
-
-### Get smart money sentiment (accumulation vs distribution) for a token
+### Get smart-money sentiment
 
 `GET /api/v1/on-chain/smart-money/sentiment`
 
-**Parameters**
+Whether smart-money wallets are accumulating or distributing a given token, with net inflow/outflow figures.
 
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `chain` | query | `string` | no | Blockchain (default: ethereum) |
-| `symbol` | query | `string` | yes | Token symbol (e.g. ETH, UNI) |
+**Query Parameters:**
+- `symbol` (string, required): Token symbol. Examples: `ETH`, `UNI`.
+- `chain` (string, optional): Blockchain. Default: `ethereum`.
 
-**Example**
-
+<CodeGroup>
 ```bash cURL
 curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/on-chain/smart-money/sentiment?chain=<chain>&symbol=<symbol>"
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/smart-money/sentiment?symbol=ETH&chain=ethereum"
 ```
 
-### Get token holder distribution from Nansen
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/on-chain/smart-money/sentiment",
+    headers={"Authorization": f"Bearer {token}"},
+    params={"symbol": "ETH", "chain": "ethereum"},
+)
+data = response.json()
+print(data["sentiment"], data["net_flow_usd"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "symbol": "ETH",
+  "chain": "ethereum",
+  "sentiment": "accumulating",
+  "smart_money_inflow_usd": 18500000.0,
+  "smart_money_outflow_usd": 7200000.0,
+  "net_flow_usd": 11300000.0,
+  "trend_7d": "increasing",
+  "data": {}
+}
+```
+
+### Screen smart-money tokens
+
+`GET /api/v1/on-chain/smart-money/screen`
+
+Screen for tokens with the highest smart-money activity across one or more chains.
+
+**Query Parameters:**
+- `chains` (string, optional): Comma-separated chains. Default: `ethereum`.
+- `timeframe` (string, optional): One of `5m`, `1h`, `6h`, `24h`, `7d`, `30d`. Default: `24h`.
+- `limit` (integer, optional): Max results. Default: `50`.
+
+<CodeGroup>
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/smart-money/screen?chains=ethereum,arbitrum&timeframe=24h&limit=10"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/on-chain/smart-money/screen",
+    headers={"Authorization": f"Bearer {token}"},
+    params={"chains": "ethereum,arbitrum", "timeframe": "24h", "limit": 10},
+)
+for token in response.json()["tokens"]:
+    print(token["symbol"], token["smart_money_score"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "count": 10,
+  "chains": ["ethereum", "arbitrum"],
+  "timeframe": "24h",
+  "tokens": [
+    {
+      "symbol": "PEPE",
+      "chain": "ethereum",
+      "smart_money_score": 92.4,
+      "net_flow_usd": 4200000.0,
+      "wallet_count": 38
+    },
+    {
+      "symbol": "ARB",
+      "chain": "arbitrum",
+      "smart_money_score": 87.1,
+      "net_flow_usd": 2900000.0,
+      "wallet_count": 24
+    }
+  ]
+}
+```
+
+### Get token holders
 
 `GET /api/v1/on-chain/token-holders/{symbol}`
 
-**Parameters**
+Holder distribution for a token, including concentration of the top 10 holders.
 
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `symbol` | path | `string` | yes | Token symbol (e.g. ETH, UNI) |
+**Path Parameters:**
+- `symbol` (string, required): Token symbol. Examples: `ETH`, `UNI`.
 
-**Example**
-
+<CodeGroup>
 ```bash cURL
 curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/on-chain/token-holders/<symbol>"
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/token-holders/UNI"
 ```
 
-### Get high-level whale activity summary for a token
+```python Python
+import requests
 
-`GET /api/v1/on-chain/whale-activity/{symbol}`
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/on-chain/token-holders/UNI",
+    headers={"Authorization": f"Bearer {token}"},
+)
+data = response.json()
+print(data["holder_count"], data["concentration_score"])
+```
+</CodeGroup>
 
-**Parameters**
+**Response (200 OK):**
 
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `symbol` | path | `string` | yes | Token symbol (e.g. btc, eth) |
-| `hours_back` | query | `int` | no | Lookback hours (default: 24) |
-
-**Example**
-
-```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/on-chain/whale-activity/<symbol>?hours_back=<hours_back>"
+```json
+{
+  "success": true,
+  "symbol": "UNI",
+  "holder_count": 425000,
+  "top_10_holders_pct": 42.7,
+  "concentration_score": 0.61,
+  "data": {}
+}
 ```
 
-### Get recent large-value on-chain transactions
+### Get whale transactions
 
 `GET /api/v1/on-chain/whale-transactions`
 
-**Parameters**
+Recent large-value on-chain transactions, optionally filtered by symbol and minimum USD value.
 
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `hours_back` | query | `int` | no | Lookback hours (default: 24) |
-| `min_value` | query | `int` | no | Min USD value (default: 500000) |
-| `symbol` | query | `string` | no | Filter by symbol (e.g. btc, eth) |
+**Query Parameters:**
+- `symbol` (string, optional): Filter by token symbol. Examples: `btc`, `eth`.
+- `min_value` (integer, optional): Minimum USD value per transaction. Default: `500000`.
+- `hours_back` (integer, optional): Lookback window in hours. Default: `24`.
 
-**Example**
-
+<CodeGroup>
 ```bash cURL
 curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/on-chain/whale-transactions?hours_back=<hours_back>&min_value=<min_value>&symbol=<symbol>"
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/whale-transactions?symbol=eth&min_value=1000000&hours_back=24"
 ```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/on-chain/whale-transactions",
+    headers={"Authorization": f"Bearer {token}"},
+    params={"symbol": "eth", "min_value": 1_000_000, "hours_back": 24},
+)
+for tx in response.json()["transactions"][:5]:
+    print(tx["amount_usd"], tx["from"], "->", tx["to"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "count": 23,
+  "min_value_usd": 1000000.0,
+  "transactions": [
+    {
+      "hash": "0xabc123...",
+      "symbol": "ETH",
+      "amount": 2400.0,
+      "amount_usd": 7200000.0,
+      "from": "0xUNKNOWN_WALLET",
+      "to": "binance_hot_wallet",
+      "timestamp": "2026-05-06T18:41:22Z"
+    }
+  ]
+}
+```
+
+### Get exchange flows
+
+`GET /api/v1/on-chain/exchange-flows`
+
+Aggregated inflows/outflows across centralized exchanges, optionally filtered by token. Net positive = exchange inflows (often associated with sell pressure); net negative = outflows (often associated with accumulation/withdrawal).
+
+**Query Parameters:**
+- `symbol` (string, optional): Filter by token symbol. Examples: `btc`, `eth`. Omit for all currencies.
+- `hours_back` (integer, optional): Lookback hours. Default: `24`.
+
+<CodeGroup>
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/exchange-flows?symbol=btc&hours_back=24"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/on-chain/exchange-flows",
+    headers={"Authorization": f"Bearer {token}"},
+    params={"symbol": "btc", "hours_back": 24},
+)
+data = response.json()
+print(data["net_flow_usd"], "across", len(data["flows"]), "exchanges")
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "symbol": "btc",
+  "timeframe": "24h",
+  "net_flow_usd": -125000000.0,
+  "flows": [
+    {"exchange": "Binance",  "inflow_usd": 42000000.0, "outflow_usd": 95000000.0, "net_usd": -53000000.0},
+    {"exchange": "Coinbase", "inflow_usd": 28000000.0, "outflow_usd": 72000000.0, "net_usd": -44000000.0}
+  ]
+}
+```
+
+### Get whale activity summary
+
+`GET /api/v1/on-chain/whale-activity/{symbol}`
+
+Aggregated whale activity for a single token over a lookback window.
+
+**Path Parameters:**
+- `symbol` (string, required): Token symbol. Examples: `btc`, `eth`.
+
+**Query Parameters:**
+- `hours_back` (integer, optional): Lookback hours. Default: `24`.
+
+<CodeGroup>
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/on-chain/whale-activity/btc?hours_back=24"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/on-chain/whale-activity/btc",
+    headers={"Authorization": f"Bearer {token}"},
+    params={"hours_back": 24},
+)
+print(response.json()["summary"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "symbol": "btc",
+  "hours_back": 24,
+  "summary": {
+    "transaction_count": 142,
+    "total_volume_usd": 3800000000.0,
+    "largest_tx_usd": 215000000.0,
+    "to_exchanges_usd": 1200000000.0,
+    "from_exchanges_usd": 1450000000.0
+  }
+}
+```
+
+## Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `MISSING_FIELD` | 400 | Required parameter missing (e.g. `symbol` on smart-money sentiment) |
+| `AUTH_REQUIRED` | 401 | Missing or invalid bearer token |
+| `RESOURCE_NOT_FOUND` | 404 | Token symbol not tracked by upstream provider |
+| `INTERNAL_ERROR` | 500 | Upstream provider (Nansen / WhaleAlert) error |

--- a/docs/api-reference/promo-codes.mdx
+++ b/docs/api-reference/promo-codes.mdx
@@ -1,11 +1,13 @@
 ---
 title: "Promo Codes API"
-description: "Admin-managed promotional codes for subscription discounts."
+description: "Admin-managed promotional codes for subscription discounts. Includes a user-facing validate endpoint used by the checkout UI."
 ---
 
 # Promo Codes API
 
-Admin-managed promotional codes for subscription discounts.
+Admin endpoints for creating, listing, revoking, reinstating, and inspecting redemptions of promo codes — plus a user-facing validate endpoint used by the checkout UI.
+
+A promo code grants `trial_days` of a subscription tier and can be scoped to user, org, or both. Soft revocation flips `active = false` (preserving redemption history); reinstate flips it back.
 
 ## Base URL
 
@@ -15,7 +17,7 @@ https://api.mangrovedeveloper.ai/api/v1/promo-codes
 
 ## Authentication
 
-All endpoints require a JWT bearer token.
+All endpoints require a JWT bearer token. Admin endpoints additionally require management privileges (`g.is_mgmt = true`); non-admin callers receive `403 Forbidden`. The `/validate` endpoint is open to any authenticated user.
 
 ```
 Authorization: Bearer YOUR_JWT_TOKEN
@@ -23,89 +25,320 @@ Authorization: Bearer YOUR_JWT_TOKEN
 
 ## Endpoints
 
-### Create a new promo code (admin only)
+### Create promo code (admin)
 
 `POST /api/v1/promo-codes`
 
-**Example**
+Create a new promo code.
 
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `code` | string | yes | Unique code string (case-sensitive). |
+| `trial_days` | integer | yes | Days of trial granted on redemption. |
+| `tier_restriction` | string | no | Tier ID this code is valid for. Omit for any tier. |
+| `scope` | string | no | One of `user`, `org`, `both`. Default: `both`. |
+| `max_redemptions` | integer | no | Total redemption cap across all users. Omit for unlimited. |
+| `per_user_once` | boolean | no | If true, a single user can redeem only once. Default: `true`. |
+| `expires_at` | string (ISO 8601) | no | Hard expiry. Omit for no expiry. |
+
+<CodeGroup>
 ```bash cURL
 curl -X POST "https://api.mangrovedeveloper.ai/api/v1/promo-codes" \
-  -H "Authorization: Bearer $TOKEN"
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "code": "LAUNCH50",
+    "trial_days": 30,
+    "tier_restriction": "pro",
+    "scope": "user",
+    "max_redemptions": 500,
+    "per_user_once": true,
+    "expires_at": "2026-12-31T23:59:59Z"
+  }'
 ```
 
-### List all promo codes (admin only)
+```python Python
+import requests
+
+response = requests.post(
+    "https://api.mangrovedeveloper.ai/api/v1/promo-codes",
+    headers={"Authorization": f"Bearer {token}"},
+    json={
+        "code": "LAUNCH50",
+        "trial_days": 30,
+        "tier_restriction": "pro",
+        "scope": "user",
+        "max_redemptions": 500,
+        "per_user_once": True,
+        "expires_at": "2026-12-31T23:59:59Z",
+    },
+)
+created = response.json()["promo_code"]
+```
+</CodeGroup>
+
+**Response (201 Created):**
+
+```json
+{
+  "success": true,
+  "promo_code": {
+    "code": "LAUNCH50",
+    "trial_days": 30,
+    "tier_restriction": "pro",
+    "scope": "user",
+    "max_redemptions": 500,
+    "redemption_count": 0,
+    "per_user_once": true,
+    "expires_at": "2026-12-31T23:59:59Z",
+    "active": true,
+    "created_by": "00000000-0000-0000-0000-000000000000",
+    "created_at": "2026-05-06T21:30:00Z",
+    "updated_at": "2026-05-06T21:30:00Z"
+  }
+}
+```
+
+**Error responses:**
+- `409 Conflict` — `{ "success": false, "error": "Code already exists", "code": "..." }`
+- `400 Bad Request` — `{ "success": false, "error": "trial_days must be > 0" }`
+
+### List promo codes (admin)
 
 `GET /api/v1/promo-codes`
 
-**Example**
+List all promo codes, active and revoked.
 
+<CodeGroup>
 ```bash cURL
 curl -H "Authorization: Bearer $TOKEN" \
   "https://api.mangrovedeveloper.ai/api/v1/promo-codes"
 ```
 
-### Validate a promo code against a prospective checkout
+```python Python
+import requests
 
-`POST /api/v1/promo-codes/validate`
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/promo-codes",
+    headers={"Authorization": f"Bearer {token}"},
+)
+for code in response.json()["promo_codes"]:
+    print(code["code"], code["active"], code["redemption_count"])
+```
+</CodeGroup>
 
-Body: { code, tier_id, scope }  where scope is 'user' or 'org'.
-Returns ValidationResult (valid, trial_days, reason, message).
+**Response (200 OK):**
 
-**Example**
-
-```bash cURL
-curl -X POST "https://api.mangrovedeveloper.ai/api/v1/promo-codes/validate" \
-  -H "Authorization: Bearer $TOKEN"
+```json
+{
+  "success": true,
+  "promo_codes": [
+    {
+      "code": "LAUNCH50",
+      "trial_days": 30,
+      "tier_restriction": "pro",
+      "scope": "user",
+      "max_redemptions": 500,
+      "redemption_count": 42,
+      "per_user_once": true,
+      "expires_at": "2026-12-31T23:59:59Z",
+      "active": true,
+      "created_by": "00000000-0000-0000-0000-000000000000",
+      "created_at": "2026-05-06T21:30:00Z",
+      "updated_at": "2026-05-06T21:30:00Z"
+    }
+  ]
+}
 ```
 
-### List redemptions for a promo code (admin only)
-
-`GET /api/v1/promo-codes/{code}/redemptions`
-
-**Parameters**
-
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `code` | path | `string` | yes |  |
-
-**Example**
-
-```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/promo-codes/<code>/redemptions"
-```
-
-### Re-activate a previously revoked promo code
-
-`PATCH /api/v1/promo-codes/{code}/reinstate`
-
-**Parameters**
-
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `code` | path | `string` | yes |  |
-
-**Example**
-
-```bash cURL
-curl -X PATCH "https://api.mangrovedeveloper.ai/api/v1/promo-codes/<code>/reinstate" \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-### Revoke a promo code (soft -- active = false)
+### Revoke promo code (admin)
 
 `PATCH /api/v1/promo-codes/{code}/revoke`
 
-**Parameters**
+Soft-revoke a promo code (`active = false`). Existing redemptions remain valid; future attempts are blocked.
 
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `code` | path | `string` | yes |  |
+**Path Parameters:**
+- `code` (string, required): Promo code to revoke.
 
-**Example**
-
+<CodeGroup>
 ```bash cURL
-curl -X PATCH "https://api.mangrovedeveloper.ai/api/v1/promo-codes/<code>/revoke" \
+curl -X PATCH "https://api.mangrovedeveloper.ai/api/v1/promo-codes/LAUNCH50/revoke" \
   -H "Authorization: Bearer $TOKEN"
 ```
+
+```python Python
+import requests
+
+requests.patch(
+    "https://api.mangrovedeveloper.ai/api/v1/promo-codes/LAUNCH50/revoke",
+    headers={"Authorization": f"Bearer {token}"},
+)
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{ "success": true }
+```
+
+### Reinstate promo code (admin)
+
+`PATCH /api/v1/promo-codes/{code}/reinstate`
+
+Re-activate a previously revoked code (`active = true`).
+
+**Path Parameters:**
+- `code` (string, required): Promo code to reinstate.
+
+<CodeGroup>
+```bash cURL
+curl -X PATCH "https://api.mangrovedeveloper.ai/api/v1/promo-codes/LAUNCH50/reinstate" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```python Python
+import requests
+
+requests.patch(
+    "https://api.mangrovedeveloper.ai/api/v1/promo-codes/LAUNCH50/reinstate",
+    headers={"Authorization": f"Bearer {token}"},
+)
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{ "success": true }
+```
+
+### List redemptions (admin)
+
+`GET /api/v1/promo-codes/{code}/redemptions`
+
+List all redemption events for a single promo code.
+
+**Path Parameters:**
+- `code` (string, required): Promo code to inspect.
+
+<CodeGroup>
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/promo-codes/LAUNCH50/redemptions"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/promo-codes/LAUNCH50/redemptions",
+    headers={"Authorization": f"Bearer {token}"},
+)
+for r in response.json()["redemptions"]:
+    print(r["redeemed_at"], r["user_id"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "redemptions": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "code": "LAUNCH50",
+      "user_id": "22222222-2222-2222-2222-222222222222",
+      "org_id": null,
+      "stripe_session_id": "cs_test_a1b2c3",
+      "stripe_subscription_id": "sub_a1b2c3",
+      "redeemed_at": "2026-05-05T17:14:09Z"
+    }
+  ]
+}
+```
+
+### Validate promo code (any authenticated user)
+
+`POST /api/v1/promo-codes/validate`
+
+Dry-run validation. The checkout UI calls this to render the discount preview before initiating payment. Does not consume a redemption.
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `code` | string | yes | Code to validate. |
+| `tier_id` | string | yes | Subscription tier the user is about to purchase. |
+| `scope` | string | yes | `user` or `org`. |
+
+<CodeGroup>
+```bash cURL
+curl -X POST "https://api.mangrovedeveloper.ai/api/v1/promo-codes/validate" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "code": "LAUNCH50",
+    "tier_id": "pro",
+    "scope": "user"
+  }'
+```
+
+```python Python
+import requests
+
+response = requests.post(
+    "https://api.mangrovedeveloper.ai/api/v1/promo-codes/validate",
+    headers={"Authorization": f"Bearer {token}"},
+    json={"code": "LAUNCH50", "tier_id": "pro", "scope": "user"},
+)
+result = response.json()["validation"]
+if result["valid"]:
+    print(f"Apply {result['trial_days']} trial days")
+else:
+    print("Reject:", result["message"])
+```
+</CodeGroup>
+
+**Response (200 OK) — valid:**
+
+```json
+{
+  "success": true,
+  "validation": {
+    "valid": true,
+    "trial_days": 30,
+    "reason": null,
+    "message": "30-day free trial will be applied at checkout."
+  }
+}
+```
+
+**Response (200 OK) — invalid:**
+
+```json
+{
+  "success": true,
+  "validation": {
+    "valid": false,
+    "trial_days": 0,
+    "reason": "tier_mismatch",
+    "message": "This code is only valid on the pro tier."
+  }
+}
+```
+
+`reason` values: `not_found`, `revoked`, `expired`, `tier_mismatch`, `scope_mismatch`, `already_redeemed`, `cap_reached`.
+
+## Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `AUTH_REQUIRED` | 401 | Missing or invalid bearer token |
+| `FORBIDDEN` | 403 | Caller lacks management privilege (admin endpoints) |
+| `RESOURCE_NOT_FOUND` | 404 | Code does not exist (revoke / reinstate / redemptions) |
+| `VALIDATION_ERROR` | 400 | Missing or invalid request body field |
+| `CONFLICT` | 409 | Code already exists (create) |

--- a/docs/api-reference/social.mdx
+++ b/docs/api-reference/social.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Social API"
-description: "Social-data endpoints — sentiment, mention volume, influence scoring."
+description: "Social signals from X/Twitter — sentiment scoring, mention volume, and influence metrics."
 ---
 
 # Social API
 
-Social-data endpoints — sentiment, mention volume, influence scoring.
+Social-data endpoints sourced from X/Twitter. Use them to gauge sentiment around a topic, surface recent posts, or score the influence of a single account.
 
 ## Base URL
 
@@ -23,56 +23,151 @@ Authorization: Bearer YOUR_JWT_TOKEN
 
 ## Endpoints
 
-### Get influence score and follower metrics for a user
-
-`GET /api/v1/social/influence/{username}`
-
-**Parameters**
-
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `username` | path | `string` | yes | X/Twitter username (without @) |
-
-**Example**
-
-```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/social/influence/<username>"
-```
-
-### Get recent mentions for a topic
-
-`GET /api/v1/social/mentions/{topic}`
-
-**Parameters**
-
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `topic` | path | `string` | yes | Topic or keyword to search |
-| `limit` | query | `int` | no | Max posts to return (default 20) |
-| `hours_back` | query | `int` | no | Time window in hours (default 24) |
-
-**Example**
-
-```bash cURL
-curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/social/mentions/<topic>?limit=<limit>&hours_back=<hours_back>"
-```
-
-### Get social sentiment score for a topic
+### Get sentiment
 
 `GET /api/v1/social/sentiment/{topic}`
 
-**Parameters**
+Aggregated sentiment score for a topic or symbol over a lookback window.
 
-| Name | In | Type | Required | Description |
-|------|----|------|----------|-------------|
-| `topic` | path | `string` | yes | Topic or symbol to analyze (e.g. BTC, ETH, Solana) |
-| `hours_back` | query | `int` | no | Time window in hours (default 24) |
+**Path Parameters:**
+- `topic` (string, required): Topic, symbol, or keyword. Examples: `BTC`, `ETH`, `Solana`.
 
-**Example**
+**Query Parameters:**
+- `hours_back` (integer, optional): Time window in hours. Default: `24`.
 
+<CodeGroup>
 ```bash cURL
 curl -H "Authorization: Bearer $TOKEN" \
-  "https://api.mangrovedeveloper.ai/api/v1/social/sentiment/<topic>?hours_back=<hours_back>"
+  "https://api.mangrovedeveloper.ai/api/v1/social/sentiment/BTC?hours_back=24"
 ```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/social/sentiment/BTC",
+    headers={"Authorization": f"Bearer {token}"},
+    params={"hours_back": 24},
+)
+data = response.json()
+print(data["sentiment"], data["score"], "from", data["mentions"], "mentions")
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "topic": "BTC",
+  "sentiment": "bullish",
+  "score": 72.3,
+  "mentions": 18420,
+  "data": {}
+}
+```
+
+`sentiment` is one of `bullish`, `bearish`, or `neutral`. `score` is 0–100 (higher = more bullish).
+
+### Get mentions
+
+`GET /api/v1/social/mentions/{topic}`
+
+Recent posts matching a topic, ordered most recent first.
+
+**Path Parameters:**
+- `topic` (string, required): Topic or keyword. Examples: `BTC`, `defi`, `restaking`.
+
+**Query Parameters:**
+- `hours_back` (integer, optional): Time window in hours. Default: `24`.
+- `limit` (integer, optional): Max posts to return. Default: `20`.
+
+<CodeGroup>
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/social/mentions/restaking?hours_back=12&limit=5"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/social/mentions/restaking",
+    headers={"Authorization": f"Bearer {token}"},
+    params={"hours_back": 12, "limit": 5},
+)
+for post in response.json()["posts"]:
+    print(post["author"], "-", post["text"][:80])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "topic": "restaking",
+  "count": 5,
+  "posts": [
+    {
+      "id": "1788234567890123456",
+      "author": "@example_user",
+      "text": "Restaking TVL just crossed $20B...",
+      "likes": 128,
+      "reposts": 34,
+      "created_at": "2026-05-06T19:12:08Z"
+    }
+  ]
+}
+```
+
+### Get influence
+
+`GET /api/v1/social/influence/{username}`
+
+Influence score and follower metrics for a single X/Twitter account.
+
+**Path Parameters:**
+- `username` (string, required): X/Twitter handle without the `@`. Example: `VitalikButerin`.
+
+<CodeGroup>
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/social/influence/VitalikButerin"
+```
+
+```python Python
+import requests
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/social/influence/VitalikButerin",
+    headers={"Authorization": f"Bearer {token}"},
+)
+data = response.json()
+print(data["username"], "score:", data["score"], "followers:", data["followers"])
+```
+</CodeGroup>
+
+**Response (200 OK):**
+
+```json
+{
+  "success": true,
+  "username": "VitalikButerin",
+  "score": 98.7,
+  "followers": 5300000,
+  "data": {
+    "verified": true,
+    "engagement_rate_30d": 0.024
+  }
+}
+```
+
+`score` is 0–100. It blends follower count, engagement rate, and reach.
+
+## Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `AUTH_REQUIRED` | 401 | Missing or invalid bearer token |
+| `INTERNAL_ERROR` | 500 | Upstream provider (X/Twitter) error |


### PR DESCRIPTION
Follow-up to #42. That PR shipped auto-generated stub pages for the 5 missing API domains — placeholder values, curl only, no JSON responses. This PR replaces all five with full hand-authored pages matching the bar set by `strategies.mdx`.

## Per-page coverage

| Domain | Operations | curl + Python | JSON responses |
|--------|-----------|---------------|----------------|
| config | 2 | both | 2 (full nested + flattened) |
| defi | 3 | both | 3 |
| on-chain | 6 | both | 6 |
| promo-codes | 6 | both | 7 (validate has valid + invalid) |
| social | 3 | both | 3 |

Every endpoint now has:
- Real example values (`aave`, `Ethereum`, `BTC`, `LAUNCH50`, `VitalikButerin`) — no `<placeholder>` strings.
- A `<CodeGroup>` with both curl and Python (using `requests`, matching `strategies.mdx`).
- A full JSON response example.
- Per-domain error code table.

Response shapes were derived from the live flask-restx models in `MangroveAI/src/MangroveAI/domains/<domain>/routes.py` — not invented. `config` mirrors `trading_defaults.json`. `promo-codes` includes documented `reason` values for the validate endpoint.

## Out of scope

- The deploy-promotion PR in MangroveAI (bumping `docs_image_label` in `deployment/production.json`) — to be opened after this merges so the prod docs site picks up both #42 and this PR in one image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)