### PR TITLE
fix(openapi): replace flask-restx int/float with valid OpenAPI 3.0 types

### DIFF
--- a/docs/openapi3.json
+++ b/docs/openapi3.json
@@ -2290,7 +2290,7 @@
                         "description": "Maximum number of results",
                         "name": "limit",
                         "schema": {
-                            "type": "int",
+                            "type": "integer",
                             "default": 100
                         }
                     },
@@ -2300,7 +2300,7 @@
                         "description": "Minimum risk score (0-100)",
                         "name": "min_score",
                         "schema": {
-                            "type": "float"
+                            "type": "number"
                         }
                     },
                     {
@@ -2545,7 +2545,7 @@
                         "description": "Number of days (default: 30)",
                         "name": "days",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     }
                 ],
@@ -2640,7 +2640,7 @@
                         "description": "Max results (default: 20)",
                         "name": "limit",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {
@@ -2649,7 +2649,7 @@
                         "description": "Min position size in USD (default: 1000000)",
                         "name": "min_value",
                         "schema": {
-                            "type": "float"
+                            "type": "number"
                         }
                     },
                     {
@@ -2710,7 +2710,7 @@
                         "description": "Max results (default: 20)",
                         "name": "limit",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {
@@ -3776,7 +3776,7 @@
                         "description": "Lookback hours (default: 24)",
                         "name": "hours_back",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {
@@ -3825,7 +3825,7 @@
                         "description": "Max results (default: 50)",
                         "name": "limit",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {
@@ -4005,7 +4005,7 @@
                         "description": "Lookback hours (default: 24)",
                         "name": "hours_back",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     }
                 ],
@@ -4046,7 +4046,7 @@
                         "description": "Lookback hours (default: 24)",
                         "name": "hours_back",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {
@@ -4054,7 +4054,7 @@
                         "description": "Min USD value (default: 500000)",
                         "name": "min_value",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {
@@ -5646,7 +5646,7 @@
                         "description": "Max posts to return (default 20)",
                         "name": "limit",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     },
                     {
@@ -5654,7 +5654,7 @@
                         "description": "Time window in hours (default 24)",
                         "name": "hours_back",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     }
                 ],
@@ -5706,7 +5706,7 @@
                         "description": "Time window in hours (default 24)",
                         "name": "hours_back",
                         "schema": {
-                            "type": "int"
+                            "type": "integer"
                         }
                     }
                 ],


### PR DESCRIPTION
## What broke

After PR #42 + #43 deployed to docs.mangrovedeveloper.ai (commit \`ceb070a\` → docs image \`ceb070a\`), every URL returned HTTP 500. Rolled back via MangroveAI #493 — site is currently back at \`dfb6bad\` and serving 200.

## Root cause

The refreshed \`openapi3.json\` (from PR #42) contains 14 invalid OpenAPI 3.0 type names:

| Bad value | Count | Should be |
|-----------|-------|-----------|
| \`"type": "int"\` | 12 | \`"type": "integer"\` |
| \`"type": "float"\` | 2 | \`"type": "number"\` |

flask-restx generates these from Python type hints in its Swagger 2.0 output. \`swagger2openapi\` does not normalize them. Mintlify's prod SSR strict-validates and 500s.

\`mintlify dev\` surfaces the underlying error as a warning:
\`\`\`
Error validating OpenAPI file /openapi3.json:
/crypto-assets/all/get/parameters/0: must have required property '\$ref'
\`\`\`
The validator can't resolve the inline schema because \`"int"\` isn't a valid type, so it falls back to expecting a \`\$ref\`. Locally Mintlify still serves pages with the warning; prod is stricter.

## The fix

15 lines changed (the 14 type fixes plus the trailing newline). JSON re-emitted with the same 4-space indent and unicode preserved so the diff is exactly the substantive changes.

## Verification before push

- [x] Local \`mintlify dev\` no longer warns on \`/openapi3.json\`
- [x] All 5 new API pages still 200 locally (\`/api-reference/{config,defi,on-chain,promo-codes,social}\`)
- [x] \`json.load\` succeeds; \`paths\` count still 131

## After merge

A new promote-to-prod PR in MangroveAI will bump \`docs_image_label\` to this commit's SHA, redeploying the IA reorder + accordion catalog + 5 API domain pages from #42/#43 with the spec fix applied.

## Pre-deploy checklist for future docs PRs

- [ ] Run \`cd docs && mintlify dev\` and check for warnings before opening the PR
- [ ] Hit at least one page in each top-level section (intro, api-reference, signals, knowledge-base) to verify rendering
- [ ] Specifically watch for OpenAPI validator warnings — they're advisory in dev and fatal in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)