### PR TITLE
fix(docker): resolve broken prebuild symlinks so Mintlify SSR can boot

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -38,6 +38,29 @@ COPY --from=builder /root/.mintlify/mint/apps/client/ ./client/
 # Copy required node_modules (next.js runtime dependencies)
 COPY --from=builder /root/.mintlify/mint/node_modules/ ./node_modules/
 
+# Mintlify's prebuild emits hashed package references (shiki-<hash>,
+# focus-visible-<hash>, @shikijs/<scoped>-<hash>, next-<hash>, etc.)
+# into /app/client/.next/node_modules/ as RELATIVE symlinks. They were
+# generated assuming the original layout
+# /root/.mintlify/mint/apps/client/.next/node_modules/ where
+# `../../../../node_modules/<pkg>` resolves to
+# /root/.mintlify/mint/node_modules/<pkg> and
+# `../../../../apps/client/node_modules/<pkg>` resolves to
+# /root/.mintlify/mint/apps/client/node_modules/<pkg>.
+#
+# At runtime in the new image, the same relative paths from
+# /app/client/.next/node_modules/ resolve to /node_modules/<pkg> and
+# /apps/client/node_modules/<pkg> -- neither of which exist by default.
+# Without the targets present, Next.js's standalone server fails
+# every request with ERR_MODULE_NOT_FOUND for the hashed packages,
+# producing site-wide HTTP 500s.
+#
+# Two root-level symlinks make every existing prebuild relative
+# symlink resolve correctly without rewriting them.
+RUN ln -s /app/node_modules /node_modules && \
+    mkdir -p /apps && \
+    ln -s /app/client /apps/client
+
 # Ensure SEO files (robots.txt, sitemap.xml, llms.txt) are present at the
 # canonical paths regardless of whether Mintlify's prebuild also copies them.
 # nginx-docs.conf serves these at /robots.txt, /sitemap.xml, /llms.txt, and


### PR DESCRIPTION
## TL;DR
The actual root cause of yesterday's prod outage. PR #44 was necessary but not sufficient — fixing the OpenAPI type names cleared the dev warning but didn't fix the SSR crash. This PR does.

## The bug

Mintlify's prebuild emits hashed external package references at \`/app/client/.next/node_modules/\` as **relative symlinks**:
\`\`\`
shiki-43d062b67f27bbdc            -> ../../../../node_modules/shiki
focus-visible-d66c75b3d1a04d28    -> ../../../../node_modules/focus-visible
@shikijs/twoslash-356990365e244966 -> ../../../../node_modules/@shikijs/twoslash
postcss-9745a0d11e3197ae          -> ../../../../node_modules/postcss
typescript-279735412610ef8d       -> ../../../../node_modules/typescript
next-1192ecdc1ac48cb7             -> ../../../../apps/client/node_modules/next
\`\`\`

Built in the builder stage where the layout was \`/root/.mintlify/mint/apps/client/.next/node_modules/\`, those \`../../../../\` paths resolve to \`/root/.mintlify/mint/node_modules/\` and \`/root/.mintlify/mint/apps/client/node_modules/\` — both populated, both valid.

In the runtime stage, the same relative paths from \`/app/client/.next/node_modules/\` resolve to \`/node_modules/<pkg>\` and \`/apps/client/node_modules/<pkg>\` — neither exists.

Result: Next.js standalone server boots, then on every request throws \`ERR_MODULE_NOT_FOUND\` for the hashed-name imports. Site-wide HTTP 500.

PR #42's new content (5 new API pages with multiple code blocks + accordion-wrapped signal catalog) caused Mintlify's prebuild to start emitting these hashed package refs. Older builds (e.g. \`dfb6bad\`) didn't trip this code path.

## The fix

Two root-level symlinks at runtime so the existing relative paths from prebuild resolve at the new layout:

\`\`\`dockerfile
RUN ln -s /app/node_modules /node_modules && \
    mkdir -p /apps && \
    ln -s /app/client /apps/client
\`\`\`

Cheaper and more robust than rewriting every symlink target individually — handles scoped packages like \`@shikijs/twoslash-<hash>\` automatically.

## Verification

Built \`Dockerfile.docs\` locally on top of current main + this fix. Ran the resulting image. Tested:

| Page | Status |
|------|--------|
| / | 307 (redirects to /introduction) |
| /introduction | 200 |
| /api-reference/{overview, defi, on-chain, social, promo-codes, config} | 200 |
| /signals/catalog/{momentum, trend, patterns} | 200 |
| /knowledge-base/glossary | 200 |

Container logs: zero \`ERR_MODULE_NOT_FOUND\`. Prior to this fix the same image config produced an unbroken stream of them on every request.

## After merge

1. \`build-docs.yml\` runs and produces a new image.
2. I open the promote-to-prod PR in MangroveAI bumping \`docs_image_label\` to this commit's SHA.
3. You merge promote → I dispatch deploy → I verify the live site returns 200 across the same page set above.
4. THIS time I'll have built and run the image locally first, so I have actual confidence it'll boot in Cloud Run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)