### PR TITLE
docs(site): restore numbered titles to Knowledge Base nav

### DIFF
--- a/docs/knowledge-base/chart-patterns.mdx
+++ b/docs/knowledge-base/chart-patterns.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Chart Patterns"
+title: "7. Chart Patterns"
 description: "Technical chart patterns -- candlestick patterns, multi-bar formations, and classical patterns."
 ---
 

--- a/docs/knowledge-base/indicators.mdx
+++ b/docs/knowledge-base/indicators.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Technical Indicators"
+title: "6. Technical Indicators"
 description: "Comprehensive reference for 40+ technical indicators used in MangroveAI -- calculation, interpretation, and signal types."
 ---
 

--- a/docs/knowledge-base/instruments.mdx
+++ b/docs/knowledge-base/instruments.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Instruments & Market Mechanics"
+title: "2. Instruments & Market Mechanics"
 description: "Financial instruments and market mechanics -- spot markets, derivatives, leverage, and crypto-specific considerations."
 ---
 

--- a/docs/knowledge-base/market-foundations.mdx
+++ b/docs/knowledge-base/market-foundations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Market Foundations"
+title: "1. Market Foundations"
 description: "Fundamental concepts underlying financial markets -- microstructure, order mechanics, participant dynamics, and execution."
 ---
 

--- a/docs/knowledge-base/quantitative-analysis.mdx
+++ b/docs/knowledge-base/quantitative-analysis.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quantitative Analysis"
+title: "8. Quantitative Analysis"
 description: "Quantitative patterns and statistical phenomena -- seasonality, volatility dynamics, mean reversion, and ML approaches."
 ---
 

--- a/docs/knowledge-base/risk-management.mdx
+++ b/docs/knowledge-base/risk-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Risk Management"
+title: "5. Risk Management"
 description: "Comprehensive risk management principles -- position sizing, stop-losses, portfolio risk, and drawdown management."
 ---
 

--- a/docs/knowledge-base/strategy-design.mdx
+++ b/docs/knowledge-base/strategy-design.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Strategy Design & Modeling"
+title: "4. Strategy Design & Modeling"
 description: "Principles for designing, developing, and validating systematic trading strategies."
 ---
 

--- a/docs/knowledge-base/trading-concepts.mdx
+++ b/docs/knowledge-base/trading-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Core Trading Concepts"
+title: "3. Core Trading Concepts"
 description: "Fundamental analytical frameworks -- trend analysis, support/resistance, volume analysis, and market regimes."
 ---
 


### PR DESCRIPTION
## Summary
- Adds numbers 1–8 back to the Knowledge Base navigation titles (Market Foundations through Quantitative Analysis)
- Glossary and Signals Quick Reference left unnumbered as reference pages

## Test plan
- [ ] Verify numbered titles render correctly in Mintlify sidebar nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)