### PR TITLE
docs(book): An Agent's Guide to Systematic Trading

### DIFF
--- a/.claude/skills/systematic-trading/SKILL.md
+++ b/.claude/skills/systematic-trading/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: systematic-trading
+description: Use this skill to read or quote "An Agent's Guide to Systematic Trading" by Timothy Darrah, PhD. Trigger when the user asks about systematic trading, technical indicators (RSI, MACD, ADX, Bollinger Bands, etc.), trading signals, chart patterns, strategy archetypes (trend following, momentum, mean reversion, breakout, carry), backtesting, walk-forward optimization, risk management (position sizing, stop-loss, Kelly criterion, risk of ruin), market microstructure, order types, slippage, futures, options Greeks, perpetual swaps, quantitative trading methods (GARCH, cointegration, pairs trading, seasonality), or when the user asks "what does the book say about X". Do not trigger for general finance questions unrelated to systematic trading methodology.
+---
+
+# Skill: Read "An Agent's Guide to Systematic Trading"
+
+This skill teaches agents how to consume the book progressively: scan cheap metadata first, load specific sections only when needed. The book is large (~280 PDF pages, ~10,500 source lines of markdown) and slurping whole chapters into context is wasteful.
+
+## When to use this skill
+
+Trigger when the user asks about systematic trading methodology. Match against:
+
+- Indicators: RSI, MACD, ADX, Bollinger Bands, ATR, OBV, VWAP, Ichimoku, Parabolic SAR, CCI, Williams %R, MFI, Stochastic, Keltner Channels, etc.
+- Signal concepts: TRIGGER vs FILTER, signal categories (momentum, trend, volume, volatility, patterns), crossover signals, divergence, breakout, mean reversion.
+- Strategy concepts: trend following, momentum, breakout, mean reversion, carry, event-driven, scalping, day trading, swing trading, position trading.
+- Risk concepts: position sizing, Kelly criterion, stop-loss engineering, drawdown control, risk-reward ratios, risk of ruin, expected shortfall, VaR, portfolio risk.
+- Market mechanics: microstructure, order types, market makers, HFT, liquidity, slippage, spread, price discovery, futures, options Greeks, perpetual swaps, funding rate, leverage, margin, FX.
+- Quant methods: GARCH, cointegration, pairs trading, seasonality, time-series momentum, cross-sectional momentum, autocorrelation, machine learning features.
+- Chart patterns: candlestick patterns (Doji, Hammer, Engulfing), Head and Shoulders, Double Top/Bottom, triangles, flags, wedges, channels.
+
+Do NOT trigger for general personal-finance questions, equity research on specific tickers, or trading advice. This skill returns book content, not recommendations.
+
+## Progressive disclosure: how to load the book
+
+The book lives in two forms:
+
+1. **Markdown source** at `knowledge-base/01-…10-*.md` in the MangroveKnowledgeBase repo. Authoritative source for both the printed book and the agent-readable form.
+2. **PDF** at `book/book.pdf` (built from the same source). For human reading; do not parse for agent queries.
+
+When the KB server is running (`http://localhost:8081` locally, `https://kb.mangrovedeveloper.ai` in prod), prefer its query API. When offline, fall back to reading the markdown directly.
+
+### Recommended access pattern
+
+Follow this loading order. Each step is cheap; only escalate when the prior step did not yield enough context.
+
+**Step 1: Discover the relevant chapter.**
+
+Read the chapter index by listing the front-matter of all 10 chapters. Each chapter file begins with a YAML block containing `slug`, `title`, `tldr`, `triggers`, `tags`, `key_concepts`. Total cost across all 10 chapters is approximately 2,000 tokens.
+
+If the KB server is reachable:
+
+```
+kb_list_documents(limit=20)
+```
+
+Offline fallback: read lines 1, 30 of each `knowledge-base/NN-*.md` to extract front-matter.
+
+**Step 2: Match the user's question against `triggers` and `tags`.**
+
+Pick at most two chapters. If the question spans more, list candidate chapters with their TLDRs to the user and ask which.
+
+**Step 3: Load the chapter-level TLDR, "When to read this", and section headings.**
+
+If the KB server is reachable:
+
+```
+kb_get_document(slug="04-strategy-design-modeling", max_chars=2000)
+```
+
+Use the resulting outline to choose specific sections.
+
+**Step 4: Load only the relevant section(s).**
+
+If the KB server is reachable:
+
+```
+kb_get_sections(slug="04-strategy-design-modeling", anchors=["4.2", "4.5"], max_chars_per_section=3000)
+```
+
+Offline fallback: open the markdown file, jump to the heading by anchor (e.g., `## 4.2 Strategy Archetypes`), read that section only.
+
+**Step 5: Follow `prerequisites` or `see_also` links only when needed.**
+
+Each section ends with a `### See also` list. Each chapter ends with a chapter-level `## See also` and `## References`. Follow these transitively only if the current section did not answer the question.
+
+### Special cases
+
+- **Glossary terms.** Use `kb_glossary_lookup(term="VWAP")` for one-line definitions. Faster than loading Chapter 9 wholesale.
+- **Signal lookup by name.** Use `kb_get_signal_quick_reference()` for the alphabetical index of all 223 signals. Each entry points back to the parent indicator section in Chapter 6.
+- **Free-text search across the book.** Use `kb_search(q="momentum divergence", expand=true, limit=5)` when triggers and tags do not produce a clean chapter match.
+
+## How to quote the book
+
+When citing book content in a response, name the chapter and section explicitly:
+
+> Per *An Agent's Guide to Systematic Trading*, Chapter 4, §4.2 (Strategy Archetypes): "Trend Following bets on regime persistence; Momentum bets on near-term acceleration. The two are commonly conflated but have different risk profiles."
+
+Always preserve the section reference so the user can verify. Do not paraphrase formulas, mathematical rules, or risk thresholds. Quote them.
+
+## What this skill does NOT do
+
+- It does not give trading advice. If the user asks "should I buy X" or "what is a good entry for Y", decline and redirect to the relevant chapter.
+- It does not execute signals or compute indicators. For computation, use the KB server's `evaluate_signal` and `compute_indicator` endpoints (which are x402-gated and require payment).
+- It does not modify book content. If the user wants to edit a chapter, route to the MangroveKnowledgeBase repo's product owner.
+
+## Book metadata
+
+- **Title:** An Agent's Guide to Systematic Trading
+- **Author:** Timothy Darrah, PhD
+- **License:** MIT
+- **Repository:** `MangroveTechnologies/MangroveKnowledgeBase`
+- **Source format:** Markdown in `knowledge-base/`, with YAML front-matter and structured headings per `book/TEMPLATE.md`.
+- **Print format:** LaTeX (memoir class), built from the same markdown via pandoc.

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,10 @@ htmlcov/
 .env
 .env.*
 
-# Claude Code
-.claude/
+# Claude Code: ignore personal config, but ship shared skills with the repo
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 
 # OS files
 .DS_Store

--- a/book/AUDIT.md
+++ b/book/AUDIT.md
@@ -1,0 +1,70 @@
+# Chapter Audit Against the Progressive-Disclosure Template
+
+Per-chapter assessment of what the existing markdown has versus what the template requires. The good news: the existing `Definition / Core Principles / Common Use Cases / Examples / Best Practices / Formulas` section pattern is highly consistent across all 8 narrative chapters and maps cleanly to the "body" portion of the section template. The work is **additive**, not a rewrite.
+
+Legend: ✅ present, ⚠ partial, ✗ missing, n/a not applicable
+
+| | YAML front-matter | Chapter TLDR | Triggers | Key concepts (linked) | Prereqs | Section TLDR + trigger | Section body pattern | See-also blocks | References | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **Ch.1 Market Foundations** | ✗ | ⚠ (1 sentence) | ✗ | ✗ | n/a | ✗ | ✅ | ✗ | ✗ | Clean, very consistent. Lowest-risk chapter to pilot. |
+| **Ch.2 Instruments** | ✗ | ⚠ | ✗ | ✗ | n/a | ✗ | ✅ | ✗ | ✗ | Mirrors Ch.1 structure exactly. |
+| **Ch.3 Core Concepts** | ✗ | ⚠ | ✗ | ✗ | n/a | ✗ | ⚠ | ✗ | ✗ | §3.0 is a discursive framing intro that doesn't follow the `Definition/Principles/...` pattern. Acceptable; treat as a chapter-opening essay. |
+| **Ch.4 Strategy Design** | ✗ | ⚠ | ✗ | ✗ | n/a | ✗ | ✅ | ✗ | ✗ | Longest chapter (1,587 lines). Includes archetype tables and risk-profile summaries, convert to LaTeX `tabularx` / `longtable`. |
+| **Ch.5 Risk Management** | ✗ | ⚠ | ✗ | ✗ | n/a | ✗ | ⚠ | ✗ | ✗ | §5.0 is framing essay (parallel to §3.0). Heavy table use, review for column widths. |
+| **Ch.6 Indicators** | ✗ | ⚠ | ✗ | ✗ | n/a | ✗ | ⚠ | ✗ | ✗ | Preamble defines TRIGGER vs FILTER classification. Each indicator block deviates from the standard section pattern, has its own sub-structure (formula / API ref / related signals). Document as a Ch.6-specific template variant. |
+| **Ch.7 Chart Patterns** | ✗ | ⚠ | ✗ | ✗ | n/a | ✗ | ✅ | ✗ | ✗ | Standard pattern. |
+| **Ch.8 Quantitative Analysis** | ✗ | ⚠ | ✗ | ✗ | n/a | ✗ | ✅ | ✗ | ✗ | Standard pattern. Will need careful BibTeX work, heavy academic references expected (GARCH, cointegration, factor investing). |
+
+## Sizes
+
+| Chapter | Lines | Estimated PDF pages (10pt memoir, 1.2x leading) |
+|---|---:|---:|
+| 1 | 624 | ~18 |
+| 2 | 670 | ~20 |
+| 3 | 1,013 | ~30 |
+| 4 | 1,587 | ~46 |
+| 5 | 977 | ~28 |
+| 6 | 1,763 | ~52 |
+| 7 | 990 | ~28 |
+| 8 | 1,168 | ~34 |
+| **Body total** | **8,792** | **~256 pages** |
+| 9 Glossary | 140 | ~6 |
+| 10 Signals Appendix | 931 | ~20 (compact tables) |
+| **Grand total** | **9,863** | **~280 pages** |
+
+## Per-chapter restructuring effort
+
+For each chapter, "restructure" = add YAML front-matter, write chapter-level TLDR + triggers + key-concepts list, add section-level TLDR/trigger callouts, add see-also blocks, research and add a References section.
+
+| Chapter | Restructuring effort | Notes |
+|---|---|---|
+| 1 | Light | Cleanest source; ideal POC. |
+| 2 | Light | Same shape as Ch.1. |
+| 3 | Medium | §3.0 framing essay needs its own mini-TLDR treatment. |
+| 4 | Heavy | Large; archetype tables need LaTeX styling decisions. |
+| 5 | Medium | §5.0 essay; risk-dimension table is central, preserve verbatim. |
+| 6 | Heavy | Per-indicator block has its own sub-template (formula/API/signals), needs a Ch.6-specific variant of the section template. |
+| 7 | Light-Medium | Standard pattern, but pattern reliability data needs care. |
+| 8 | Medium-Heavy | Quant chapter, needs heavy BibTeX (Engle GARCH, Engle-Granger cointegration, Jegadeesh-Titman momentum, etc.). |
+
+## Phase 0 decisions (need approval now)
+
+Only one Phase 0 decision is needed before Chapter 1 work begins, beyond the templates and skill themselves: confirming the references requirement.
+
+1. **References per chapter:** zero exist today. All 8 chapters need 6 to 12 references researched, verified, and entered as BibTeX. Pre-electronic-era citations get a one-line historical context annotation per `feedback-references-historical-context`. This is the largest piece of new authoring per chapter.
+
+## Deferred observations (revisit at the relevant chapter gate)
+
+These are real quirks worth recording, but they belong to their own chapter or back-matter gate. Do not block Chapter 1 on them.
+
+- **Ch.3 §3.0 and Ch.5 §5.0 are discursive framing essays.** They do not fit the strict `Definition / Core Principles / ...` body pattern. Treatment will be decided at the Ch.3 and Ch.5 gates. Likely path: keep their shape, add only a TLDR/trigger callout on top.
+- **Ch.6 indicator blocks have a distinct sub-structure.** Each indicator already follows Educational / API Reference / Related Signals. Whether to formalize this as a Ch.6 variant or restructure will be decided at the Ch.6 gate.
+- **Ch.4 archetype tables and Ch.5 risk-dimension tables.** Column widths and `longtable` vs `tabularx` choices will be settled at the respective chapter gates.
+- **Ch.9 (Glossary) format.** Likely path: memoir `glossaries` package, agents query via `kb_glossary_lookup`. Decision deferred to the Ch.9 gate.
+- **Ch.10 promoted to Appendix A (Signal Reference).** Likely path: `longtable` in the appendix, skill exposes via `kb_get_signal_quick_reference`. Decision deferred to the Appendix A gate.
+
+## Recommended chapter order for conversion
+
+Pilot Chapter 1 (lowest risk, cleanest source), then proceed in numerical order. Defer Ch.6 to last among the narrative chapters because its section variant adds template work.
+
+Order: **1 → 2 → 3 → 4 → 5 → 7 → 8 → 6 → 9 (glossary) → Appendix A (signals) → front matter / polish.**

--- a/book/TEMPLATE.md
+++ b/book/TEMPLATE.md
@@ -1,0 +1,217 @@
+# Book Structure Template
+
+This is the structural contract for *An Agent's Guide to Systematic Trading*. Every chapter and every section conforms to this template so that:
+
+1. **AI agents** can scan TLDRs, match triggers, and load only the sections they need (progressive disclosure).
+2. **Human readers** get a coherent, well-paced narrative with consistent rhythm.
+3. **The KB server** (`kb_search`, `kb_get_sections`) and the **`systematic-trading` skill** can derive structured metadata from a single source of truth, the markdown itself, without sidecar files.
+
+Source of truth: `knowledge-base/NN-chapter.md`. The LaTeX book and the skill both derive from this. No drift.
+
+---
+
+## Chapter-level template
+
+Every chapter file begins with YAML front-matter, then a fixed sequence of top-level headings before the body sections.
+
+````markdown
+---
+slug: 01-market-foundations
+chapter: 1
+title: Market Foundations
+tldr: >
+  How markets actually work at the mechanical level, order types, participants,
+  liquidity, regimes, venues, spreads, and price discovery. Read this before any
+  chapter that assumes you can "just execute a trade."
+triggers:
+  - "how do markets work"
+  - "what is a limit order vs a market order"
+  - "what is slippage"
+  - "what is market microstructure"
+prerequisites: []
+key_concepts:
+  - {term: "microstructure", section: "1.1", glossary: "market-microstructure"}
+  - {term: "limit order",    section: "1.2", glossary: "limit-order"}
+  - {term: "slippage",       section: "1.4", glossary: "slippage"}
+estimated_read_time_min: 25
+tags: [market-structure, microstructure, order-types, execution, liquidity, volatility]
+---
+
+# 1. Market Foundations
+
+## TLDR
+
+(50-100 words. Self-contained chapter summary. An agent should be able to decide
+from this paragraph alone whether to load the rest of the chapter.)
+
+## When to read this
+
+(Bullet list of concrete trigger phrases. Match what an agent or human would
+actually ask, not abstract topic labels.)
+
+- If you need to choose between a market order and a limit order
+- If you are estimating execution cost for a strategy
+- If you need to understand why your backtest results disagree with live fills
+
+## Key concepts
+
+(One-line definitions, with section anchors. Mirrors the YAML `key_concepts`
+list in human-readable form. Each term links to its section and to the glossary.)
+
+- **Microstructure** (§1.1), the mechanics of order flow and price formation
+- **Limit order** (§1.2), an order that fills only at a specified price or better
+- ...
+
+## Prerequisites
+
+(Other chapters/sections that should be read first. Empty list is fine for
+foundational chapters.)
+
+None. This is a foundational chapter.
+
+---
+
+## 1.1 Section title
+
+(Section body. See section-level template below.)
+
+## 1.2 Section title
+
+...
+
+---
+
+## References
+
+(6-12 entries. Mix of seminal academic works and practitioner texts. BibTeX
+keys live in `book/bib/ch01.bib` and are cited inline using `[@key]` syntax
+that pandoc converts to LaTeX `\cite{}`.)
+
+1. Harris, L. (2002). *Trading and Exchanges: Market Microstructure for Practitioners*. Oxford University Press. [@harris2002trading]
+2. O'Hara, M. (1995). *Market Microstructure Theory*. Blackwell. [@ohara1995microstructure]
+3. Kyle, A. S. (1985). "Continuous Auctions and Insider Trading." *Econometrica*, 53(6), 1315–1335. [@kyle1985continuous]
+4. ...
+
+## See also
+
+- Chapter 2 (Instruments & Market Mechanics): for derivative-specific execution
+- Chapter 5, §5.4 (Stop-Loss Engineering): applies the slippage concepts here
+- Glossary entries: [microstructure], [VWAP], [TWAP]
+````
+
+---
+
+## Section-level template
+
+Every numbered section (e.g., §1.1, §3.7) opens with TLDR + trigger before
+diving into the existing `Definition / Core Principles / …` body pattern.
+
+````markdown
+## 1.1 Market Microstructure
+
+> **TLDR.** (1-2 sentences. Plain prose, no jargon if avoidable.)
+>
+> **When this matters.** (Single sentence. The concrete situation in which an
+> agent or trader needs this section.)
+
+### Definition
+
+(Existing body content; minimal disruption.)
+
+### Core Principles
+
+...
+
+### Common Use Cases
+
+...
+
+### Examples
+
+...
+
+### Best Practices
+
+...
+
+### Mathematical Rules / Formulas
+
+(Optional. Present where applicable.)
+
+### See also
+
+- §1.4 Liquidity, Slippage & Market Impact (for execution cost framing)
+- §3.5 Volume & Order Flow (for the analytic side)
+````
+
+The existing `Definition / Core Principles / Common Use Cases / Examples / Best Practices / Formulas` pattern is preserved as-is. It is already well-suited as the section body. The change is **additive**: a TLDR/trigger callout at the top and a `See also` list at the bottom.
+
+---
+
+## YAML front-matter schema
+
+```yaml
+slug: string             # filename stem, e.g. "01-market-foundations"
+chapter: integer         # chapter number
+title: string            # chapter title without the number prefix
+tldr: multiline string   # 50-100 words, self-contained
+triggers: list[string]   # natural-language phrases an agent might match
+prerequisites: list[string]  # slugs of chapters/sections to read first; e.g. ["01-market-foundations", "03-core-trading-concepts#3.5"]
+key_concepts:            # list of {term, section, glossary} objects
+  - term: string
+    section: string      # "1.1", used to anchor links
+    glossary: string     # glossary entry slug
+estimated_read_time_min: integer
+tags: list[string]       # topic tags; reused from existing TOC
+```
+
+The schema is intentionally minimal. Anything else (references, see-also, body)
+belongs in the prose, not the front-matter.
+
+---
+
+## Glossary, signal reference, and chapter 0
+
+- **Chapter 0 (`00-table-of-contents.md`):** current content is tool-usage notes (`kb_get_document` examples) intended for agents calling the KB server. Drop from the book; keep the file in the repo as agent-facing infrastructure. A real TOC is auto-generated by memoir.
+- **Chapter 9 (Glossary):** exported as memoir `glossaries` package entries. The skill exposes glossary lookup via `kb_glossary_lookup`. No prose template needed; it's a flat term list.
+- **Chapter 10 (Signals Quick Reference):** promoted to **Appendix A: Signal Reference**. Long-table format (`longtable`). Skill exposes via `kb_get_signal_quick_reference`. No prose template needed.
+
+---
+
+## Voice contract for chapter prose
+
+The book is authored under Timothy Darrah's byline. Every chapter must follow his voice contract, synthesized from his ICAART 2024 paper, his PHM Society 2022 paper, and his Vanderbilt PhD thesis. Authoritative source: `MangroveOracle/reports/tims-voice.md`.
+
+Summary of the voice contract:
+
+1. Open with stakes, not abstraction. The first paragraph of every chapter tells the reader what is lost if the material is not internalized.
+2. Define technical terms on first use. Italicize the term, expand acronyms immediately in parens (e.g., *Volume-Weighted Average Price* (VWAP)).
+3. Position against the literature explicitly. Use moves like "Typically,", "Most current research does not", "The literature lacks", "Currently, there are no". Each gap is followed by the claim that the chapter addresses it.
+4. Tutorial register in technical sections. Walk the reader through methods step by step.
+5. First-person plural throughout. "We demonstrate", "our approach", "we show". Active voice.
+6. Enumerate contributions explicitly. Numbered or letter-tagged lists, never implicit.
+7. Every chapter introduction ends with a "Chapter Organization" subsection that walks through what each section contains. Fixed move, not optional.
+8. Flat section transitions. "discussed next", "as described in §X". No throat-clearing.
+9. Self-citation matter-of-fact. Cite prior work and build on it without ceremony.
+10. Narrate prior work in-prose. "In (Harris, 2002), the author lays out X." The cited work is the subject of a sentence, not a trailing bracket.
+11. Hedge on causes, not on claims. Claims are direct. Hedging appears only when explaining *why*.
+12. Bold is reserved for the one-sentence claim a section exists to deliver. At most one bold sentence per section.
+13. Results presented as facts plus one sentence of interpretation. No caveats stacked in front of findings.
+14. No em dashes. Use commas, colons, parentheses, or two separate sentences instead.
+15. Prose targets an 8th-grade reading level (Flesch-Kincaid grade ~8.0). Technical passages (formulas, mathematical rules, indicator definitions, signal mechanics, code) stay technical when clarity requires it. The voice traits above are about structure and rhetoric; they coexist with plain vocabulary. Prefer short sentences, common words, concrete subjects, active voice. Split long sentences into two short ones. Replace Latinate words with Anglo-Saxon equivalents where the meaning is preserved.
+
+Reference annotations for pre-electronic-era citations (roughly pre-2000) must include a one-line note situating the work in its historical market context. The book's domain spans markets that were transformed by decimalization in 2001, Reg NMS in 2007, the rise of HFT, dark pools, and the emergence of perpetual swaps and crypto. Pair foundational results (Kyle 1985, Engle 1982, etc.) with modern follow-ups where applicable.
+
+---
+
+## What the skill expects
+
+The `.claude/skills/systematic-trading/` skill instructs agents to:
+
+1. Read the chapter YAML front-matter first (cheap; ~200 tokens per chapter).
+2. Match the user's question against `triggers` + `tags` to pick a chapter.
+3. Read the chapter-level TLDR and section headings.
+4. Use `kb_get_sections(slug, anchors)` to load only the relevant section(s).
+5. Follow `prerequisites` / `see_also` links transitively only when needed.
+
+This is the same progressive-disclosure pattern Claude Code skills use internally: small description → SKILL.md → deeper files. The book inherits it.


### PR DESCRIPTION
## Summary

Long-running draft PR for the book project. This PR will accumulate one commit per chapter over many editorial cycles. Keep it draft until the whole book is ready to ship.

## What this opening commit lands (Phase 0)

* `book/TEMPLATE.md`: the structural contract every chapter must follow. YAML front-matter schema, chapter and section heading order, and the 15-point voice contract (synthesized from the author's prior published works).
* `book/AUDIT.md`: per-chapter gap analysis against the template, recommended conversion order, and deferred observations for chapter-specific quirks.
* `.claude/skills/systematic-trading/SKILL.md`: book-reader skill so agents can consume the book progressively via the KB server's `kb_get_sections` and friends, with a markdown fallback for offline use.
* `.gitignore`: opened up `.claude/skills/` so the shared skill ships with the repo while personal Claude Code config stays ignored.

## What is intentionally NOT in this commit

* No chapter prose has been converted yet.
* No LaTeX files. `book/book.tex`, `book/preamble.tex`, `book/scripts/build.sh`, etc. arrive in the Chapter 1 commit so the build wiring lands together with the first real chapter.
* No BibTeX files. References are researched per chapter and committed alongside the chapter conversion.

## Per-chapter workflow

Each chapter goes through the same cycle and lands as its own commit on this branch:

1. Research 6 to 12 verified references for the chapter. Pre-electronic-era citations are paired with modern HFT-era follow-ups and get a one-line historical context note.
2. Draft a chapter plan (outline mapped to the existing markdown, BibTeX entries, restructuring diff, open questions).
3. Editorial gate. Wait for explicit approval before touching the markdown.
4. Restructure the markdown to the template (additive: YAML front-matter, chapter and section TLDRs, See also blocks, References).
5. Convert to LaTeX via pandoc, build the PDF, visually inspect.
6. Commit chapter + bib + any required preamble changes.

Conversion order: 1, 2, 3, 4, 5, 7, 8, 6, 9 (glossary), Appendix A (signals), front matter, polish, CI.

## Book metadata

* **Title:** An Agent's Guide to Systematic Trading
* **Author:** Timothy Darrah, PhD (sole)
* **License:** MIT
* **Class:** `memoir`
* **Toolchain:** pandoc to LaTeX, `lualatex` build, `listings` for code

## Test plan

This Phase 0 commit only adds documentation and a skill manifest. No build to run yet. For reviewers:

- [ ] Confirm `book/TEMPLATE.md` voice contract matches Tim's intent for the book (cross-check against `MangroveOracle/reports/tims-voice.md`).
- [ ] Confirm `book/AUDIT.md` conversion order is acceptable.
- [ ] Confirm `.claude/skills/systematic-trading/SKILL.md` triggers and progressive-loading instructions are accurate.
- [ ] Verify `.gitignore` change does not accidentally expose personal `.claude/` config (only `.claude/skills/**` should be trackable).