### PR TITLE
fix(docker): pin node to 22-slim (mintlify refuses 25+) + harden prebuild assertions

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,5 +1,5 @@
 # Stage 1: Build - Install mintlify CLI, run prebuild to generate content
-FROM node:26-slim AS builder
+FROM node:22-slim AS builder
 
 # Install mintlify CLI globally
 RUN npm install -g mintlify@4.2.414
@@ -14,18 +14,25 @@ COPY docs/ .
 # Then kill it - we only need the prebuild output, not the dev server
 RUN mintlify dev --port 9999 & \
     MPID=$! && \
+    READY=0 && \
     for i in $(seq 1 60); do \
-      if curl -s -o /dev/null http://localhost:9999/ 2>/dev/null; then break; fi; \
+      if curl -s -o /dev/null http://localhost:9999/ 2>/dev/null; then READY=1; break; fi; \
       sleep 2; \
     done && \
     kill $MPID 2>/dev/null; \
-    wait $MPID 2>/dev/null || true
+    wait $MPID 2>/dev/null || true && \
+    if [ "$READY" != "1" ]; then \
+      echo "ERROR: mintlify dev never came up on port 9999 within 120s. Likely Mintlify CLI / Node incompatibility (e.g. mintlify@4.2.414 refuses Node 25+)."; \
+      exit 1; \
+    fi && \
+    test -d /root/.mintlify/mint/apps/client -a -d /root/.mintlify/mint/node_modules \
+      || (echo "ERROR: mintlify dev did not populate /root/.mintlify/mint/{apps/client,node_modules}; stage-2 COPY would fail silently."; exit 1)
 
 # Stage 2: Runtime - nginx serves static files, node serves dynamic routes
 # nginx is needed because Next.js standalone server does not properly decode
 # percent-encoded parentheses in static file paths (e.g. route groups like
 # "(local)" become "%28local%29" in browser requests, causing 404s).
-FROM node:26-slim
+FROM node:22-slim
 
 RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends nginx \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

PR #47 bumped \`Dockerfile.docs\` node 20-slim -> 26-slim. \`mintlify@4.2.414\` explicitly errors on Node 25+:

\`\`\`
erro mint dev is not supported on node versions 25+. Please
     downgrade to an LTS node version.
\`\`\`

The dev-server-warmup step in \`Dockerfile.docs\` swallowed that error (mintlify exited immediately, the for-loop never matched, the \`kill\` no-oped, \`wait\` returned 0), so stage 1 "succeeded" with an empty \`/root/.mintlify/mint/\` and stage 2 failed cryptically on \`COPY ... mint/apps/client: not found\`.

## State to be aware of

The KB \`release.yml\` triggered by the merge of #47 ran far enough to produce a half-baked v1.0.4 release before I caught it:

- ✓ git tag \`v1.0.4\` at \`cb15abe\` (on origin)
- ✓ GitHub Release v1.0.4 published
- ✓ PyPI \`mangrove-kb==1.0.4\` published (functionally identical to 1.0.3 -- no service code changed)
- ✗ \`mangrove-ai-docs:cb15abe\` artifact: build failed
- ✗ \`mangrove-ai-kb:cb15abe\` artifact: build-and-push.yaml didn't fire on this push

We'll forward-fix as v1.0.5 once this merges (release.yml will compute the next patch from v1.0.4 and tag at this PR's merge SHA).

## Changes

1. **Pin node to 22-slim.** Next active LTS that Mintlify supports. Keeps the spirit of the dependency-update PR without crossing the mintlify-supported-version line.

2. **Harden prebuild step.** Both new assertions would have caught the Node-26 regression at build time:
   - Track \`READY=1\` if the dev server was actually reachable on port 9999. Fail with a clear error message otherwise.
   - Assert that \`/root/.mintlify/mint/{apps/client,node_modules}\` were actually populated before stage 2 tries to COPY from them.

## Test plan

- [ ] Merge this PR.
- [ ] \`build-docs.yml\` fires on the merge -- verify it succeeds (the Node-22 base) AND that the new READY assertion would have caught Node-26 (visible in workflow log even on success).
- [ ] Trigger \`release.yml\` (bump=patch) -- ships v1.0.5 with PyPI + GH Release + a deployable docs image at the merge SHA.
- [ ] Bump MangroveAI \`production.json\` \`kb_image_label\` + \`docs_image_label\` to the v1.0.5 SHA in a follow-up promote PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)