### PR TITLE
fix(docker): install curl in builder stage (node:22-slim strips it)

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -1,6 +1,14 @@
 # Stage 1: Build - Install mintlify CLI, run prebuild to generate content
 FROM node:22-slim AS builder
 
+# node:22-slim does not include curl. The readiness probe below uses curl
+# to detect when `mintlify dev` is serving; without it, every probe iteration
+# silently fails (the for-loop swallows stderr) and the READY assertion fires
+# at the 120s timeout looking like a Mintlify hang.
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && command -v curl >/dev/null
+
 # Install mintlify CLI globally
 RUN npm install -g mintlify@4.2.414
 


### PR DESCRIPTION
## Summary

PR #49 pinned \`Dockerfile.docs\` to node:22-slim. The build failed with the new READY assertion firing at 120s -- "mintlify dev never came up." Misleading. The real cause: **\`node:22-slim\` does not ship with \`curl\`**, and the readiness probe relies on it. Every probe iteration silently failed (\`-s\` + \`2>/dev/null\` hid \`curl: command not found\`), the for-loop ran the full 60 iterations, and the assertion fired with a Mintlify-shaped message that was actually a missing-binary message.

## Why the old build worked

The previous \`node:20-slim\` image happened to include curl (or some transitive layer pulled it in). \`node:22-slim\` is leaner; curl is no longer there. The \`apt-get install\` is the explicit dependency we should have been declaring all along.

## Changes

- \`apt-get install curl ca-certificates\` in the builder stage.
- \`command -v curl >/dev/null\` assertion immediately after, so future image regressions fail at this layer instead of cascading 120s into the Mintlify probe.

## Test plan

- [ ] Merge.
- [ ] \`build-docs.yml\` fires on the merge SHA -- should succeed this time.
- [ ] Trigger KB \`release.yml\` (bump=patch -> v1.0.5).
- [ ] Open MangroveAI promote PR bumping \`kb_image_label\` + \`docs_image_label\` to the v1.0.5 SHA.

## Half-released v1.0.4 still pending cleanup

v1.0.4 (tag + GH Release + PyPI wheel) at \`cb15abe\` still has no deployable image. As planned: forward-fix as v1.0.5; v1.0.4 stays a skipped version. No rollback.