### PR TITLE
feat(signals): add On-Chain signal category (12 signals)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ curl -X POST http://localhost:8081/api/evaluate \
 
 Open-source trading signals, technical indicators, and knowledge base. Three components:
 
-1. **Python Package** (`mangrove_kb`) -- 223 signal functions, 99 indicator classes (including 27 pattern indicators), RuleRegistry, docstring parser. Published on PyPI as `mangrove-kb`.
+1. **Python Package** (`mangrove_kb`) -- 235 signal functions, 99 indicator classes (including 27 pattern indicators), RuleRegistry, docstring parser. Published on PyPI as `mangrove-kb`.
 2. **KB Server** (`kb_server/`) -- Unified server with dual protocol access (REST + MCP) on the same port. FastAPI REST API + FastMCP tools. SQLite FTS5 full-text search, 11 trading education documents, glossary, cross-references, synonym expansion. Signal/indicator metadata (free) and computation (x402 gated).
 3. **Knowledge Base Content** (`knowledge-base/`) -- 11 markdown documents covering market foundations through quantitative analysis
 
@@ -161,8 +161,9 @@ Terraform module: `MangroveAI/infra/terraform/modules/app-mangroveai-kb/`
 - Every signal docstring must include `Type:` (TRIGGER or FILTER) and `Requires:` (comma-separated column names)
 - Every parameter must include `Range: min-max` and `Default: value` in the Args section
 - Use `window` for all windowing parameters (not `lookback`, `period`, `length`)
-- Signal counts: 223 signals (108 TRIGGER, 115 FILTER) across 5 categories
-- Categories: Momentum (42), Trend (88), Volume (33), Volatility (20), Patterns (40)
+- Signal counts: 235 signals (113 TRIGGER, 122 FILTER) across 6 categories
+- Categories: Momentum (42), Trend (88), Volume (33), Volatility (20), Patterns (40), On-Chain (12)
+- On-Chain signals consume alternative-data columns (SmartMoneyNetflow, SmartMoneyHoldings, ExchangeNetflow, WhaleNetInflow, TokenHolderCount, HolderConcentration) sourced from the Nansen/WhaleAlert feeds documented in docs/data-providers.mdx; the caller populates them time-aligned to OHLCV bars
 
 ## GitHub
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -126,7 +126,8 @@
             "signals/catalog/trend",
             "signals/catalog/volume",
             "signals/catalog/volatility",
-            "signals/catalog/patterns"
+            "signals/catalog/patterns",
+            "signals/catalog/on-chain"
           ]
         }
       ]

--- a/docs/signals/catalog.mdx
+++ b/docs/signals/catalog.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Signal Catalog"
-description: "Index of all 223 trading signals across 5 categories."
+description: "Index of all 235 trading signals across 6 categories."
 ---
 
 # Signal Catalog
 
-Complete reference for all **223** trading signals 
-(108 TRIGGER, 115 FILTER) organized by category.
+Complete reference for all **235** trading signals 
+(113 TRIGGER, 122 FILTER) organized by category.
 
 See [Signals Overview](/signals/overview) for an introduction to how signals work.
 
@@ -19,6 +19,7 @@ See [Signals Overview](/signals/overview) for an introduction to how signals wor
 | Volume | 33 | [/signals/catalog/volume](/signals/catalog/volume) |
 | Volatility | 20 | [/signals/catalog/volatility](/signals/catalog/volatility) |
 | Patterns | 40 | [/signals/catalog/patterns](/signals/catalog/patterns) |
+| On-Chain | 12 | [/signals/catalog/on-chain](/signals/catalog/on-chain) |
 
 ## All signals
 
@@ -247,7 +248,19 @@ See [Signals Overview](/signals/overview) for an introduction to how signals wor
 | [`tweezer_tops_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
 | [`two_bar_reversal_bearish_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
 | [`two_bar_reversal_bullish_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`exchange_net_outflow`](/signals/catalog/on-chain) | FILTER | On-Chain | ExchangeNetflow |
+| [`exchange_outflow_spike`](/signals/catalog/on-chain) | TRIGGER | On-Chain | ExchangeNetflow |
+| [`holder_base_expanding`](/signals/catalog/on-chain) | FILTER | On-Chain | TokenHolderCount |
+| [`holder_concentration_falling`](/signals/catalog/on-chain) | FILTER | On-Chain | HolderConcentration |
+| [`holder_concentration_low`](/signals/catalog/on-chain) | FILTER | On-Chain | HolderConcentration |
+| [`holder_growth_breakout`](/signals/catalog/on-chain) | TRIGGER | On-Chain | TokenHolderCount |
+| [`smart_money_holdings_cross`](/signals/catalog/on-chain) | TRIGGER | On-Chain | SmartMoneyHoldings |
+| [`smart_money_holdings_rising`](/signals/catalog/on-chain) | FILTER | On-Chain | SmartMoneyHoldings |
+| [`smart_money_inflow_spike`](/signals/catalog/on-chain) | TRIGGER | On-Chain | SmartMoneyNetflow |
+| [`smart_money_net_positive`](/signals/catalog/on-chain) | FILTER | On-Chain | SmartMoneyNetflow |
+| [`whale_accumulation_trigger`](/signals/catalog/on-chain) | TRIGGER | On-Chain | WhaleNetInflow |
+| [`whale_net_accumulation`](/signals/catalog/on-chain) | FILTER | On-Chain | WhaleNetInflow |
 
 ---
 
-_Generated from docstring metadata. 223 signals total (108 TRIGGER, 115 FILTER)._
+_Generated from docstring metadata. 235 signals total (113 TRIGGER, 122 FILTER)._

--- a/docs/signals/catalog/on-chain.mdx
+++ b/docs/signals/catalog/on-chain.mdx
@@ -1,0 +1,538 @@
+---
+title: "On-Chain Signals"
+description: "12 on-chain trading signals with parameters, descriptions, and examples."
+---
+
+# On-Chain Signals
+
+_12 signals in this category._
+
+See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.
+
+Click a signal to expand parameters and examples.
+
+<AccordionGroup>
+
+<Accordion title="exchange_net_outflow" description="FILTER - requires ExchangeNetflow">
+
+Check whether exchanges saw net outflows over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Number of bars to sum |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "exchange_net_outflow",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "exchange_net_outflow",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="exchange_outflow_spike" description="TRIGGER - requires ExchangeNetflow">
+
+Detect an unusually large net outflow from exchanges on the latest bar. Coins leaving exchanges reduce immediately sellable supply and are typically read as bullish.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 5 -- 200 | `20` | Lookback for the rolling baseline |
+| `z_threshold` | `float` | 0.5 -- 5.0 | `2.0` | How many standard deviations below the baseline mean the latest flow must be to fire |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "exchange_outflow_spike",
+    "parameters": {
+        "window": 20,
+        "z_threshold": 2.0
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "exchange_outflow_spike",
+  "parameters": {
+    "window": 20,
+    "z_threshold": 2.0
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="holder_base_expanding" description="FILTER - requires TokenHolderCount">
+
+Check whether the holder base grew over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 365 | `14` | Lookback for the comparison |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "holder_base_expanding",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "holder_base_expanding",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="holder_concentration_falling" description="FILTER - requires HolderConcentration">
+
+Check whether top-holder concentration is declining over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Lookback for the comparison |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "holder_concentration_falling",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "holder_concentration_falling",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="holder_concentration_low" description="FILTER - requires HolderConcentration">
+
+Check whether top-holder concentration is below a threshold. Lower concentration means supply is more widely distributed and less exposed to a single-wallet dump.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `threshold` | `float` | 0.0 -- 1.0 | `0.5` | Maximum acceptable top-holder share |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "holder_concentration_low",
+    "parameters": {
+        "threshold": 0.5
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "holder_concentration_low",
+  "parameters": {
+    "threshold": 0.5
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="holder_growth_breakout" description="TRIGGER - requires TokenHolderCount">
+
+Detect the holder count making a new high over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 3 -- 365 | `30` | Lookback for the prior high |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "holder_growth_breakout",
+    "parameters": {
+        "window": 30
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "holder_growth_breakout",
+  "parameters": {
+    "window": 30
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="smart_money_holdings_cross" description="TRIGGER - requires SmartMoneyHoldings">
+
+Detect smart-money holdings crossing above their moving average.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 3 -- 200 | `20` | Moving-average window for the holdings baseline |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "smart_money_holdings_cross",
+    "parameters": {
+        "window": 20
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "smart_money_holdings_cross",
+  "parameters": {
+    "window": 20
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="smart_money_holdings_rising" description="FILTER - requires SmartMoneyHoldings">
+
+Check whether smart-money holdings are higher than window bars ago.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Lookback for the comparison |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "smart_money_holdings_rising",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "smart_money_holdings_rising",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="smart_money_inflow_spike" description="TRIGGER - requires SmartMoneyNetflow">
+
+Detect an unusually large smart-money inflow on the latest bar.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 5 -- 200 | `20` | Lookback for the rolling baseline |
+| `z_threshold` | `float` | 0.5 -- 5.0 | `2.0` | How many standard deviations above the baseline mean the latest inflow must be to fire |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "smart_money_inflow_spike",
+    "parameters": {
+        "window": 20,
+        "z_threshold": 2.0
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "smart_money_inflow_spike",
+  "parameters": {
+    "window": 20,
+    "z_threshold": 2.0
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="smart_money_net_positive" description="FILTER - requires SmartMoneyNetflow">
+
+Check whether smart money has been a net buyer over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Number of bars to sum |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "smart_money_net_positive",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "smart_money_net_positive",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="whale_accumulation_trigger" description="TRIGGER - requires WhaleNetInflow">
+
+Detect whale net flow flipping to accumulation.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 100 | `7` | Smoothing window for the net-flow moving average |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "whale_accumulation_trigger",
+    "parameters": {
+        "window": 7
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "whale_accumulation_trigger",
+  "parameters": {
+    "window": 7
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="whale_net_accumulation" description="FILTER - requires WhaleNetInflow">
+
+Check whether whales were net accumulators over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Number of bars to sum |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "whale_net_accumulation",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "whale_net_accumulation",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+</AccordionGroup>

--- a/kb_server/services/signal_service.py
+++ b/kb_server/services/signal_service.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from mangrove_kb.registry import RuleRegistry
 from mangrove_kb.docstring_parser import parse_all_signals
-from mangrove_kb.signals import momentum, trend, volume, volatility, patterns
+from mangrove_kb.signals import momentum, trend, volume, volatility, patterns, onchain
 
 _MODULE_CATEGORY = {
     "momentum": "Momentum",
@@ -16,9 +16,10 @@ _MODULE_CATEGORY = {
     "volume": "Volume",
     "volatility": "Volatility",
     "patterns": "Patterns",
+    "onchain": "On-Chain",
 }
 
-_SIGNAL_MODULES = [momentum, trend, volume, volatility, patterns]
+_SIGNAL_MODULES = [momentum, trend, volume, volatility, patterns, onchain]
 
 
 class SignalService:

--- a/mangrove_kb/signals/__init__.py
+++ b/mangrove_kb/signals/__init__.py
@@ -10,6 +10,7 @@ Signal Categories:
     - volume: OBV, CMF, MFI, VWAP, ADI, Force Index, etc.
     - volatility: Bollinger Bands, ATR, Keltner Channel, Donchian, etc.
     - patterns: Doji, Hammer, Engulfing, MorningStar, InsideBar, NR7, etc.
+    - onchain: smart-money flows, exchange flows, whale activity, holder distribution
 """
 
 # Import all signal modules to trigger registration with RuleRegistry
@@ -18,3 +19,4 @@ from mangrove_kb.signals import trend
 from mangrove_kb.signals import volume
 from mangrove_kb.signals import volatility
 from mangrove_kb.signals import patterns
+from mangrove_kb.signals import onchain

--- a/mangrove_kb/signals/onchain.py
+++ b/mangrove_kb/signals/onchain.py
@@ -1,0 +1,385 @@
+"""On-chain trading signals.
+
+This module contains signal functions based on on-chain data feeds that
+Mangrove exposes through its API (Nansen smart-money + token analytics and
+WhaleAlert transaction flows). Unlike the price/volume signals in the other
+modules, these consume alternative-data columns alongside (or instead of)
+OHLCV.
+
+The caller is responsible for populating these columns on the DataFrame,
+time-aligned to the same bars as OHLCV -- exactly the way OHLCV itself is
+supplied. Each value is the metric for that bar (snapshot or per-bar net):
+
+    SmartMoneyNetflow   Per-bar net USD flow of smart-money wallets into the
+                        token. Positive = net accumulation by smart money.
+                        (Nansen flow-intelligence / smart-money netflows.)
+    SmartMoneyHoldings  Aggregate USD held by smart-money wallets, snapshot
+                        per bar. (Nansen smart-money holdings.)
+    ExchangeNetflow     Per-bar net token flow INTO exchanges. Positive =
+                        inflow (potential sell pressure); negative = outflow
+                        (coins leaving exchanges, typically bullish).
+                        (WhaleAlert exchange-flows.)
+    WhaleNetInflow      Per-bar net whale-transaction value signed toward
+                        accumulation. Positive = net movement into
+                        non-exchange / accumulation wallets.
+                        (WhaleAlert whale-transactions.)
+    TokenHolderCount    Number of holding addresses, snapshot per bar.
+                        (Nansen token-holders.)
+    HolderConcentration Share of supply held by the top holders, 0.0-1.0.
+                        Higher = more concentrated (higher dump risk).
+                        (Nansen token-holders concentration.)
+
+See docs/data-providers.mdx for the upstream provider coverage map.
+"""
+
+import logging
+
+import pandas as pd
+
+from mangrove_kb.registry import RuleRegistry
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _clean_series(df: pd.DataFrame, column: str) -> pd.Series | None:
+    """Return the named column as a float Series with NaNs dropped.
+
+    Returns None if the column is absent or has no usable values, so callers
+    can fail closed (return False) the same way the OHLCV signals do.
+    """
+    if column not in df.columns:
+        return None
+    series = pd.to_numeric(df[column], errors="coerce").dropna()
+    if series.empty:
+        return None
+    return series
+
+
+# =============================================================================
+# Smart-money signals (Nansen)
+# =============================================================================
+
+@RuleRegistry.register("smart_money_inflow_spike")
+def smart_money_inflow_spike(df: pd.DataFrame, window: int = 20, z_threshold: float = 2.0) -> bool:
+    """
+    Detect an unusually large smart-money inflow on the latest bar.
+
+    Type: TRIGGER
+    Requires: SmartMoneyNetflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with a SmartMoneyNetflow column.
+        window (int): Lookback for the rolling baseline. Range: 5-200. Default: 20.
+        z_threshold (float): How many standard deviations above the baseline
+            mean the latest inflow must be to fire. Range: 0.5-5.0. Default: 2.0.
+
+    Returns:
+        bool: True if the latest net inflow is positive and at least
+            z_threshold standard deviations above the rolling mean.
+    """
+    series = _clean_series(df, "SmartMoneyNetflow")
+    if series is None or len(series) < window:
+        return False
+
+    recent = series.iloc[-window:]
+    last = float(series.iloc[-1])
+    std = float(recent.std())
+    if std == 0 or pd.isna(std):
+        return False
+
+    z = (last - float(recent.mean())) / std
+    return last > 0 and z >= z_threshold
+
+
+@RuleRegistry.register("smart_money_holdings_cross")
+def smart_money_holdings_cross(df: pd.DataFrame, window: int = 20) -> bool:
+    """
+    Detect smart-money holdings crossing above their moving average.
+
+    Type: TRIGGER
+    Requires: SmartMoneyHoldings
+
+    Args:
+        df (pd.DataFrame): DataFrame with a SmartMoneyHoldings column.
+        window (int): Moving-average window for the holdings baseline.
+            Range: 3-200. Default: 20.
+
+    Returns:
+        bool: True if holdings were at/below their moving average on the prior
+            bar and are above it on the latest bar.
+    """
+    series = _clean_series(df, "SmartMoneyHoldings")
+    if series is None or len(series) < window + 1:
+        return False
+
+    ma = series.rolling(window=window).mean()
+    prev, last = series.iloc[-2], series.iloc[-1]
+    prev_ma, last_ma = ma.iloc[-2], ma.iloc[-1]
+    if pd.isna(prev_ma) or pd.isna(last_ma):
+        return False
+
+    return prev <= prev_ma and last > last_ma
+
+
+@RuleRegistry.register("smart_money_net_positive")
+def smart_money_net_positive(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether smart money has been a net buyer over the window.
+
+    Type: FILTER
+    Requires: SmartMoneyNetflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with a SmartMoneyNetflow column.
+        window (int): Number of bars to sum. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the summed net inflow over the window is positive.
+    """
+    series = _clean_series(df, "SmartMoneyNetflow")
+    if series is None or len(series) < window:
+        return False
+
+    return float(series.iloc[-window:].sum()) > 0
+
+
+@RuleRegistry.register("smart_money_holdings_rising")
+def smart_money_holdings_rising(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether smart-money holdings are higher than window bars ago.
+
+    Type: FILTER
+    Requires: SmartMoneyHoldings
+
+    Args:
+        df (pd.DataFrame): DataFrame with a SmartMoneyHoldings column.
+        window (int): Lookback for the comparison. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the latest holdings exceed the value window bars ago.
+    """
+    series = _clean_series(df, "SmartMoneyHoldings")
+    if series is None or len(series) < window + 1:
+        return False
+
+    return float(series.iloc[-1]) > float(series.iloc[-1 - window])
+
+
+# =============================================================================
+# Exchange-flow signals (WhaleAlert)
+# =============================================================================
+
+@RuleRegistry.register("exchange_outflow_spike")
+def exchange_outflow_spike(df: pd.DataFrame, window: int = 20, z_threshold: float = 2.0) -> bool:
+    """
+    Detect an unusually large net outflow from exchanges on the latest bar.
+
+    Coins leaving exchanges reduce immediately sellable supply and are
+    typically read as bullish.
+
+    Type: TRIGGER
+    Requires: ExchangeNetflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with an ExchangeNetflow column (positive
+            = inflow to exchanges, negative = outflow).
+        window (int): Lookback for the rolling baseline. Range: 5-200. Default: 20.
+        z_threshold (float): How many standard deviations below the baseline
+            mean the latest flow must be to fire. Range: 0.5-5.0. Default: 2.0.
+
+    Returns:
+        bool: True if the latest flow is a net outflow (negative) and at least
+            z_threshold standard deviations below the rolling mean.
+    """
+    series = _clean_series(df, "ExchangeNetflow")
+    if series is None or len(series) < window:
+        return False
+
+    recent = series.iloc[-window:]
+    last = float(series.iloc[-1])
+    std = float(recent.std())
+    if std == 0 or pd.isna(std):
+        return False
+
+    z = (last - float(recent.mean())) / std
+    return last < 0 and z <= -z_threshold
+
+
+@RuleRegistry.register("exchange_net_outflow")
+def exchange_net_outflow(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether exchanges saw net outflows over the window.
+
+    Type: FILTER
+    Requires: ExchangeNetflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with an ExchangeNetflow column.
+        window (int): Number of bars to sum. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the summed exchange flow over the window is negative
+            (more leaving exchanges than entering).
+    """
+    series = _clean_series(df, "ExchangeNetflow")
+    if series is None or len(series) < window:
+        return False
+
+    return float(series.iloc[-window:].sum()) < 0
+
+
+# =============================================================================
+# Whale-transaction signals (WhaleAlert)
+# =============================================================================
+
+@RuleRegistry.register("whale_accumulation_trigger")
+def whale_accumulation_trigger(df: pd.DataFrame, window: int = 7) -> bool:
+    """
+    Detect whale net flow flipping to accumulation.
+
+    Type: TRIGGER
+    Requires: WhaleNetInflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with a WhaleNetInflow column.
+        window (int): Smoothing window for the net-flow moving average.
+            Range: 2-100. Default: 7.
+
+    Returns:
+        bool: True if the smoothed whale net inflow was at/below zero on the
+            prior bar and is positive on the latest bar.
+    """
+    series = _clean_series(df, "WhaleNetInflow")
+    if series is None or len(series) < window + 1:
+        return False
+
+    ma = series.rolling(window=window).mean()
+    prev_ma, last_ma = ma.iloc[-2], ma.iloc[-1]
+    if pd.isna(prev_ma) or pd.isna(last_ma):
+        return False
+
+    return prev_ma <= 0 and last_ma > 0
+
+
+@RuleRegistry.register("whale_net_accumulation")
+def whale_net_accumulation(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether whales were net accumulators over the window.
+
+    Type: FILTER
+    Requires: WhaleNetInflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with a WhaleNetInflow column.
+        window (int): Number of bars to sum. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the summed whale net inflow over the window is positive.
+    """
+    series = _clean_series(df, "WhaleNetInflow")
+    if series is None or len(series) < window:
+        return False
+
+    return float(series.iloc[-window:].sum()) > 0
+
+
+# =============================================================================
+# Holder-distribution signals (Nansen)
+# =============================================================================
+
+@RuleRegistry.register("holder_growth_breakout")
+def holder_growth_breakout(df: pd.DataFrame, window: int = 30) -> bool:
+    """
+    Detect the holder count making a new high over the window.
+
+    Type: TRIGGER
+    Requires: TokenHolderCount
+
+    Args:
+        df (pd.DataFrame): DataFrame with a TokenHolderCount column.
+        window (int): Lookback for the prior high. Range: 3-365. Default: 30.
+
+    Returns:
+        bool: True if the latest holder count strictly exceeds the highest
+            count over the preceding window bars.
+    """
+    series = _clean_series(df, "TokenHolderCount")
+    if series is None or len(series) < window + 1:
+        return False
+
+    prior_high = float(series.iloc[-1 - window:-1].max())
+    return float(series.iloc[-1]) > prior_high
+
+
+@RuleRegistry.register("holder_base_expanding")
+def holder_base_expanding(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether the holder base grew over the window.
+
+    Type: FILTER
+    Requires: TokenHolderCount
+
+    Args:
+        df (pd.DataFrame): DataFrame with a TokenHolderCount column.
+        window (int): Lookback for the comparison. Range: 2-365. Default: 14.
+
+    Returns:
+        bool: True if the latest holder count exceeds the count window bars ago.
+    """
+    series = _clean_series(df, "TokenHolderCount")
+    if series is None or len(series) < window + 1:
+        return False
+
+    return float(series.iloc[-1]) > float(series.iloc[-1 - window])
+
+
+@RuleRegistry.register("holder_concentration_low")
+def holder_concentration_low(df: pd.DataFrame, threshold: float = 0.5) -> bool:
+    """
+    Check whether top-holder concentration is below a threshold.
+
+    Lower concentration means supply is more widely distributed and less
+    exposed to a single-wallet dump.
+
+    Type: FILTER
+    Requires: HolderConcentration
+
+    Args:
+        df (pd.DataFrame): DataFrame with a HolderConcentration column (0.0-1.0).
+        threshold (float): Maximum acceptable top-holder share. Range: 0.0-1.0.
+            Default: 0.5.
+
+    Returns:
+        bool: True if the latest concentration is below the threshold.
+    """
+    series = _clean_series(df, "HolderConcentration")
+    if series is None:
+        return False
+
+    return float(series.iloc[-1]) < threshold
+
+
+@RuleRegistry.register("holder_concentration_falling")
+def holder_concentration_falling(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether top-holder concentration is declining over the window.
+
+    Type: FILTER
+    Requires: HolderConcentration
+
+    Args:
+        df (pd.DataFrame): DataFrame with a HolderConcentration column (0.0-1.0).
+        window (int): Lookback for the comparison. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the latest concentration is below the value window bars ago.
+    """
+    series = _clean_series(df, "HolderConcentration")
+    if series is None or len(series) < window + 1:
+        return False
+
+    return float(series.iloc[-1]) < float(series.iloc[-1 - window])

--- a/scripts/generate-signal-catalog.py
+++ b/scripts/generate-signal-catalog.py
@@ -27,7 +27,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import mangrove_kb  # noqa: E402
 from mangrove_kb.registry import RuleRegistry  # noqa: E402
 from mangrove_kb.docstring_parser import parse_all_signals  # noqa: E402
-from mangrove_kb.signals import momentum, trend, volume, volatility, patterns  # noqa: E402
+from mangrove_kb.signals import momentum, trend, volume, volatility, patterns, onchain  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Category classification
@@ -39,6 +39,7 @@ MODULE_CATEGORY = {
     "volume": "Volume",
     "volatility": "Volatility",
     "patterns": "Patterns",
+    "onchain": "On-Chain",
 }
 
 
@@ -154,7 +155,7 @@ def generate_catalog():
     """Generate the docs/signals/catalog.mdx file."""
 
     # Parse all signals
-    signal_modules = [momentum, trend, volume, volatility, patterns]
+    signal_modules = [momentum, trend, volume, volatility, patterns, onchain]
     all_signals = parse_all_signals(signal_modules)
 
     # Attach category info
@@ -170,7 +171,7 @@ def generate_catalog():
         })
 
     # Sort by category then name
-    category_order = ["Momentum", "Trend", "Volume", "Volatility", "Patterns", "Other"]
+    category_order = ["Momentum", "Trend", "Volume", "Volatility", "Patterns", "On-Chain", "Other"]
     enriched.sort(key=lambda s: (category_order.index(s["category"]) if s["category"] in category_order else 99, s["name"]))
 
     # Group by category
@@ -252,7 +253,7 @@ def generate_catalog():
     index_lines = []
     index_lines.append("---")
     index_lines.append('title: "Signal Catalog"')
-    index_lines.append(f'description: "Index of all {total} trading signals across 5 categories."')
+    index_lines.append(f'description: "Index of all {total} trading signals across {len(grouped)} categories."')
     index_lines.append("---")
     index_lines.append("")
     index_lines.append("# Signal Catalog")

--- a/tests/test_api_signals.py
+++ b/tests/test_api_signals.py
@@ -12,7 +12,7 @@ class TestSignalEndpoints:
         resp = client.get("/api/signals")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 223
+        assert data["total"] == 235
 
     def test_list_signals_filter_category(self):
         resp = client.get("/api/signals?category=Momentum")
@@ -22,7 +22,7 @@ class TestSignalEndpoints:
     def test_list_signals_filter_type(self):
         resp = client.get("/api/signals?signal_type=TRIGGER")
         assert resp.status_code == 200
-        assert resp.json()["total"] == 108
+        assert resp.json()["total"] == 113
 
     def test_get_signal(self):
         resp = client.get("/api/signals/rsi_oversold")

--- a/tests/test_onchain_signals.py
+++ b/tests/test_onchain_signals.py
@@ -1,0 +1,217 @@
+"""
+Validation and behavioral tests for on-chain signals.
+
+Parses all signal functions in the onchain module using the docstring parser
+and validates structural correctness (required tags, param types, ranges,
+defaults), then exercises each signal against synthetic on-chain data to
+confirm it fires (and stays quiet) under the expected conditions.
+
+Usage:
+    pytest tests/test_onchain_signals.py -v
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mangrove_kb.registry import RuleRegistry
+from mangrove_kb.signals import onchain as onchain_signals
+from mangrove_kb.docstring_parser import parse_all_signals
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def parsed_onchain() -> dict:
+    """Parse all on-chain signal docstrings."""
+    return parse_all_signals([onchain_signals])
+
+
+# ---------------------------------------------------------------------------
+# Coverage
+# ---------------------------------------------------------------------------
+
+class TestOnChainCoverage:
+    """Verify all on-chain signals are discovered and parseable."""
+
+    EXPECTED_TRIGGER_COUNT = 5
+    EXPECTED_FILTER_COUNT = 7
+    EXPECTED_TOTAL = EXPECTED_TRIGGER_COUNT + EXPECTED_FILTER_COUNT
+
+    def test_total_count(self, parsed_onchain):
+        assert len(parsed_onchain) == self.EXPECTED_TOTAL, (
+            f"Expected {self.EXPECTED_TOTAL} on-chain signals, "
+            f"got {len(parsed_onchain)}: {sorted(parsed_onchain.keys())}"
+        )
+
+    def test_trigger_count(self, parsed_onchain):
+        triggers = [k for k, v in parsed_onchain.items() if v["type"] == "TRIGGER"]
+        assert len(triggers) == self.EXPECTED_TRIGGER_COUNT, sorted(triggers)
+
+    def test_filter_count(self, parsed_onchain):
+        filters = [k for k, v in parsed_onchain.items() if v["type"] == "FILTER"]
+        assert len(filters) == self.EXPECTED_FILTER_COUNT, sorted(filters)
+
+    def test_all_registered(self, parsed_onchain):
+        for name in parsed_onchain:
+            assert name in RuleRegistry._registry, (
+                f"Signal '{name}' parsed but not in RuleRegistry"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Structural validation
+# ---------------------------------------------------------------------------
+
+class TestOnChainMetadata:
+    """Validate required fields and parameter metadata."""
+
+    VALID_COLUMNS = {
+        "SmartMoneyNetflow",
+        "SmartMoneyHoldings",
+        "ExchangeNetflow",
+        "WhaleNetInflow",
+        "TokenHolderCount",
+        "HolderConcentration",
+    }
+
+    def test_type_and_requires(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            assert meta["type"] in ("TRIGGER", "FILTER"), name
+            assert isinstance(meta["requires"], list) and meta["requires"], (
+                f"{name} must require at least one column"
+            )
+            for col in meta["requires"]:
+                assert col in self.VALID_COLUMNS, (
+                    f"{name} requires unknown column: '{col}'"
+                )
+
+    def test_description_present(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            assert len(meta["description"]) > 10, name
+
+    def test_numeric_params_have_valid_range(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            for pname, pspec in meta.get("params", {}).items():
+                if pspec["type"] in ("int", "float"):
+                    assert "min" in pspec and "max" in pspec, f"{name}.{pname}"
+                    assert pspec["min"] < pspec["max"], f"{name}.{pname}"
+
+    def test_defaults_within_range(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            for pname, pspec in meta.get("params", {}).items():
+                if "default" in pspec and "min" in pspec:
+                    assert pspec["min"] <= pspec["default"] <= pspec["max"], (
+                        f"{name}.{pname} default {pspec['default']} out of range"
+                    )
+
+    def test_df_excluded(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            assert "df" not in meta.get("params", {}), name
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests
+# ---------------------------------------------------------------------------
+
+def _evaluate(name, df, params=None):
+    return RuleRegistry.evaluate({"name": name, "params": params or {}}, df)
+
+
+class TestOnChainBehavior:
+    """Exercise each signal against synthetic data with a known outcome."""
+
+    def test_smart_money_inflow_spike(self):
+        flow = [10.0] * 25 + [500.0]  # large spike on the last bar
+        df = pd.DataFrame({"SmartMoneyNetflow": flow})
+        assert _evaluate("smart_money_inflow_spike", df, {"window": 20, "z_threshold": 2.0})
+
+        flat = pd.DataFrame({"SmartMoneyNetflow": [10.0] * 26})
+        assert not _evaluate("smart_money_inflow_spike", flat)
+
+    def test_smart_money_holdings_cross(self):
+        # Holdings sit below their MA then jump above it on the last bar.
+        holdings = [100.0] * 25 + [400.0]
+        df = pd.DataFrame({"SmartMoneyHoldings": holdings})
+        assert _evaluate("smart_money_holdings_cross", df, {"window": 20})
+
+    def test_smart_money_net_positive(self):
+        assert _evaluate(
+            "smart_money_net_positive",
+            pd.DataFrame({"SmartMoneyNetflow": [5.0] * 14}),
+        )
+        assert not _evaluate(
+            "smart_money_net_positive",
+            pd.DataFrame({"SmartMoneyNetflow": [-5.0] * 14}),
+        )
+
+    def test_smart_money_holdings_rising(self):
+        rising = pd.DataFrame({"SmartMoneyHoldings": list(np.arange(20, dtype=float))})
+        assert _evaluate("smart_money_holdings_rising", rising, {"window": 14})
+        falling = pd.DataFrame({"SmartMoneyHoldings": list(np.arange(20, 0, -1, dtype=float))})
+        assert not _evaluate("smart_money_holdings_rising", falling, {"window": 14})
+
+    def test_exchange_outflow_spike(self):
+        flow = [0.0] * 25 + [-500.0]  # large outflow on the last bar
+        df = pd.DataFrame({"ExchangeNetflow": flow})
+        assert _evaluate("exchange_outflow_spike", df, {"window": 20, "z_threshold": 2.0})
+        # A large *inflow* must not fire this bullish signal.
+        inflow = pd.DataFrame({"ExchangeNetflow": [0.0] * 25 + [500.0]})
+        assert not _evaluate("exchange_outflow_spike", inflow)
+
+    def test_exchange_net_outflow(self):
+        assert _evaluate(
+            "exchange_net_outflow",
+            pd.DataFrame({"ExchangeNetflow": [-3.0] * 14}),
+        )
+        assert not _evaluate(
+            "exchange_net_outflow",
+            pd.DataFrame({"ExchangeNetflow": [3.0] * 14}),
+        )
+
+    def test_whale_accumulation_trigger(self):
+        # Net flow negative for a stretch, then positive bars fill the window
+        # so the smoothed flow crosses zero on the last bar.
+        flow = [-10.0] * 10 + [5.0, 5.0, 5.0]
+        df = pd.DataFrame({"WhaleNetInflow": flow})
+        assert _evaluate("whale_accumulation_trigger", df, {"window": 3})
+
+    def test_whale_net_accumulation(self):
+        assert _evaluate(
+            "whale_net_accumulation",
+            pd.DataFrame({"WhaleNetInflow": [2.0] * 14}),
+        )
+        assert not _evaluate(
+            "whale_net_accumulation",
+            pd.DataFrame({"WhaleNetInflow": [-2.0] * 14}),
+        )
+
+    def test_holder_growth_breakout(self):
+        counts = list(range(100, 130)) + [200]  # new high on the last bar
+        df = pd.DataFrame({"TokenHolderCount": [float(c) for c in counts]})
+        assert _evaluate("holder_growth_breakout", df, {"window": 30})
+        flat = pd.DataFrame({"TokenHolderCount": [100.0] * 31})
+        assert not _evaluate("holder_growth_breakout", flat, {"window": 30})
+
+    def test_holder_base_expanding(self):
+        rising = pd.DataFrame({"TokenHolderCount": list(np.arange(100, 120, dtype=float))})
+        assert _evaluate("holder_base_expanding", rising, {"window": 14})
+
+    def test_holder_concentration_low(self):
+        low = pd.DataFrame({"HolderConcentration": [0.3]})
+        assert _evaluate("holder_concentration_low", low, {"threshold": 0.5})
+        high = pd.DataFrame({"HolderConcentration": [0.8]})
+        assert not _evaluate("holder_concentration_low", high, {"threshold": 0.5})
+
+    def test_holder_concentration_falling(self):
+        falling = pd.DataFrame({"HolderConcentration": list(np.linspace(0.8, 0.4, 20))})
+        assert _evaluate("holder_concentration_falling", falling, {"window": 14})
+
+    def test_missing_column_returns_false(self):
+        """Every signal must fail closed when its column is absent."""
+        empty = pd.DataFrame({"Close": [1.0, 2.0, 3.0]})
+        for name, meta in parse_all_signals([onchain_signals]).items():
+            result = _evaluate(name, empty)
+            assert result is False, f"{name} should return False on missing data"

--- a/tests/test_signal_service.py
+++ b/tests/test_signal_service.py
@@ -8,7 +8,7 @@ class TestSignalServiceMetadata:
 
     def test_list_signals_returns_all(self):
         signals = self.service.list_signals()
-        assert len(signals) == 223
+        assert len(signals) == 235
 
     def test_list_signals_filter_by_category(self):
         momentum = self.service.list_signals(category="Momentum")
@@ -16,7 +16,7 @@ class TestSignalServiceMetadata:
 
     def test_list_signals_filter_by_type(self):
         triggers = self.service.list_signals(signal_type="TRIGGER")
-        assert len(triggers) == 108
+        assert len(triggers) == 113
 
     def test_get_signal_exists(self):
         signal = self.service.get_signal("rsi_oversold")


### PR DESCRIPTION
## Summary

Adds a new **On-Chain** signal category to the signal library. Until now every
one of the library's signals consumed only OHLCV (price/volume), even though the
platform pays for rich on-chain data via Nansen and WhaleAlert. This PR closes
that gap with 12 signals that turn smart-money flows, exchange/whale activity,
and holder distribution into TRIGGER/FILTER indicators.

## Design

Following the existing convention, on-chain signals **declare the columns they
need** via `Requires:` and operate on a time-indexed DataFrame supplied by the
caller — exactly how OHLCV signals work today. No data-fetching code or provider
coupling is added to this repo; MangroveAI remains responsible for populating
the columns, time-aligned to OHLCV bars.

New alternative-data columns (sourced from the feeds in `docs/data-providers.mdx`):

| Column | Source | Meaning |
|---|---|---|
| `SmartMoneyNetflow` | Nansen | Per-bar net USD flow of smart-money wallets (+ = accumulation) |
| `SmartMoneyHoldings` | Nansen | Aggregate smart-money holdings (USD), snapshot per bar |
| `ExchangeNetflow` | WhaleAlert | Net token flow into exchanges (+ = inflow/sell pressure) |
| `WhaleNetInflow` | WhaleAlert | Net whale-transaction value toward accumulation |
| `TokenHolderCount` | Nansen | Number of holding addresses |
| `HolderConcentration` | Nansen | Top-holder share of supply, 0.0–1.0 |

## Signals (12: 5 TRIGGER, 7 FILTER)

**TRIGGER:** `smart_money_inflow_spike`, `smart_money_holdings_cross`,
`exchange_outflow_spike`, `whale_accumulation_trigger`, `holder_growth_breakout`

**FILTER:** `smart_money_net_positive`, `smart_money_holdings_rising`,
`exchange_net_outflow`, `whale_net_accumulation`, `holder_base_expanding`,
`holder_concentration_low`, `holder_concentration_falling`

## Wiring

- Registered the new module in `mangrove_kb.signals` and in `SignalService`
  (new `On-Chain` category) — so the signals surface on `/api/signals` and MCP
  automatically.
- Updated the signal catalog generator and regenerated catalog pages; added the
  On-Chain page to the Mintlify nav (`docs/mint.json`).
- Updated `CLAUDE.md` signal facts: 235 signals (113 TRIGGER, 122 FILTER) across
  6 categories.

## Tests

- New `tests/test_onchain_signals.py` — **22 tests**: coverage, metadata/docstring
  validation, per-signal behavior (fires when it should, stays quiet otherwise),
  and fail-closed behavior when the data column is missing.
- Updated existing count-based assertions (223→235 total, 108→113 TRIGGER).
- Full suite green locally (excluding the pre-existing `fastmcp`/external-JSON
  environment skips, which are unrelated to this change).

## Notes

- Signal counts: **235** total (was 223). New category is purely additive — no
  existing signal behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
