### PR TITLE
docs: oracle-backtest page + SIEVE→paper guide + generated MCP tools catalog

### DIFF
--- a/docs/api-reference/oracle-backtest.mdx
+++ b/docs/api-reference/oracle-backtest.mdx
@@ -1,0 +1,339 @@
+---
+title: "Oracle backtest & data query"
+description: "Single-strategy backtests (sync, async, and bulk) plus the BigQuery-backed corpus query for reading historical sweep results and OHLCV bars."
+---
+
+# Oracle backtest & data query
+
+This page covers the **single-strategy** subset of the Oracle engine plus the corpus query API. For multi-strategy parameter sweeps see [Experiments](/api-reference/experiments); for the curated paper-trading dashboard surface see [Deployed strategies](/api-reference/oracle-deployed).
+
+<Note>
+**Disambiguation.** `/api/v1/oracle/backtest*` (this page) runs through Mangrove Oracle — a faster engine optimised for batch and sweep workloads. `/api/v1/backtesting/run` (see [Backtesting](/api-reference/backtesting)) runs through the legacy MangroveAI strategy engine. New code should target the Oracle endpoints documented here.
+</Note>
+
+All endpoints sit under `/api/v1/oracle/` on the MangroveAI gateway and are forwarded to the Oracle engine with your identity attached. Auth: API key or JWT, same as the rest of `/api/v1/*`.
+
+## Endpoints
+
+| Method | Path | SDK method | Billable |
+|---|---|---|---|
+| `POST` | `/api/v1/oracle/backtest` | `client.oracle.backtest(req)` | `oracle_backtest` (1 unit; x402 $0.10) |
+| `POST` | `/api/v1/oracle/backtest/async` | `client.oracle.backtest_async(req)` | `oracle_backtest` (1 unit; x402 $0.10) |
+| `GET`  | `/api/v1/oracle/backtest/async/{backtest_id}` | `client.oracle.backtest_poll(id)` | free (metadata) |
+| `POST` | `/api/v1/oracle/backtest/bulk` | `client.oracle.backtest_bulk(req)` | `oracle_backtest` (1 unit per call; x402 $0.10) |
+| `POST` | `/api/v1/oracle/data/query` | `client.oracle.data_query(req)` | `oracle_data_query` (1 unit; x402 $0.01) |
+
+Each HTTP call counts as one billable unit regardless of how many trades the backtest produces or how many rows the query returns. The bulk endpoint runs up to 99 strategies in one call against shared OHLCV fetches — pay for the request, not for the fan-out.
+
+## Synchronous single-strategy backtest
+
+`POST /api/v1/oracle/backtest`
+
+Runs one strategy against one (asset, interval) pair and blocks until the engine returns the full result. Typical wall-clock is **30–120 seconds** depending on the date range and signal complexity; tune your HTTP client timeout accordingly (the SDK defaults to 180s).
+
+### Request
+
+```json
+{
+  "asset": "BTC",
+  "interval": "1h",
+  "strategy_json": "{ \"entry\": {...}, \"exit\": {...} }",
+  "initial_balance": 10000,
+  "max_open_positions": 1,
+  "max_risk_per_trade": 0.02
+}
+```
+
+Required: `asset`, `interval`, `strategy_json` (a JSON-encoded MangroveAI Strategy object). All risk-management / execution fields are optional — the server fills any missing field from the canonical `trading_defaults.json`, so a minimal request is sufficient for exploratory work. See the SDK's `OracleBacktestRequest` model for the full surface.
+
+### Response
+
+```json
+{
+  "success": true,
+  "metrics": {
+    "sharpe": 1.42, "sortino": 1.88, "calmar": 0.94,
+    "max_drawdown": 0.31, "win_rate": 0.58, "total_trades": 47,
+    "final_balance": 11820.5, "...": "..."
+  },
+  "execution_time_seconds": 42.1,
+  "trade_count": 47,
+  "strategy_names": ["rsi_oversold + ema_uptrend / take_profit_5pct"],
+  "trade_history": [{"...": "..."}],
+  "denied_signals": []
+}
+```
+
+`denied_signals` lists signals the engine refused (e.g. unsupported columns, malformed params). Inspect this when `total_trades` comes back lower than expected.
+
+### Example
+
+<CodeGroup>
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/backtest \
+  -H "Authorization: Bearer $MANGROVE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "asset": "BTC",
+    "interval": "1h",
+    "strategy_json": "{...}",
+    "initial_balance": 10000
+  }'
+```
+
+```python Python
+from mangrove_ai import MangroveAI
+from mangrove_ai.models.oracle import OracleBacktestRequest
+
+client = MangroveAI(api_key="prod_…")
+
+result = client.oracle.backtest(OracleBacktestRequest(
+    asset="BTC",
+    interval="1h",
+    strategy_json='{...}',
+    initial_balance=10000,
+))
+
+print(f"Sharpe: {result.metrics['sharpe']:.2f}")
+print(f"Trades: {result.trade_count}")
+```
+</CodeGroup>
+
+## Async submit + poll
+
+When 30–120s of blocking is too long — for example, dispatching dozens of backtests from a worker that should remain responsive — use the async pair.
+
+### Submit
+
+`POST /api/v1/oracle/backtest/async`
+
+Same request body as the sync endpoint. Returns immediately:
+
+```json
+{ "backtest_id": "bkt_20260603T140212548Z", "status": "queued" }
+```
+
+### Poll
+
+`GET /api/v1/oracle/backtest/async/{backtest_id}`
+
+```json
+{
+  "backtest_id": "bkt_20260603T140212548Z",
+  "status": "running",
+  "metrics": null,
+  "trade_history": null
+}
+```
+
+`status` transitions `queued` → `running` → `completed` (or `failed`). Once `completed`, the response carries the full `metrics`/`trade_history`/`trade_count` shape of the synchronous response. Polling the endpoint is **free** (metadata-tier); typical poll interval is 5–10 seconds.
+
+### Example
+
+<CodeGroup>
+```bash cURL
+# Submit
+ID=$(curl -s -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/backtest/async \
+  -H "Authorization: Bearer $MANGROVE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"asset":"BTC","interval":"1h","strategy_json":"{...}"}' \
+  | jq -r .backtest_id)
+
+# Poll
+while true; do
+  status=$(curl -s -H "Authorization: Bearer $MANGROVE_API_KEY" \
+    https://api.mangrovedeveloper.ai/api/v1/oracle/backtest/async/$ID | jq -r .status)
+  [[ "$status" == "completed" || "$status" == "failed" ]] && break
+  sleep 5
+done
+```
+
+```python Python
+import time
+
+submission = client.oracle.backtest_async(OracleBacktestRequest(
+    asset="BTC", interval="1h", strategy_json='{...}',
+))
+
+while True:
+    status = client.oracle.backtest_poll(submission.backtest_id)
+    if status.status in ("completed", "failed"):
+        break
+    time.sleep(5)
+
+print(status.metrics)
+```
+</CodeGroup>
+
+## Bulk
+
+`POST /api/v1/oracle/backtest/bulk`
+
+Evaluates many strategies over a **shared date range** with shared OHLCV fetches. One HTTP call, one bill. Up to 99 strategies per request.
+
+This is the right endpoint when you have a SIEVE-filtered shortlist and want to score the survivors quickly — see [SIEVE → live strategy](/guides/sieve-to-live-strategy) for the full workflow.
+
+### Request
+
+```json
+{
+  "start_date": "2024-01-01",
+  "end_date":   "2024-12-31",
+  "initial_balance": 10000,
+  "min_balance_threshold": 100,
+  "min_trade_amount": 10,
+  "max_open_positions": 1,
+  "max_trades_per_day": 5,
+  "max_risk_per_trade": 0.02,
+  "max_units_per_trade": 1.0,
+  "max_trade_amount": 5000,
+  "volatility_window": 14,
+  "strategies": [
+    { "asset": "BTC", "interval": "1h", "strategy_json": "{...}" },
+    { "asset": "BTC", "interval": "1h", "strategy_json": "{...}" }
+  ]
+}
+```
+
+All bulk-level execution / risk fields are required; per-strategy fields are not (the server uses the bulk-level defaults). Strategies that share an `(asset, interval)` pair reuse a single OHLCV fetch — the response's `data_fetches` field reports how many unique fetches the engine did.
+
+### Response
+
+```json
+{
+  "success": true,
+  "results": [
+    { "metrics": {...}, "trade_count": 47,  "strategy_index": 0 },
+    { "metrics": {...}, "trade_count": 12,  "strategy_index": 1 }
+  ],
+  "data_fetches": 1,
+  "total_execution_time_seconds": 51.2
+}
+```
+
+### Example
+
+<CodeGroup>
+```python Python
+from mangrove_ai.models.oracle import OracleBulkBacktestRequest
+
+result = client.oracle.backtest_bulk(OracleBulkBacktestRequest(
+    start_date="2024-01-01",
+    end_date="2024-12-31",
+    initial_balance=10000,
+    min_balance_threshold=100,
+    min_trade_amount=10,
+    max_open_positions=1,
+    max_trades_per_day=5,
+    max_risk_per_trade=0.02,
+    max_units_per_trade=1.0,
+    max_trade_amount=5000,
+    volatility_window=14,
+    strategies=[
+        {"asset": "BTC", "interval": "1h", "strategy_json": "{...}"},
+        {"asset": "BTC", "interval": "1h", "strategy_json": "{...}"},
+    ],
+))
+
+for i, r in enumerate(result.results):
+    print(f"Strategy {i}: sharpe={r['metrics'].get('sharpe'):.2f} trades={r['trade_count']}")
+```
+</CodeGroup>
+
+## Data query (corpus)
+
+`POST /api/v1/oracle/data/query`
+
+Direct access to Oracle's BigQuery-backed corpus of historical backtest results and OHLCV bars. The proxy whitelists tables and filter operators server-side so the surface stays narrow.
+
+### Whitelist
+
+| Concern | Allowed values |
+|---|---|
+| Tables | `results`, `ohlcv` |
+| Filter ops | `=`, `!=`, `>`, `>=`, `<`, `<=`, `in`, `between` |
+| Tenancy | `WHERE org_id = <caller's org>` is injected by Oracle. Cross-tenant reads are not possible by construction. |
+
+### Request
+
+```json
+{
+  "table": "results",
+  "select": ["strategy_name", "asset", "interval", "metrics_sharpe", "trade_count"],
+  "filters": [
+    { "col": "asset", "op": "=", "value": "BTC" },
+    { "col": "interval", "op": "=", "value": "1h" },
+    { "col": "metrics_sharpe", "op": ">", "value": 1.0 }
+  ],
+  "order_by": ["metrics_sharpe DESC"],
+  "limit": 50,
+  "offset": 0
+}
+```
+
+`select` is required; `filters` defaults to `[]`. `order_by` accepts SQL-style column expressions. Default `limit` is 100; the engine caps at 1000.
+
+### Response
+
+```json
+{
+  "rows": [
+    {"strategy_name": "...", "asset": "BTC", "metrics_sharpe": 1.84, "trade_count": 91},
+    {"...": "..."}
+  ],
+  "row_count": 23,
+  "table": "results"
+}
+```
+
+### Example
+
+<CodeGroup>
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/data/query \
+  -H "Authorization: Bearer $MANGROVE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "table": "results",
+    "select": ["strategy_name","metrics_sharpe","trade_count"],
+    "filters": [{"col":"asset","op":"=","value":"BTC"}],
+    "order_by": ["metrics_sharpe DESC"],
+    "limit": 20
+  }'
+```
+
+```python Python
+from mangrove_ai.models.oracle import DataQueryRequest, DataQueryFilter
+
+result = client.oracle.data_query(DataQueryRequest(
+    table="results",
+    select=["strategy_name", "metrics_sharpe", "trade_count"],
+    filters=[DataQueryFilter(col="asset", op="=", value="BTC")],
+    order_by=["metrics_sharpe DESC"],
+    limit=20,
+))
+
+for row in result.rows:
+    print(row)
+```
+</CodeGroup>
+
+## Costs
+
+| Action | Quota unit | x402 price |
+|---|---|---|
+| Each `POST /backtest`, `POST /backtest/async`, or `POST /backtest/bulk` call | `oracle_backtest` (1 unit) | $0.10 |
+| `POST /data/query` | `oracle_data_query` (1 unit) | $0.01 |
+| `GET /backtest/async/{id}` poll | free (metadata) | — |
+
+The bulk endpoint amortises efficiently: one billed call fans out internally to up to 99 strategy evaluations. The async endpoint costs the same as sync — pick async when the wall-clock matters for your caller, not to save on billing.
+
+See [Pricing](/api-reference/overview#pricing) for tier monthly caps on `oracle_backtest` / `oracle_data_query` resource buckets.
+
+## Related
+
+- [Experiments](/api-reference/experiments) — multi-strategy parameter sweeps with managed lifecycle (`create` → `validate` → `launch` → poll results). Use experiments when the parameter grid is larger than a single bulk request can hold.
+- [SIEVE classifier](/api-reference/sieve) — score 1–99 candidate strategies in milliseconds before paying for backtests. Pre-filter aggressively when the candidate set is hundreds wide.
+- [Deployed strategies](/api-reference/oracle-deployed) — live execution state for curated paper-trading strategies, not for ad-hoc backtests.
+- [SIEVE → live strategy walkthrough](/guides/sieve-to-live-strategy) — end-to-end demo combining list-signals, SIEVE, bulk-backtest, and `update_status('paper')`.
+- [`mangroveai` Python SDK](/sdks/mangroveai) — `client.oracle.backtest(...)`, `backtest_async(...)`, `backtest_poll(...)`, `backtest_bulk(...)`, `data_query(...)` are typed wrappers as of SDK v1.4.0.

--- a/docs/api-reference/oracle-backtest.mdx
+++ b/docs/api-reference/oracle-backtest.mdx
@@ -13,23 +13,45 @@ This page covers the **single-strategy** subset of the Oracle engine plus the co
 
 All endpoints sit under `/api/v1/oracle/` on the MangroveAI gateway and are forwarded to the Oracle engine with your identity attached. Auth: API key or JWT, same as the rest of `/api/v1/*`.
 
+<Warning>
+**SDK ↔ server contract note.** The `mangroveai` Python SDK 1.4.0 types the risk-management fields on `OracleBacktestRequest` / `OracleBulkBacktestRequest` as `Optional` with `None` defaults. The **server requires every one of those fields explicitly** — the SDK comment "server-default-fillable" is currently aspirational, not honored. Pass them in full until the SDK typing is reconciled. The `DataQueryResponse` Pydantic model also defines a `table: str` field that the actual server response does NOT include; that wrapper will fail validation on every successful 200. The examples below use raw HTTP for these three endpoints so the demos actually run. SDK-typed examples will return once the SDK matches the server contract.
+</Warning>
+
 ## Endpoints
 
-| Method | Path | SDK method | Billable |
-|---|---|---|---|
-| `POST` | `/api/v1/oracle/backtest` | `client.oracle.backtest(req)` | `oracle_backtest` (1 unit; x402 $0.10) |
-| `POST` | `/api/v1/oracle/backtest/async` | `client.oracle.backtest_async(req)` | `oracle_backtest` (1 unit; x402 $0.10) |
-| `GET`  | `/api/v1/oracle/backtest/async/{backtest_id}` | `client.oracle.backtest_poll(id)` | free (metadata) |
-| `POST` | `/api/v1/oracle/backtest/bulk` | `client.oracle.backtest_bulk(req)` | `oracle_backtest` (1 unit per call; x402 $0.10) |
-| `POST` | `/api/v1/oracle/data/query` | `client.oracle.data_query(req)` | `oracle_data_query` (1 unit; x402 $0.01) |
+| Method | Path | Meter | x402 price | Quota counter |
+|---|---|---|---|---|
+| `POST` | `/api/v1/oracle/backtest` | `oracle_backtest` | $0.10 | `api_calls` |
+| `POST` | `/api/v1/oracle/backtest/async` | `oracle_backtest` | $0.10 | `api_calls` |
+| `GET`  | `/api/v1/oracle/backtest/async/{backtest_id}` | `oracle_backtest` | $0.10 | `api_calls` |
+| `POST` | `/api/v1/oracle/backtest/bulk` | `oracle_backtest` | $0.10 | `api_calls` |
+| `POST` | `/api/v1/oracle/data/query` | `oracle_data_query` | $0.10 | `oracle_data_queries` |
 
-Each HTTP call counts as one billable unit regardless of how many trades the backtest produces or how many rows the query returns. The bulk endpoint runs up to 99 strategies in one call against shared OHLCV fetches — pay for the request, not for the fan-out.
+Every HTTP call counts as **1 billable unit**, regardless of how many strategies the bulk endpoint fans out to or how many rows the query returns. Async poll requests are billed at the same rate as the submit — design your polling loop accordingly (5-10s intervals are conventional). The bulk endpoint amortises efficiently: a single billed call can drive up to 99 strategies through shared OHLCV fetches.
+
+Pricing source-of-truth: `MangroveAI/src/MangroveAI/domains/backtesting/oracle_proxy.py::_PROXY_METERING`.
 
 ## Synchronous single-strategy backtest
 
 `POST /api/v1/oracle/backtest`
 
-Runs one strategy against one (asset, interval) pair and blocks until the engine returns the full result. Typical wall-clock is **30–120 seconds** depending on the date range and signal complexity; tune your HTTP client timeout accordingly (the SDK defaults to 180s).
+Runs one strategy against one (asset, interval) pair and blocks until the engine returns the full result. Typical wall-clock is **30–120 seconds** depending on the date range; the SDK default HTTP timeout is 180s.
+
+### Required fields
+
+18 top-level fields, enforced by `MangroveOracle/src/api/routes/backtest.py::run_backtest`:
+
+- `asset`, `strategy_json` — what to run
+- `initial_balance`, `min_balance_threshold`, `min_trade_amount` — account
+- `max_open_positions`, `max_trades_per_day`, `max_risk_per_trade`, `max_units_per_trade`, `max_trade_amount` — risk caps
+- `volatility_window`, `target_volatility`, `volatility_mode`, `enable_volatility_adjustment` — volatility-aware sizing
+- `cooldown_bars`, `daily_momentum_limit`, `weekly_momentum_limit` — circuit breakers
+
+Plus a top-level `execution_config` containing at least `position_size_calc: "v2"` (`v1` legacy also accepted). The engine raises `position_size_calc is required` if it's missing.
+
+Optional: `interval` (defaults to `"1h"`), `lookback_months`, `start_date`, `end_date` (provide one of: explicit start+end, start alone (defaults end to now), or `lookback_months`).
+
+Pull canonical defaults from `GET /api/v1/oracle/exec-config/defaults` to skip hand-rolling these.
 
 ### Request
 
@@ -37,14 +59,36 @@ Runs one strategy against one (asset, interval) pair and blocks until the engine
 {
   "asset": "BTC",
   "interval": "1h",
-  "strategy_json": "{ \"entry\": {...}, \"exit\": {...} }",
+  "strategy_json": "{ \"asset\": \"BTC\", \"interval\": \"1h\", \"entry\": [...], \"exit\": [...] }",
+  "lookback_months": 3,
+
+  "execution_config": {
+    "position_size_calc": "v2",
+    "reward_factor": 2,
+    "atr_period": 14,
+    "atr_volatility_factor": 2.0,
+    "atr_short_weight": 0.95,
+    "atr_long_weight": 0.05,
+    "atr_cap_multiplier": 2.1
+  },
+
   "initial_balance": 10000,
+  "min_balance_threshold": 100,
+  "min_trade_amount": 25,
   "max_open_positions": 1,
-  "max_risk_per_trade": 0.02
+  "max_trades_per_day": 5,
+  "max_risk_per_trade": 0.02,
+  "max_units_per_trade": 1.0,
+  "max_trade_amount": 5000,
+  "volatility_window": 14,
+  "target_volatility": 0.20,
+  "volatility_mode": "off",
+  "enable_volatility_adjustment": false,
+  "cooldown_bars": 24,
+  "daily_momentum_limit": 3,
+  "weekly_momentum_limit": 3
 }
 ```
-
-Required: `asset`, `interval`, `strategy_json` (a JSON-encoded MangroveAI Strategy object). All risk-management / execution fields are optional — the server fills any missing field from the canonical `trading_defaults.json`, so a minimal request is sufficient for exploratory work. See the SDK's `OracleBacktestRequest` model for the full surface.
 
 ### Response
 
@@ -58,13 +102,13 @@ Required: `asset`, `interval`, `strategy_json` (a JSON-encoded MangroveAI Strate
   },
   "execution_time_seconds": 42.1,
   "trade_count": 47,
-  "strategy_names": ["rsi_oversold + ema_uptrend / take_profit_5pct"],
+  "strategy_names": ["..."],
   "trade_history": [{"...": "..."}],
   "denied_signals": []
 }
 ```
 
-`denied_signals` lists signals the engine refused (e.g. unsupported columns, malformed params). Inspect this when `total_trades` comes back lower than expected.
+`denied_signals` lists signals the engine refused (unsupported columns, malformed params). Check this when `trade_count` is lower than expected.
 
 ### Example
 
@@ -73,41 +117,76 @@ Required: `asset`, `interval`, `strategy_json` (a JSON-encoded MangroveAI Strate
 curl -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/backtest \
   -H "Authorization: Bearer $MANGROVE_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{
-    "asset": "BTC",
-    "interval": "1h",
-    "strategy_json": "{...}",
-    "initial_balance": 10000
-  }'
+  -d @backtest_request.json
 ```
 
-```python Python
-from mangrove_ai import MangroveAI
-from mangrove_ai.models.oracle import OracleBacktestRequest
+```python Python (raw HTTP)
+import json, requests
 
-client = MangroveAI(api_key="prod_…")
+# Fetch canonical defaults so we don't hand-roll execution_config
+defaults = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/oracle/exec-config/defaults",
+    headers={"Authorization": f"Bearer {API_KEY}"},
+).json()
 
-result = client.oracle.backtest(OracleBacktestRequest(
-    asset="BTC",
-    interval="1h",
-    strategy_json='{...}',
-    initial_balance=10000,
-))
+strategy = {
+    "asset": "BTC", "interval": "1h",
+    "entry": [{"name": "rsi_oversold", "signal_type": "TRIGGER", "timeframe": "1h",
+               "params": {"window": 14, "threshold": 30}}],
+    "exit":  [{"name": "rsi_overbought", "signal_type": "TRIGGER", "timeframe": "1h",
+               "params": {"window": 14, "threshold": 70}}],
+}
 
-print(f"Sharpe: {result.metrics['sharpe']:.2f}")
-print(f"Trades: {result.trade_count}")
+body = {
+    "asset": "BTC", "interval": "1h",
+    "strategy_json": json.dumps(strategy),
+    "lookback_months": 3,
+    "execution_config": {
+        "position_size_calc": defaults["position_size_calc"],
+        "reward_factor":         defaults["reward_factor"],
+        "atr_period":            defaults["atr_period"],
+        "atr_volatility_factor": defaults["atr_volatility_factor"],
+        "atr_short_weight":      defaults["atr_short_weight"],
+        "atr_long_weight":       defaults["atr_long_weight"],
+        "atr_cap_multiplier":    defaults["atr_cap_multiplier"],
+    },
+    "initial_balance":      defaults["initial_balance"],
+    "min_balance_threshold": 100,
+    "min_trade_amount":      defaults["min_trade_amount"],
+    "max_open_positions":    1,
+    "max_trades_per_day":    5,
+    "max_risk_per_trade":    0.02,
+    "max_units_per_trade":   1.0,
+    "max_trade_amount":      5000,
+    "volatility_window":     14,
+    "target_volatility":     0.20,
+    "volatility_mode":       "off",
+    "enable_volatility_adjustment": False,
+    "cooldown_bars":         defaults["cooldown_bars"],
+    "daily_momentum_limit":  defaults["daily_momentum_limit"],
+    "weekly_momentum_limit": defaults["weekly_momentum_limit"],
+}
+
+resp = requests.post(
+    "https://api.mangrovedeveloper.ai/api/v1/oracle/backtest",
+    headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
+    json=body, timeout=180,
+)
+result = resp.json()
+print(f"success={result['success']} trade_count={result['trade_count']}")
+print(f"metrics: {result['metrics']}")
 ```
 </CodeGroup>
 
 ## Async submit + poll
 
-When 30–120s of blocking is too long — for example, dispatching dozens of backtests from a worker that should remain responsive — use the async pair.
+When 30-120s of blocking is too long — dispatching dozens of backtests from a worker that should stay responsive — use the async pair.
 
 ### Submit
 
 `POST /api/v1/oracle/backtest/async`
 
-Same request body as the sync endpoint. Returns immediately:
+Same request body as the sync endpoint (same 18 required fields + top-level `execution_config`). Returns immediately:
 
 ```json
 { "backtest_id": "bkt_20260603T140212548Z", "status": "queued" }
@@ -126,76 +205,73 @@ Same request body as the sync endpoint. Returns immediately:
 }
 ```
 
-`status` transitions `queued` → `running` → `completed` (or `failed`). Once `completed`, the response carries the full `metrics`/`trade_history`/`trade_count` shape of the synchronous response. Polling the endpoint is **free** (metadata-tier); typical poll interval is 5–10 seconds.
+`status` transitions `queued` → `running` → `completed` (or `failed`). Once `completed`, the response carries the full `metrics`/`trade_history`/`trade_count` shape of the synchronous response. Polling is metered at the same rate as submit ($0.10 / api_calls unit per call); space your polls accordingly.
 
 ### Example
 
-<CodeGroup>
-```bash cURL
-# Submit
-ID=$(curl -s -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/backtest/async \
-  -H "Authorization: Bearer $MANGROVE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"asset":"BTC","interval":"1h","strategy_json":"{...}"}' \
-  | jq -r .backtest_id)
+```python Python (raw HTTP)
+import time, requests
+
+# Submit (body shape identical to sync /backtest above)
+resp = requests.post(
+    "https://api.mangrovedeveloper.ai/api/v1/oracle/backtest/async",
+    headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
+    json=body,
+)
+backtest_id = resp.json()["backtest_id"]
 
 # Poll
-while true; do
-  status=$(curl -s -H "Authorization: Bearer $MANGROVE_API_KEY" \
-    https://api.mangrovedeveloper.ai/api/v1/oracle/backtest/async/$ID | jq -r .status)
-  [[ "$status" == "completed" || "$status" == "failed" ]] && break
-  sleep 5
-done
-```
-
-```python Python
-import time
-
-submission = client.oracle.backtest_async(OracleBacktestRequest(
-    asset="BTC", interval="1h", strategy_json='{...}',
-))
-
 while True:
-    status = client.oracle.backtest_poll(submission.backtest_id)
-    if status.status in ("completed", "failed"):
+    status = requests.get(
+        f"https://api.mangrovedeveloper.ai/api/v1/oracle/backtest/async/{backtest_id}",
+        headers={"Authorization": f"Bearer {API_KEY}"},
+    ).json()
+    if status["status"] in ("completed", "failed"):
         break
-    time.sleep(5)
+    time.sleep(10)
 
-print(status.metrics)
+print(status)
 ```
-</CodeGroup>
 
 ## Bulk
 
 `POST /api/v1/oracle/backtest/bulk`
 
-Evaluates many strategies over a **shared date range** with shared OHLCV fetches. One HTTP call, one bill. Up to 99 strategies per request.
+Evaluates many strategies over a **shared date range** with shared OHLCV fetches. One HTTP call, one bill, up to 99 strategies.
 
-This is the right endpoint when you have a SIEVE-filtered shortlist and want to score the survivors quickly — see [SIEVE → live strategy](/guides/sieve-to-live-strategy) for the full workflow.
+The right endpoint when you have a SIEVE-filtered shortlist and want to score the survivors quickly — see [SIEVE → live strategy](/guides/sieve-to-live-strategy) for the full workflow.
+
+### Required fields
+
+17 top-level fields + EXACTLY ONE of `strategy_ids` OR `strategy_configs` (not both), per `MangroveOracle/src/api/routes/backtest.py::run_bulk_backtest`:
+
+- `start_date`, `end_date` — required (no `lookback_months` shortcut on bulk)
+- The same 15 risk-mgmt fields as sync (sans `strategy_json` since each item carries its own)
+- Top-level `execution_config` with `position_size_calc`
+
+`strategy_configs` is `[{asset, interval, strategy_json}, …]`; `strategy_ids` is `[uuid, …]` referencing strategies already created via `client.strategies.create(...)` in MangroveAI.
 
 ### Request
 
 ```json
 {
-  "start_date": "2024-01-01",
-  "end_date":   "2024-12-31",
-  "initial_balance": 10000,
-  "min_balance_threshold": 100,
-  "min_trade_amount": 10,
-  "max_open_positions": 1,
-  "max_trades_per_day": 5,
-  "max_risk_per_trade": 0.02,
-  "max_units_per_trade": 1.0,
-  "max_trade_amount": 5000,
-  "volatility_window": 14,
-  "strategies": [
+  "start_date": "2024-01-01T00:00:00Z",
+  "end_date":   "2024-12-31T00:00:00Z",
+  "strategy_configs": [
     { "asset": "BTC", "interval": "1h", "strategy_json": "{...}" },
     { "asset": "BTC", "interval": "1h", "strategy_json": "{...}" }
-  ]
+  ],
+  "execution_config": { "position_size_calc": "v2" },
+
+  "initial_balance": 10000,
+  "min_balance_threshold": 100, "min_trade_amount": 25,
+  "max_open_positions": 1, "max_trades_per_day": 5,
+  "max_risk_per_trade": 0.02, "max_units_per_trade": 1.0, "max_trade_amount": 5000,
+  "volatility_window": 14, "target_volatility": 0.20,
+  "volatility_mode": "off", "enable_volatility_adjustment": false,
+  "cooldown_bars": 24, "daily_momentum_limit": 3, "weekly_momentum_limit": 3
 }
 ```
-
-All bulk-level execution / risk fields are required; per-strategy fields are not (the server uses the bulk-level defaults). Strategies that share an `(asset, interval)` pair reuse a single OHLCV fetch — the response's `data_fetches` field reports how many unique fetches the engine did.
 
 ### Response
 
@@ -203,88 +279,50 @@ All bulk-level execution / risk fields are required; per-strategy fields are not
 {
   "success": true,
   "results": [
-    { "metrics": {...}, "trade_count": 47,  "strategy_index": 0 },
-    { "metrics": {...}, "trade_count": 12,  "strategy_index": 1 }
+    {"success": true,  "strategy_name": "...", "strategy_id": "...",
+     "metrics": {...}, "trade_count": 47, "execution_time_seconds": 12.4},
+    {"success": false, "strategy_name": "...", "strategy_id": "...",
+     "error": "...", "trade_count": 0, "metrics": {}}
   ],
   "data_fetches": 1,
   "total_execution_time_seconds": 51.2
 }
 ```
 
-### Example
-
-<CodeGroup>
-```python Python
-from mangrove_ai.models.oracle import OracleBulkBacktestRequest
-
-result = client.oracle.backtest_bulk(OracleBulkBacktestRequest(
-    start_date="2024-01-01",
-    end_date="2024-12-31",
-    initial_balance=10000,
-    min_balance_threshold=100,
-    min_trade_amount=10,
-    max_open_positions=1,
-    max_trades_per_day=5,
-    max_risk_per_trade=0.02,
-    max_units_per_trade=1.0,
-    max_trade_amount=5000,
-    volatility_window=14,
-    strategies=[
-        {"asset": "BTC", "interval": "1h", "strategy_json": "{...}"},
-        {"asset": "BTC", "interval": "1h", "strategy_json": "{...}"},
-    ],
-))
-
-for i, r in enumerate(result.results):
-    print(f"Strategy {i}: sharpe={r['metrics'].get('sharpe'):.2f} trades={r['trade_count']}")
-```
-</CodeGroup>
+Individual strategies fail soft — `results[i].success == false` carries an `error` field and an empty `metrics`, but the rest of the batch continues. Input order is preserved: `results[i]` corresponds to `strategy_configs[i]`. `data_fetches` reports how many unique OHLCV fetches the engine did across the strategy list (strategies sharing `(asset, interval)` reuse one fetch).
 
 ## Data query (corpus)
 
 `POST /api/v1/oracle/data/query`
 
-Direct access to Oracle's BigQuery-backed corpus of historical backtest results and OHLCV bars. The proxy whitelists tables and filter operators server-side so the surface stays narrow.
-
-### Whitelist
-
-| Concern | Allowed values |
-|---|---|
-| Tables | `results`, `ohlcv` |
-| Filter ops | `=`, `!=`, `>`, `>=`, `<`, `<=`, `in`, `between` |
-| Tenancy | `WHERE org_id = <caller's org>` is injected by Oracle. Cross-tenant reads are not possible by construction. |
+A constrained DSL over Oracle's BigQuery-backed corpus of historical backtest results and OHLCV bars. The proxy enforces server-side: table whitelist, column whitelist, filter-op whitelist, tenancy injection (`WHERE org_id = <caller>`), and a per-query `maximum_bytes_billed` cap. Customers cannot send raw SQL.
 
 ### Request
 
-```json
-{
-  "table": "results",
-  "select": ["strategy_name", "asset", "interval", "metrics_sharpe", "trade_count"],
-  "filters": [
-    { "col": "asset", "op": "=", "value": "BTC" },
-    { "col": "interval", "op": "=", "value": "1h" },
-    { "col": "metrics_sharpe", "op": ">", "value": 1.0 }
-  ],
-  "order_by": ["metrics_sharpe DESC"],
-  "limit": 50,
-  "offset": 0
-}
-```
+| Field | Type | Notes |
+|---|---|---|
+| `table` | `"results" \| "ohlcv"` | required |
+| `select` | `list[str]` | required, 1-80 columns, whitelisted per table |
+| `filters` | `list[{col, op, value}]` | optional, ≤20 filters |
+| `order_by` | `list[{col, dir}]` | optional, ≤5 orderings; `dir` is `"asc"` or `"desc"` |
+| `limit` | `int` | optional, 1-1000, default 100 |
+| `page_token` | `str` | optional; opaque continuation token from a prior response |
 
-`select` is required; `filters` defaults to `[]`. `order_by` accepts SQL-style column expressions. Default `limit` is 100; the engine caps at 1000.
+`filters[].op` accepts: `"="`, `"!="`, `">"`, `">="`, `"<"`, `"<="`, `"in"`, `"between"` (per `MangroveOracle/src/models/data_query.py::FilterOp`).
 
 ### Response
 
 ```json
 {
-  "rows": [
-    {"strategy_name": "...", "asset": "BTC", "metrics_sharpe": 1.84, "trade_count": 91},
-    {"...": "..."}
-  ],
+  "rows": [{"...": "..."}],
   "row_count": 23,
-  "table": "results"
+  "total_bytes_billed": 10485760,
+  "cost_estimate_usd": 0.0000596,
+  "next_page_token": null
 }
 ```
+
+`total_bytes_billed` is the actual BigQuery-billed scan in bytes (used to compute the customer's invoice line for this call); `cost_estimate_usd` is that figure converted at GCP's published per-TB rate. `next_page_token` is non-null when more rows are available — pass it back as `page_token` to continue.
 
 ### Example
 
@@ -295,45 +333,48 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/data/query \
   -H "Content-Type: application/json" \
   -d '{
     "table": "results",
-    "select": ["strategy_name","metrics_sharpe","trade_count"],
-    "filters": [{"col":"asset","op":"=","value":"BTC"}],
-    "order_by": ["metrics_sharpe DESC"],
+    "select": ["strategy_name", "asset", "timeframe"],
+    "filters": [{"col": "asset", "op": "=", "value": "BTC"}],
+    "order_by": [{"col": "strategy_name", "dir": "desc"}],
     "limit": 20
   }'
 ```
 
-```python Python
-from mangrove_ai.models.oracle import DataQueryRequest, DataQueryFilter
+```python Python (raw HTTP)
+import requests
 
-result = client.oracle.data_query(DataQueryRequest(
-    table="results",
-    select=["strategy_name", "metrics_sharpe", "trade_count"],
-    filters=[DataQueryFilter(col="asset", op="=", value="BTC")],
-    order_by=["metrics_sharpe DESC"],
-    limit=20,
-))
-
-for row in result.rows:
+resp = requests.post(
+    "https://api.mangrovedeveloper.ai/api/v1/oracle/data/query",
+    headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
+    json={
+        "table": "results",
+        "select": ["strategy_name", "asset", "timeframe"],
+        "filters": [{"col": "asset", "op": "=", "value": "BTC"}],
+        "order_by": [{"col": "strategy_name", "dir": "desc"}],
+        "limit": 20,
+    },
+)
+data = resp.json()
+print(f"Got {data['row_count']} rows; billed {data['total_bytes_billed']:,} bytes "
+      f"(${data['cost_estimate_usd']:.6f})")
+for row in data["rows"]:
     print(row)
 ```
 </CodeGroup>
 
-## Costs
+## Costs (summary)
 
-| Action | Quota unit | x402 price |
+| Endpoint | Per-call | Quota counter |
 |---|---|---|
-| Each `POST /backtest`, `POST /backtest/async`, or `POST /backtest/bulk` call | `oracle_backtest` (1 unit) | $0.10 |
-| `POST /data/query` | `oracle_data_query` (1 unit) | $0.01 |
-| `GET /backtest/async/{id}` poll | free (metadata) | — |
+| All four `/backtest*` endpoints | $0.10 x402 / 1 unit | `api_calls` |
+| `/data/query` | $0.10 x402 / 1 unit | `oracle_data_queries` |
 
-The bulk endpoint amortises efficiently: one billed call fans out internally to up to 99 strategy evaluations. The async endpoint costs the same as sync — pick async when the wall-clock matters for your caller, not to save on billing.
-
-See [Pricing](/api-reference/overview#pricing) for tier monthly caps on `oracle_backtest` / `oracle_data_query` resource buckets.
+See [Pricing](/api-reference/overview#pricing) for tier monthly caps. Source of truth: `MangroveAI/src/MangroveAI/domains/backtesting/oracle_proxy.py::_PROXY_METERING`.
 
 ## Related
 
 - [Experiments](/api-reference/experiments) — multi-strategy parameter sweeps with managed lifecycle (`create` → `validate` → `launch` → poll results). Use experiments when the parameter grid is larger than a single bulk request can hold.
-- [SIEVE classifier](/api-reference/sieve) — score 1–99 candidate strategies in milliseconds before paying for backtests. Pre-filter aggressively when the candidate set is hundreds wide.
+- [SIEVE classifier](/api-reference/sieve) — score 1-99 candidate strategies in milliseconds before paying for backtests.
 - [Deployed strategies](/api-reference/oracle-deployed) — live execution state for curated paper-trading strategies, not for ad-hoc backtests.
-- [SIEVE → live strategy walkthrough](/guides/sieve-to-live-strategy) — end-to-end demo combining list-signals, SIEVE, bulk-backtest, and `update_status('paper')`.
-- [`mangroveai` Python SDK](/sdks/mangroveai) — `client.oracle.backtest(...)`, `backtest_async(...)`, `backtest_poll(...)`, `backtest_bulk(...)`, `data_query(...)` are typed wrappers as of SDK v1.4.0.
+- [SIEVE → live strategy walkthrough](/guides/sieve-to-live-strategy) — end-to-end demo: list-signals, SIEVE, sweep via experiments, adopt.
+- [`mangroveai` Python SDK](/sdks/mangroveai) — typed wrappers exist as of SDK v1.4.0, but with caveats above. Until reconciled, raw HTTP examples are the source of truth.

--- a/docs/api-reference/oracle-backtest.mdx
+++ b/docs/api-reference/oracle-backtest.mdx
@@ -239,7 +239,7 @@ print(status)
 
 Evaluates many strategies over a **shared date range** with shared OHLCV fetches. One HTTP call, one bill, up to 99 strategies.
 
-The right endpoint when you have a SIEVE-filtered shortlist and want to score the survivors quickly — see [SIEVE → live strategy](/guides/sieve-to-live-strategy) for the full workflow.
+The right endpoint when you have a SIEVE-filtered shortlist and want to score the survivors quickly — see [End-to-end workflow with SIEVE](/guides/sieve-end-to-end-workflow) for the full workflow.
 
 ### Required fields
 
@@ -376,5 +376,5 @@ See [Pricing](/api-reference/overview#pricing) for tier monthly caps. Source of 
 - [Experiments](/api-reference/experiments) — multi-strategy parameter sweeps with managed lifecycle (`create` → `validate` → `launch` → poll results). Use experiments when the parameter grid is larger than a single bulk request can hold.
 - [SIEVE classifier](/api-reference/sieve) — score 1-99 candidate strategies in milliseconds before paying for backtests.
 - [Deployed strategies](/api-reference/oracle-deployed) — live execution state for curated paper-trading strategies, not for ad-hoc backtests.
-- [SIEVE → live strategy walkthrough](/guides/sieve-to-live-strategy) — end-to-end demo: list-signals, SIEVE, sweep via experiments, adopt.
+- [End-to-end workflow with SIEVE](/guides/sieve-end-to-end-workflow) — end-to-end demo: list-signals, SIEVE, sweep via experiments, adopt.
 - [`mangroveai` Python SDK](/sdks/mangroveai) — typed wrappers exist as of SDK v1.4.0, but with caveats above. Until reconciled, raw HTTP examples are the source of truth.

--- a/docs/api-reference/oracle-backtest.mdx
+++ b/docs/api-reference/oracle-backtest.mdx
@@ -14,7 +14,9 @@ This page covers the **single-strategy** subset of the Oracle engine plus the co
 All endpoints sit under `/api/v1/oracle/` on the MangroveAI gateway and are forwarded to the Oracle engine with your identity attached. Auth: API key or JWT, same as the rest of `/api/v1/*`.
 
 <Warning>
-**SDK ↔ server contract note.** The `mangroveai` Python SDK 1.4.0 types the risk-management fields on `OracleBacktestRequest` / `OracleBulkBacktestRequest` as `Optional` with `None` defaults. The **server requires every one of those fields explicitly** — the SDK comment "server-default-fillable" is currently aspirational, not honored. Pass them in full until the SDK typing is reconciled. The `DataQueryResponse` Pydantic model also defines a `table: str` field that the actual server response does NOT include; that wrapper will fail validation on every successful 200. The examples below use raw HTTP for these three endpoints so the demos actually run. SDK-typed examples will return once the SDK matches the server contract.
+**SDK ↔ server contract note (data query only).** The `DataQueryResponse` Pydantic model in `mangroveai` Python SDK 1.4.0 defines a `table: str` field that the actual server response does NOT include — the typed wrapper fails validation on every successful 200. Separately, `DataQueryRequest.order_by` is typed as a list of strings whereas the server expects `[{col, dir}]` dict shape. The `/data/query` Python example below uses raw HTTP for this reason. Tracking fixes: [SDK#16](https://github.com/MangroveTechnologies/MangroveAI-SDK/issues/16), [SDK#17](https://github.com/MangroveTechnologies/MangroveAI-SDK/issues/17).
+
+The historical `OracleBacktestRequest` / `OracleBulkBacktestRequest` gap (risk-mgmt fields typed `Optional` but server-rejected) was closed by MangroveAI v3.10.12 — the gateway proxy now fills missing risk-mgmt fields from canonical `trading_defaults.json`, so the `Optional` typing is honored end-to-end and the SDK calls below work with just `asset` + `strategy_json` + a date range.
 </Warning>
 
 ## Endpoints
@@ -51,7 +53,7 @@ Plus a top-level `execution_config` containing at least `position_size_calc: "v2
 
 Optional: `interval` (defaults to `"1h"`), `lookback_months`, `start_date`, `end_date` (provide one of: explicit start+end, start alone (defaults end to now), or `lookback_months`).
 
-Pull canonical defaults from `GET /api/v1/oracle/exec-config/defaults` to skip hand-rolling these.
+**Defaults filled by the gateway.** Since MangroveAI v3.10.12 the proxy merges canonical values from `trading_defaults.json` into any `/backtest*` request body before forwarding to Oracle — customer-supplied values always win (customer-wins-only `setdefault`). So in practice you can call `/backtest` with just `asset`, `strategy_json`, and a date range; the 15 risk-mgmt fields and a full `execution_config` will be populated for you. Pull the same canonical values explicitly via `GET /api/v1/oracle/exec-config/defaults` when you want to inspect or override them.
 
 ### Request
 
@@ -120,14 +122,12 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/backtest \
   -d @backtest_request.json
 ```
 
-```python Python (raw HTTP)
-import json, requests
+```python Python (SDK)
+import json
+from mangrove_ai import MangroveAI
+from mangrove_ai.models.oracle import OracleBacktestRequest
 
-# Fetch canonical defaults so we don't hand-roll execution_config
-defaults = requests.get(
-    "https://api.mangrovedeveloper.ai/api/v1/oracle/exec-config/defaults",
-    headers={"Authorization": f"Bearer {API_KEY}"},
-).json()
+client = MangroveAI(api_key=API_KEY)
 
 strategy = {
     "asset": "BTC", "interval": "1h",
@@ -137,44 +137,17 @@ strategy = {
                "params": {"window": 14, "threshold": 70}}],
 }
 
-body = {
-    "asset": "BTC", "interval": "1h",
-    "strategy_json": json.dumps(strategy),
-    "lookback_months": 3,
-    "execution_config": {
-        "position_size_calc": defaults["position_size_calc"],
-        "reward_factor":         defaults["reward_factor"],
-        "atr_period":            defaults["atr_period"],
-        "atr_volatility_factor": defaults["atr_volatility_factor"],
-        "atr_short_weight":      defaults["atr_short_weight"],
-        "atr_long_weight":       defaults["atr_long_weight"],
-        "atr_cap_multiplier":    defaults["atr_cap_multiplier"],
-    },
-    "initial_balance":      defaults["initial_balance"],
-    "min_balance_threshold": 100,
-    "min_trade_amount":      defaults["min_trade_amount"],
-    "max_open_positions":    1,
-    "max_trades_per_day":    5,
-    "max_risk_per_trade":    0.02,
-    "max_units_per_trade":   1.0,
-    "max_trade_amount":      5000,
-    "volatility_window":     14,
-    "target_volatility":     0.20,
-    "volatility_mode":       "off",
-    "enable_volatility_adjustment": False,
-    "cooldown_bars":         defaults["cooldown_bars"],
-    "daily_momentum_limit":  defaults["daily_momentum_limit"],
-    "weekly_momentum_limit": defaults["weekly_momentum_limit"],
-}
+# Risk-mgmt fields and execution_config are filled by the gateway from
+# trading_defaults.json — pass only what you want to override.
+result = client.oracle.backtest(OracleBacktestRequest(
+    asset="BTC",
+    interval="1h",
+    strategy_json=json.dumps(strategy),
+    lookback_months=3,
+))
 
-resp = requests.post(
-    "https://api.mangrovedeveloper.ai/api/v1/oracle/backtest",
-    headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
-    json=body, timeout=180,
-)
-result = resp.json()
-print(f"success={result['success']} trade_count={result['trade_count']}")
-print(f"metrics: {result['metrics']}")
+print(f"success={result.success} trade_count={result.trade_count}")
+print(f"metrics: {result.metrics}")
 ```
 </CodeGroup>
 
@@ -209,28 +182,30 @@ Same request body as the sync endpoint (same 18 required fields + top-level `exe
 
 ### Example
 
-```python Python (raw HTTP)
-import time, requests
+```python Python (SDK)
+import json, time
+from mangrove_ai import MangroveAI
+from mangrove_ai.models.oracle import OracleBacktestRequest
 
-# Submit (body shape identical to sync /backtest above)
-resp = requests.post(
-    "https://api.mangrovedeveloper.ai/api/v1/oracle/backtest/async",
-    headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
-    json=body,
-)
-backtest_id = resp.json()["backtest_id"]
+client = MangroveAI(api_key=API_KEY)
+
+# Submit (same request shape as sync /backtest — gateway fills defaults)
+submit = client.oracle.backtest_async(OracleBacktestRequest(
+    asset="BTC",
+    interval="1h",
+    strategy_json=json.dumps(strategy),
+    lookback_months=3,
+))
+backtest_id = submit.backtest_id
 
 # Poll
 while True:
-    status = requests.get(
-        f"https://api.mangrovedeveloper.ai/api/v1/oracle/backtest/async/{backtest_id}",
-        headers={"Authorization": f"Bearer {API_KEY}"},
-    ).json()
-    if status["status"] in ("completed", "failed"):
+    status = client.oracle.backtest_poll(backtest_id)
+    if status.status in ("completed", "failed"):
         break
     time.sleep(10)
 
-print(status)
+print(f"final status={status.status} trade_count={status.trade_count}")
 ```
 
 ## Bulk
@@ -290,6 +265,34 @@ The right endpoint when you have a SIEVE-filtered shortlist and want to score th
 ```
 
 Individual strategies fail soft — `results[i].success == false` carries an `error` field and an empty `metrics`, but the rest of the batch continues. Input order is preserved: `results[i]` corresponds to `strategy_configs[i]`. `data_fetches` reports how many unique OHLCV fetches the engine did across the strategy list (strategies sharing `(asset, interval)` reuse one fetch).
+
+### Example
+
+```python Python (SDK)
+import json
+from mangrove_ai import MangroveAI
+from mangrove_ai.models.oracle import OracleBulkBacktestRequest
+
+client = MangroveAI(api_key=API_KEY)
+
+# Risk-mgmt fields + execution_config filled by the gateway from
+# trading_defaults.json when omitted — bulk shares the same merge path.
+batch = client.oracle.backtest_bulk(OracleBulkBacktestRequest(
+    start_date="2024-01-01T00:00:00Z",
+    end_date="2024-12-31T00:00:00Z",
+    strategy_configs=[
+        {"asset": "BTC", "interval": "1h", "strategy_json": json.dumps(strategy_a)},
+        {"asset": "BTC", "interval": "1h", "strategy_json": json.dumps(strategy_b)},
+    ],
+))
+
+print(f"data_fetches={batch.data_fetches} total_time={batch.total_execution_time_seconds:.1f}s")
+for r in batch.results:
+    if r["success"]:
+        print(f"  {r['strategy_name']}: trades={r['trade_count']} sharpe={r['metrics'].get('sharpe')}")
+    else:
+        print(f"  {r['strategy_name']}: FAILED — {r['error']}")
+```
 
 ## Data query (corpus)
 
@@ -377,4 +380,4 @@ See [Pricing](/api-reference/overview#pricing) for tier monthly caps. Source of 
 - [SIEVE classifier](/api-reference/sieve) — score 1-99 candidate strategies in milliseconds before paying for backtests.
 - [Deployed strategies](/api-reference/oracle-deployed) — live execution state for curated paper-trading strategies, not for ad-hoc backtests.
 - [End-to-end workflow with SIEVE](/guides/sieve-end-to-end-workflow) — end-to-end demo: list-signals, SIEVE, sweep via experiments, adopt.
-- [`mangroveai` Python SDK](/sdks/mangroveai) — typed wrappers exist as of SDK v1.4.0, but with caveats above. Until reconciled, raw HTTP examples are the source of truth.
+- [`mangroveai` Python SDK](/sdks/mangroveai) — typed wrappers for all `/backtest*` endpoints land in SDK v1.4.0; the historical risk-mgmt gap is now closed at the gateway (MangroveAI v3.10.12). The `/data/query` Python example below still uses raw HTTP pending SDK#16 / SDK#17.

--- a/docs/guides/sieve-end-to-end-workflow.mdx
+++ b/docs/guides/sieve-end-to-end-workflow.mdx
@@ -1,19 +1,19 @@
 ---
-title: "SIEVE → backtest → paper: end-to-end strategy adoption"
-description: "Combine SIEVE pre-filtering with an experiment sweep and the strategy lifecycle to go from 'list of candidates' to a paper-trading strategy in four phases."
+title: "End-to-end workflow with Mangrove SIEVE"
+description: "Combine SIEVE pre-filtering, bulk backtesting, and the strategy lifecycle to go from a signal mix to a running strategy in four phases."
 ---
 
-# SIEVE → backtest → paper
+# End-to-end workflow with Mangrove SIEVE
 
-This guide walks the full chain from "I have a signal mix I want to explore" to "I have a paper-trading strategy live in MangroveAI."
+This guide walks the full chain from "I have a signal mix I want to explore" to "I have a strategy registered and running on MangroveAI."
 
 Four phases:
 
 <Steps>
   <Step title="Discover the signal catalog" />
   <Step title="Generate candidates + SIEVE filter" />
-  <Step title="Bulk-backtest the top survivors via an experiment" />
-  <Step title="Adopt the winner to paper trading" />
+  <Step title="Bulk-backtest the top survivors" />
+  <Step title="Register the winner + run it" />
 </Steps>
 
 Each phase corresponds to one or two SDK calls. The Python tabs use the `mangroveai` SDK 1.4.0+; the cURL tabs hit the underlying `/api/v1/*` surface directly.
@@ -234,9 +234,9 @@ If your winner has `trade_count == 0`, the surviving candidates didn't fire entr
 
 For the full request/response shape see [Oracle backtest reference](/api-reference/oracle-backtest). For larger sweeps with a managed lifecycle, see [Experiments](/api-reference/experiments).
 
-## Phase 4 — Adopt the winner to paper trading
+## Phase 4 — Register the winner + run it
 
-The winning candidate (`top_10[i]` for the index `i` matching the experiment's best result) becomes a registered MangroveAI strategy. Paper trading runs the strategy against live OHLCV with simulated fills — no wallet, no capital, no on-chain risk.
+The winning candidate becomes a registered MangroveAI strategy. From there, you choose how to run it.
 
 ```python Python
 from mangrove_ai.models.strategies import CreateStrategyRequest
@@ -245,31 +245,38 @@ from mangrove_ai.models.strategies import CreateStrategyRequest
 # best_idx came from the bulk response — strategy_configs preserved input order
 winner_candidate = top_10[best_idx]  # the SIEVE candidate object
 
-# 1. Register the strategy
 created_strategy = client.strategies.create(CreateStrategyRequest(
     name=f"sieve-winner-{winner_candidate['asset']}-1h",
-    description="Top performer from SIEVE → experiment sweep, BTC 1h 2024",
+    description="Top performer from SIEVE + bulk backtest, BTC 1h 2024",
     asset=winner_candidate["asset"],
     entry=winner_candidate["entry"],
     exit=winner_candidate["exit"],
     execution_config=winner_candidate["execution_config"],
 ))
 print(f"Created strategy: {created_strategy.id}")
-
-# 2. Promote to paper trading
-client.strategies.update_status(created_strategy.id, "paper")
-print(f"Strategy {created_strategy.id} is now paper-trading.")
 ```
 
-The platform schedules an evaluation on the strategy's timeframe and accrues simulated fills as the signal fires.
+### Running it
 
-### Promoting to live
+`client.strategies.update_status(strategy_id, status)` transitions the strategy. Pick the path that matches your appetite:
 
-`paper` → `live` is gated server-side on a wallet with a confirmed backup, an allocation block (`wallet_address`, `token`, `amount`, `slippage_pct`), and an explicit confirmation flag — none of which are exposed by `strategies.update_status(strategy_id, status)` in SDK 1.4.0. The live promotion currently requires a raw PATCH against `/api/v1/strategies/{id}/status` with the allocation block in the body. See [Creating a strategy](/guides/creating-a-strategy) for the live-promotion contract and wallet-connect gating.
+```python Python
+# Option A — go live immediately (real capital, real fills via mangrovemarkets)
+client.strategies.update_status(created_strategy.id, "live")
+
+# Option B — paper trade first (simulated fills, no on-chain exposure)
+client.strategies.update_status(created_strategy.id, "paper")
+```
+
+Either way the platform schedules evaluations on the strategy's timeframe and the signal starts running. Paper mode lets you watch how the strategy behaves against live OHLCV before committing capital; live mode skips the simulation and trades on a real wallet from day one.
+
+### Live trading gating
+
+Going `live` is gated server-side on a wallet with a confirmed backup, an allocation block (`wallet_address`, `token`, `amount`, `slippage_pct`), and an explicit confirmation flag — none of which are exposed by `strategies.update_status(strategy_id, status)` in SDK 1.4.0. The live transition currently requires a raw PATCH against `/api/v1/strategies/{id}/status` with the allocation block in the body. See [Creating a strategy](/guides/creating-a-strategy) for the live contract and wallet-connect gating. Paper trading has no such gating and can run anywhere.
 
 ## Saving the provenance
 
-Every SIEVE response carries `model_version` and `code_version`; experiment results carry their own provenance stamps. Log them next to every adoption decision so a future you can tell which model + corpus snapshot drove the call.
+Every SIEVE response carries `model_version` and `code_version`; experiment results carry their own provenance stamps. Log them next to every decision so a future you can tell which model + corpus snapshot drove the call.
 
 ```python Python
 import datetime, json
@@ -277,7 +284,6 @@ import datetime, json
 decision_log = {
     "winner_strategy_id": created_strategy.id,
     "sieve_p_winning":    ranked[best_idx][1].four_class["winning"],
-    "experiment_id":      exp_id,
     "backtest_sortino":   best["metrics"]["sortino"],
     "backtest_sharpe":    best["metrics"]["sharpe"],
     "sieve_model_version": response.model_version,

--- a/docs/guides/sieve-to-live-strategy.mdx
+++ b/docs/guides/sieve-to-live-strategy.mdx
@@ -1,6 +1,6 @@
 ---
 title: "SIEVE → backtest → paper: end-to-end strategy adoption"
-description: "Combine SIEVE pre-filtering with bulk backtests and the strategy lifecycle to go from 'list of candidates' to a paper-trading strategy in four phases."
+description: "Combine SIEVE pre-filtering with an experiment sweep and the strategy lifecycle to go from 'list of candidates' to a paper-trading strategy in four phases."
 ---
 
 # SIEVE → backtest → paper
@@ -12,14 +12,14 @@ Four phases:
 <Steps>
   <Step title="Discover the signal catalog" />
   <Step title="Generate candidates + SIEVE filter" />
-  <Step title="Bulk backtest the top survivors" />
+  <Step title="Bulk-backtest the top survivors via an experiment" />
   <Step title="Adopt the winner to paper trading" />
 </Steps>
 
-Each phase corresponds to one (or two) SDK calls. The Python tabs use the `mangroveai` SDK (v1.4.0+); the cURL tabs hit the underlying `/api/v1/*` surface directly.
+Each phase corresponds to one or two SDK calls. The Python tabs use the `mangroveai` SDK 1.4.0+; the cURL tabs hit the underlying `/api/v1/*` surface directly.
 
 <Note>
-**Tier note.** Beginner accounts cap at 10 SIEVE calls / month, 2 sweep launches / month, and 25 backtests / month. This walkthrough fits inside those caps if you stop at top-10 (one bulk backtest call) — no Pro tier required. The Pro tier (1 SIEVE call = 99 strategies) unlocks the wider 1,000-candidate fan-in covered at the end.
+**Tier note.** Beginner accounts cap at 10 SIEVE calls / month, 2 sweep launches / month, and quotas on backtests. This walkthrough fits inside those caps if you keep candidates ≤99 (one SIEVE call) and one experiment of ≤99 backtests. The Pro tier unlocks larger sweeps if you want to widen the candidate pool.
 </Note>
 
 ## Prerequisites
@@ -42,20 +42,23 @@ client = MangroveAI(api_key="prod_...")
 
 ## Phase 1 — Discover the signal catalog
 
-Start by listing what's available. The Oracle catalog ships 223 signals across five categories (momentum, trend, volume, volatility, patterns). Each signal carries a type (`TRIGGER` or `FILTER`) and a `Requires` list that names the OHLCV columns it consumes.
+The Oracle catalog ships 223 signals across five categories (momentum, trend, volume, volatility, patterns). Each signal carries a type (`TRIGGER` or `FILTER`) and a `requires` list naming the OHLCV columns it consumes.
+
+`list_signals()` returns a list of plain dicts (one per signal) — keyed by `"name"`, `"type"`, `"params"`, `"requires"`, `"category"`, `"description"`.
 
 <CodeGroup>
 ```python Python
 catalog = client.oracle.list_signals()
+print(f"{len(catalog)} signals")
 
 # Pick a small mix: one entry trigger + one entry filter + one exit trigger
-entry_trigger = next(s for s in catalog if s.name == "rsi_oversold")
-entry_filter  = next(s for s in catalog if s.name == "is_above_sma")
-exit_trigger  = next(s for s in catalog if s.name == "rsi_overbought")
+entry_trigger = next(s for s in catalog if s["name"] == "rsi_oversold")
+entry_filter  = next(s for s in catalog if s["name"] == "is_above_sma")
+exit_trigger  = next(s for s in catalog if s["name"] == "rsi_overbought")
 
-print(f"Entry trigger: {entry_trigger.name} (params: {entry_trigger.params})")
-print(f"Entry filter:  {entry_filter.name}  (params: {entry_filter.params})")
-print(f"Exit trigger:  {exit_trigger.name}  (params: {exit_trigger.params})")
+print(f"Entry trigger: {entry_trigger['name']}  (type={entry_trigger['type']})")
+print(f"Entry filter:  {entry_filter['name']}   (type={entry_filter['type']})")
+print(f"Exit trigger:  {exit_trigger['name']}   (type={exit_trigger['type']})")
 ```
 
 ```bash cURL
@@ -64,14 +67,15 @@ curl -H "Authorization: Bearer $TOKEN" $BASE/api/v1/oracle/signals \
 ```
 </CodeGroup>
 
-For deeper inspection of any signal's parameters see [Signals reference](/signals) or hit `client.kb.list_signals()` (the docstring-extracted version) — both return the same source of truth.
+For deeper inspection of any signal's parameters see [Signals reference](/signals).
 
 ## Phase 2 — Generate candidates + SIEVE filter
 
-Build N parameter combinations of the chosen signal mix, then score them all in one round-trip through [SIEVE](/api-reference/sieve). The 4-class head tells you which combinations are most likely to win.
+Build N parameter combinations of the chosen signal mix, then score them in one round-trip through [SIEVE](/api-reference/sieve). The 4-class head tells you which combinations are most likely to win.
 
 ```python Python
 import itertools
+from mangrove_ai.models.oracle import SieveScoreRequest
 
 # Sweep three params (~24 candidates). Stay well under 99 per SIEVE call.
 candidates = []
@@ -98,10 +102,10 @@ for rsi_window, oversold, sma_window in itertools.product(
 print(f"Built {len(candidates)} candidates")
 ```
 
-Score them all:
+Score them all in one call (note: `sieve_score` takes a `SieveScoreRequest` object, not a bare `strategies=` keyword):
 
 ```python Python
-response = client.oracle.sieve_score(strategies=candidates)
+response = client.oracle.sieve_score(SieveScoreRequest(strategies=candidates))
 
 scored = list(zip(candidates, response.predictions))
 
@@ -119,69 +123,106 @@ ranked = sorted(
     reverse=True,
 )
 top_10 = [cand for cand, _ in ranked[:10]]
-print(f"Top 10 P(winning): {[ranked[i][1].four_class['winning'] for i in range(10)]}")
+
+# Provenance is in the response
+print(f"model_version={response.model_version}")
+print(f"code_version={response.code_version}")
 ```
 
 <Tip>
 **Each `sieve_score` call is one billable `oracle_sieve_calls` unit, regardless of how many strategies are in the batch.** Pack the batch as close to 99 as you can — it's the same cost as scoring 1.
 </Tip>
 
-## Phase 3 — Bulk backtest the top survivors
+## Phase 3 — Bulk-backtest the top survivors
 
-The top-10 list goes through one [`backtest_bulk` call](/api-reference/oracle-backtest#bulk) with shared OHLCV fetches. One HTTP call, one bill, ten results.
+The cleanest endpoint for "backtest these specific N candidates with the same date range and risk config" is `POST /api/v1/oracle/backtest/bulk`. One HTTP call, shared OHLCV fetches across the batch, results in a single response.
+
+<Note>
+This guide uses raw HTTP (Python `requests`) for the bulk-backtest step. The `mangroveai` SDK 1.4.0 typed wrapper currently marks the 17 required risk-mgmt fields as `Optional` (`None` default), but the server requires every one explicitly — see the warning callout on [Oracle backtest](/api-reference/oracle-backtest) for the SDK ↔ server contract gap. Until the SDK Optional typing is reconciled, raw HTTP is the cleanest pattern.
+</Note>
+
+Convert each SIEVE-survived candidate into a `strategy_configs` entry, fetch canonical execution defaults, then issue one bulk call:
 
 ```python Python
 import json
-from mangrove_ai.models.oracle import OracleBulkBacktestRequest
+import requests
 
-# Convert SIEVE-shaped strategies into bulk-backtest shape
-def to_backtest_entry(strategy):
-    return {
-        "asset": strategy["asset"],
+API_KEY = "prod_..."  # same key used for the SDK above
+BASE    = "https://api.mangrovedeveloper.ai"
+HEADERS = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
+
+# Canonical execution_config defaults
+defaults = requests.get(f"{BASE}/api/v1/oracle/exec-config/defaults", headers=HEADERS).json()
+
+# Wrap each candidate into the bulk-backtest strategy_configs shape
+strategy_configs = [
+    {
+        "asset": cand["asset"],
         "interval": "1h",
         "strategy_json": json.dumps({
-            "entry": strategy["entry"],
-            "exit":  strategy["exit"],
-            "execution_config": strategy["execution_config"],
+            "asset":  cand["asset"],
+            "interval": "1h",
+            "entry":  cand["entry"],
+            "exit":   cand["exit"],
         }),
     }
+    for cand in top_10
+]
 
-bulk_request = OracleBulkBacktestRequest(
-    start_date="2024-01-01",
-    end_date="2024-12-31",
-    initial_balance=10000,
-    min_balance_threshold=100,
-    min_trade_amount=10,
-    max_open_positions=1,
-    max_trades_per_day=5,
-    max_risk_per_trade=0.02,
-    max_units_per_trade=1.0,
-    max_trade_amount=5000,
-    volatility_window=14,
-    strategies=[to_backtest_entry(s) for s in top_10],
-)
+body = {
+    "start_date": "2024-01-01T00:00:00Z",
+    "end_date":   "2024-12-31T00:00:00Z",
+    "strategy_configs": strategy_configs,
+    "execution_config": {
+        "position_size_calc": defaults["position_size_calc"],  # required: 'v2'
+    },
+    # 15 required risk-mgmt fields — populate from canonical defaults
+    "initial_balance":       defaults["initial_balance"],
+    "min_balance_threshold": 100,
+    "min_trade_amount":      defaults["min_trade_amount"],
+    "max_open_positions":    1,
+    "max_trades_per_day":    5,
+    "max_risk_per_trade":    0.02,
+    "max_units_per_trade":   1.0,
+    "max_trade_amount":      5000,
+    "volatility_window":     14,
+    "target_volatility":     0.20,
+    "volatility_mode":       "off",
+    "enable_volatility_adjustment": False,
+    "cooldown_bars":         defaults["cooldown_bars"],
+    "daily_momentum_limit":  defaults["daily_momentum_limit"],
+    "weekly_momentum_limit": defaults["weekly_momentum_limit"],
+}
 
-result = client.oracle.backtest_bulk(bulk_request)
-print(f"Bulk run: {len(result.results)} results in "
-      f"{result.total_execution_time_seconds:.1f}s, "
-      f"{result.data_fetches} OHLCV fetch(es)")
+resp = requests.post(f"{BASE}/api/v1/oracle/backtest/bulk",
+                     headers=HEADERS, json=body, timeout=300)
+data = resp.json()
+print(f"Bulk: {len(data['results'])} results in "
+      f"{data['total_execution_time_seconds']:.1f}s, "
+      f"{data['data_fetches']} OHLCV fetch(es)")
 ```
 
-Pick a metric that matters for your goal (Sortino weights downside; Sharpe is the conventional choice; Calmar emphasises drawdown):
+Pick the winner. Rank by Sortino (downside-aware), fall back to Sharpe on ties:
 
 ```python Python
-# Rank by Sortino, fall back to Sharpe on ties
+# Each entry in data["results"] has the shape:
+#   {"success": bool, "strategy_name": str, "strategy_id": str,
+#    "metrics": {...}, "trade_count": int,
+#    "execution_time_seconds": float, "error": str | None}
+# `strategy_configs` preserves input order — data["results"][i] corresponds
+# to strategy_configs[i] / top_10[i].
+successful = [(i, r) for i, r in enumerate(data["results"]) if r.get("success")]
+
 ranked_bt = sorted(
-    enumerate(result.results),
+    successful,
     key=lambda ir: (
         ir[1]["metrics"].get("sortino", 0),
         ir[1]["metrics"].get("sharpe", 0),
     ),
     reverse=True,
 )
-
 best_idx, best = ranked_bt[0]
-print(f"Best by Sortino: idx={best_idx}")
+print(f"Best by Sortino:")
 print(f"  sortino={best['metrics']['sortino']:.2f}")
 print(f"  sharpe={best['metrics']['sharpe']:.2f}")
 print(f"  win_rate={best['metrics']['win_rate']:.2%}")
@@ -189,64 +230,58 @@ print(f"  max_drawdown={best['metrics']['max_drawdown']:.2%}")
 print(f"  trades={best['trade_count']}")
 ```
 
-If `total_trades == 0` on the winner, your candidates didn't actually fire entries in the test window — go back to Phase 2, widen the parameter ranges, and re-rank. The bulk endpoint billed you for the call regardless; SIEVE's `p_no_trades` is the cheaper place to catch that.
+If your winner has `trade_count == 0`, the surviving candidates didn't fire entries in this window — widen the parameter ranges in Phase 2 and re-rank. SIEVE's `p_no_trades` is the cheaper place to catch that.
 
-See [Oracle backtest reference](/api-reference/oracle-backtest) for the full request and response shapes, including `denied_signals` (which the engine populates when a signal mix is rejected before evaluation).
+For the full request/response shape see [Oracle backtest reference](/api-reference/oracle-backtest). For larger sweeps with a managed lifecycle, see [Experiments](/api-reference/experiments).
 
 ## Phase 4 — Adopt the winner to paper trading
 
-The winning strategy lives in your local Python variable. To run it autonomously on MangroveAI, register it as a strategy, then promote it to `paper`. Paper trading runs the strategy against live OHLCV with simulated fills — no wallet, no capital, no on-chain risk.
+The winning candidate (`top_10[i]` for the index `i` matching the experiment's best result) becomes a registered MangroveAI strategy. Paper trading runs the strategy against live OHLCV with simulated fills — no wallet, no capital, no on-chain risk.
 
 ```python Python
-winner_strategy = top_10[best_idx]
+from mangrove_ai.models.strategies import CreateStrategyRequest
 
-# 1. Register the strategy on MangroveAI
-created = client.strategies.create(
-    name=f"sieve-winner-{winner_strategy['asset']}-1h",
-    description="Top performer from SIEVE→bulk sweep, 2024-01..2024-12",
-    asset=winner_strategy["asset"],
-    timeframe="1h",
-    entry=winner_strategy["entry"],
-    exit=winner_strategy["exit"],
-    execution_config=winner_strategy["execution_config"],
-)
-print(f"Created strategy: {created.id}")
+# Match the winning configuration back to its candidate
+# best_idx came from the bulk response — strategy_configs preserved input order
+winner_candidate = top_10[best_idx]  # the SIEVE candidate object
+
+# 1. Register the strategy
+created_strategy = client.strategies.create(CreateStrategyRequest(
+    name=f"sieve-winner-{winner_candidate['asset']}-1h",
+    description="Top performer from SIEVE → experiment sweep, BTC 1h 2024",
+    asset=winner_candidate["asset"],
+    entry=winner_candidate["entry"],
+    exit=winner_candidate["exit"],
+    execution_config=winner_candidate["execution_config"],
+))
+print(f"Created strategy: {created_strategy.id}")
 
 # 2. Promote to paper trading
-client.strategies.update_status(
-    strategy_id=created.id,
-    status="paper",
-    confirm=True,
-)
-print(f"Strategy {created.id} is now paper-trading.")
+client.strategies.update_status(created_strategy.id, "paper")
+print(f"Strategy {created_strategy.id} is now paper-trading.")
 ```
 
-The platform schedules an evaluation on the strategy's timeframe (`1h` here) and accrues simulated fills as the signal fires. Inspect runs via `client.evaluation.list(strategy_id=...)` or `client.strategies.get(strategy_id=...)`.
+The platform schedules an evaluation on the strategy's timeframe and accrues simulated fills as the signal fires.
 
 ### Promoting to live
 
-When you're satisfied with paper performance, the next promotion is `paper` → `live`. That step requires:
-
-- A connected wallet with a confirmed backup
-- An allocation block (`wallet_address`, `token`, `amount`, `slippage_pct`)
-- `confirm=true` on the status update
-
-See the wallet-connect / live-promotion docs (linked from [Creating a strategy](/guides/creating-a-strategy)) for the full gating story — beyond the scope of this guide.
+`paper` → `live` is gated server-side on a wallet with a confirmed backup, an allocation block (`wallet_address`, `token`, `amount`, `slippage_pct`), and an explicit confirmation flag — none of which are exposed by `strategies.update_status(strategy_id, status)` in SDK 1.4.0. The live promotion currently requires a raw PATCH against `/api/v1/strategies/{id}/status` with the allocation block in the body. See [Creating a strategy](/guides/creating-a-strategy) for the live-promotion contract and wallet-connect gating.
 
 ## Saving the provenance
 
-Every SIEVE response carries `model_version` and `code_version`; every Oracle backtest carries the same in its metrics envelope. Log them next to any decision so a future you can tell which model + corpus snapshot drove the call.
+Every SIEVE response carries `model_version` and `code_version`; experiment results carry their own provenance stamps. Log them next to every adoption decision so a future you can tell which model + corpus snapshot drove the call.
 
 ```python Python
 import datetime, json
 
 decision_log = {
-    "winner_strategy_id": created.id,
+    "winner_strategy_id": created_strategy.id,
     "sieve_p_winning":    ranked[best_idx][1].four_class["winning"],
+    "experiment_id":      exp_id,
     "backtest_sortino":   best["metrics"]["sortino"],
     "backtest_sharpe":    best["metrics"]["sharpe"],
-    "model_version":      response.model_version,
-    "code_version":       response.code_version,
+    "sieve_model_version": response.model_version,
+    "sieve_code_version":  response.code_version,
     "decided_at":         datetime.datetime.utcnow().isoformat(),
 }
 print(json.dumps(decision_log, indent=2))
@@ -255,8 +290,8 @@ print(json.dumps(decision_log, indent=2))
 ## See also
 
 - [Filtering Strategies with Mangrove SIEVE](/guides/using-sieve-prefilter) — deeper dive on the SIEVE prefilter step in isolation
-- [Oracle backtest reference](/api-reference/oracle-backtest) — full request/response shapes for `backtest`, `backtest_async`, `backtest_bulk`, `data_query`
+- [Oracle backtest reference](/api-reference/oracle-backtest) — full request/response shapes for the single-strategy backtest endpoints + data corpus query
+- [Experiments](/api-reference/experiments) — the sweep lifecycle used in Phase 3
 - [SIEVE API reference](/api-reference/sieve) — endpoint details for `sieve/score`
-- [Experiments](/api-reference/experiments) — for sweeps larger than a single bulk request (uses experiment lifecycle instead)
 - [Creating a strategy](/guides/creating-a-strategy) — strategy-object shape, status transitions, and the wallet/allocation gating for `live`
 - [`mangroveai` Python SDK](/sdks/mangroveai)

--- a/docs/guides/sieve-to-live-strategy.mdx
+++ b/docs/guides/sieve-to-live-strategy.mdx
@@ -1,0 +1,262 @@
+---
+title: "SIEVE → backtest → paper: end-to-end strategy adoption"
+description: "Combine SIEVE pre-filtering with bulk backtests and the strategy lifecycle to go from 'list of candidates' to a paper-trading strategy in four phases."
+---
+
+# SIEVE → backtest → paper
+
+This guide walks the full chain from "I have a signal mix I want to explore" to "I have a paper-trading strategy live in MangroveAI."
+
+Four phases:
+
+<Steps>
+  <Step title="Discover the signal catalog" />
+  <Step title="Generate candidates + SIEVE filter" />
+  <Step title="Bulk backtest the top survivors" />
+  <Step title="Adopt the winner to paper trading" />
+</Steps>
+
+Each phase corresponds to one (or two) SDK calls. The Python tabs use the `mangroveai` SDK (v1.4.0+); the cURL tabs hit the underlying `/api/v1/*` surface directly.
+
+<Note>
+**Tier note.** Beginner accounts cap at 10 SIEVE calls / month, 2 sweep launches / month, and 25 backtests / month. This walkthrough fits inside those caps if you stop at top-10 (one bulk backtest call) — no Pro tier required. The Pro tier (1 SIEVE call = 99 strategies) unlocks the wider 1,000-candidate fan-in covered at the end.
+</Note>
+
+## Prerequisites
+
+- A MangroveAI API key (`prod_…`). See [Authentication](/authentication).
+- The `mangroveai` Python SDK 1.4.0+ (`pip install -U mangroveai`).
+
+<CodeGroup>
+```bash cURL
+export TOKEN="prod_..."
+export BASE="https://api.mangrovedeveloper.ai"
+```
+
+```python Python
+from mangrove_ai import MangroveAI
+
+client = MangroveAI(api_key="prod_...")
+```
+</CodeGroup>
+
+## Phase 1 — Discover the signal catalog
+
+Start by listing what's available. The Oracle catalog ships 223 signals across five categories (momentum, trend, volume, volatility, patterns). Each signal carries a type (`TRIGGER` or `FILTER`) and a `Requires` list that names the OHLCV columns it consumes.
+
+<CodeGroup>
+```python Python
+catalog = client.oracle.list_signals()
+
+# Pick a small mix: one entry trigger + one entry filter + one exit trigger
+entry_trigger = next(s for s in catalog if s.name == "rsi_oversold")
+entry_filter  = next(s for s in catalog if s.name == "is_above_sma")
+exit_trigger  = next(s for s in catalog if s.name == "rsi_overbought")
+
+print(f"Entry trigger: {entry_trigger.name} (params: {entry_trigger.params})")
+print(f"Entry filter:  {entry_filter.name}  (params: {entry_filter.params})")
+print(f"Exit trigger:  {exit_trigger.name}  (params: {exit_trigger.params})")
+```
+
+```bash cURL
+curl -H "Authorization: Bearer $TOKEN" $BASE/api/v1/oracle/signals \
+  | jq '.[] | select(.name == "rsi_oversold" or .name == "is_above_sma" or .name == "rsi_overbought")'
+```
+</CodeGroup>
+
+For deeper inspection of any signal's parameters see [Signals reference](/signals) or hit `client.kb.list_signals()` (the docstring-extracted version) — both return the same source of truth.
+
+## Phase 2 — Generate candidates + SIEVE filter
+
+Build N parameter combinations of the chosen signal mix, then score them all in one round-trip through [SIEVE](/api-reference/sieve). The 4-class head tells you which combinations are most likely to win.
+
+```python Python
+import itertools
+
+# Sweep three params (~24 candidates). Stay well under 99 per SIEVE call.
+candidates = []
+for rsi_window, oversold, sma_window in itertools.product(
+    [7, 14, 21],
+    [25, 30],
+    [50, 100, 200, 300],
+):
+    candidates.append({
+        "asset": "BTC",
+        "entry": [
+            {"name": "rsi_oversold",  "signal_type": "TRIGGER", "timeframe": "1h",
+             "params": {"window": rsi_window, "threshold": oversold}},
+            {"name": "is_above_sma",  "signal_type": "FILTER",  "timeframe": "1h",
+             "params": {"window": sma_window}},
+        ],
+        "exit": [
+            {"name": "rsi_overbought", "signal_type": "TRIGGER", "timeframe": "1h",
+             "params": {"window": rsi_window, "threshold": 70}},
+        ],
+        "execution_config": {"reward_factor": 2.0, "max_risk_per_trade": 0.01},
+    })
+
+print(f"Built {len(candidates)} candidates")
+```
+
+Score them all:
+
+```python Python
+response = client.oracle.sieve_score(strategies=candidates)
+
+scored = list(zip(candidates, response.predictions))
+
+# Drop strategies SIEVE thinks won't fire at all
+will_trade = [
+    (cand, pred) for cand, pred in scored
+    if pred.binary["p_no_trades"] < 0.5
+]
+print(f"After binary filter: {len(will_trade)} / {len(candidates)} survive")
+
+# Rank survivors by P(winning)
+ranked = sorted(
+    will_trade,
+    key=lambda sp: sp[1].four_class["winning"],
+    reverse=True,
+)
+top_10 = [cand for cand, _ in ranked[:10]]
+print(f"Top 10 P(winning): {[ranked[i][1].four_class['winning'] for i in range(10)]}")
+```
+
+<Tip>
+**Each `sieve_score` call is one billable `oracle_sieve_calls` unit, regardless of how many strategies are in the batch.** Pack the batch as close to 99 as you can — it's the same cost as scoring 1.
+</Tip>
+
+## Phase 3 — Bulk backtest the top survivors
+
+The top-10 list goes through one [`backtest_bulk` call](/api-reference/oracle-backtest#bulk) with shared OHLCV fetches. One HTTP call, one bill, ten results.
+
+```python Python
+import json
+from mangrove_ai.models.oracle import OracleBulkBacktestRequest
+
+# Convert SIEVE-shaped strategies into bulk-backtest shape
+def to_backtest_entry(strategy):
+    return {
+        "asset": strategy["asset"],
+        "interval": "1h",
+        "strategy_json": json.dumps({
+            "entry": strategy["entry"],
+            "exit":  strategy["exit"],
+            "execution_config": strategy["execution_config"],
+        }),
+    }
+
+bulk_request = OracleBulkBacktestRequest(
+    start_date="2024-01-01",
+    end_date="2024-12-31",
+    initial_balance=10000,
+    min_balance_threshold=100,
+    min_trade_amount=10,
+    max_open_positions=1,
+    max_trades_per_day=5,
+    max_risk_per_trade=0.02,
+    max_units_per_trade=1.0,
+    max_trade_amount=5000,
+    volatility_window=14,
+    strategies=[to_backtest_entry(s) for s in top_10],
+)
+
+result = client.oracle.backtest_bulk(bulk_request)
+print(f"Bulk run: {len(result.results)} results in "
+      f"{result.total_execution_time_seconds:.1f}s, "
+      f"{result.data_fetches} OHLCV fetch(es)")
+```
+
+Pick a metric that matters for your goal (Sortino weights downside; Sharpe is the conventional choice; Calmar emphasises drawdown):
+
+```python Python
+# Rank by Sortino, fall back to Sharpe on ties
+ranked_bt = sorted(
+    enumerate(result.results),
+    key=lambda ir: (
+        ir[1]["metrics"].get("sortino", 0),
+        ir[1]["metrics"].get("sharpe", 0),
+    ),
+    reverse=True,
+)
+
+best_idx, best = ranked_bt[0]
+print(f"Best by Sortino: idx={best_idx}")
+print(f"  sortino={best['metrics']['sortino']:.2f}")
+print(f"  sharpe={best['metrics']['sharpe']:.2f}")
+print(f"  win_rate={best['metrics']['win_rate']:.2%}")
+print(f"  max_drawdown={best['metrics']['max_drawdown']:.2%}")
+print(f"  trades={best['trade_count']}")
+```
+
+If `total_trades == 0` on the winner, your candidates didn't actually fire entries in the test window — go back to Phase 2, widen the parameter ranges, and re-rank. The bulk endpoint billed you for the call regardless; SIEVE's `p_no_trades` is the cheaper place to catch that.
+
+See [Oracle backtest reference](/api-reference/oracle-backtest) for the full request and response shapes, including `denied_signals` (which the engine populates when a signal mix is rejected before evaluation).
+
+## Phase 4 — Adopt the winner to paper trading
+
+The winning strategy lives in your local Python variable. To run it autonomously on MangroveAI, register it as a strategy, then promote it to `paper`. Paper trading runs the strategy against live OHLCV with simulated fills — no wallet, no capital, no on-chain risk.
+
+```python Python
+winner_strategy = top_10[best_idx]
+
+# 1. Register the strategy on MangroveAI
+created = client.strategies.create(
+    name=f"sieve-winner-{winner_strategy['asset']}-1h",
+    description="Top performer from SIEVE→bulk sweep, 2024-01..2024-12",
+    asset=winner_strategy["asset"],
+    timeframe="1h",
+    entry=winner_strategy["entry"],
+    exit=winner_strategy["exit"],
+    execution_config=winner_strategy["execution_config"],
+)
+print(f"Created strategy: {created.id}")
+
+# 2. Promote to paper trading
+client.strategies.update_status(
+    strategy_id=created.id,
+    status="paper",
+    confirm=True,
+)
+print(f"Strategy {created.id} is now paper-trading.")
+```
+
+The platform schedules an evaluation on the strategy's timeframe (`1h` here) and accrues simulated fills as the signal fires. Inspect runs via `client.evaluation.list(strategy_id=...)` or `client.strategies.get(strategy_id=...)`.
+
+### Promoting to live
+
+When you're satisfied with paper performance, the next promotion is `paper` → `live`. That step requires:
+
+- A connected wallet with a confirmed backup
+- An allocation block (`wallet_address`, `token`, `amount`, `slippage_pct`)
+- `confirm=true` on the status update
+
+See the wallet-connect / live-promotion docs (linked from [Creating a strategy](/guides/creating-a-strategy)) for the full gating story — beyond the scope of this guide.
+
+## Saving the provenance
+
+Every SIEVE response carries `model_version` and `code_version`; every Oracle backtest carries the same in its metrics envelope. Log them next to any decision so a future you can tell which model + corpus snapshot drove the call.
+
+```python Python
+import datetime, json
+
+decision_log = {
+    "winner_strategy_id": created.id,
+    "sieve_p_winning":    ranked[best_idx][1].four_class["winning"],
+    "backtest_sortino":   best["metrics"]["sortino"],
+    "backtest_sharpe":    best["metrics"]["sharpe"],
+    "model_version":      response.model_version,
+    "code_version":       response.code_version,
+    "decided_at":         datetime.datetime.utcnow().isoformat(),
+}
+print(json.dumps(decision_log, indent=2))
+```
+
+## See also
+
+- [Filtering Strategies with Mangrove SIEVE](/guides/using-sieve-prefilter) — deeper dive on the SIEVE prefilter step in isolation
+- [Oracle backtest reference](/api-reference/oracle-backtest) — full request/response shapes for `backtest`, `backtest_async`, `backtest_bulk`, `data_query`
+- [SIEVE API reference](/api-reference/sieve) — endpoint details for `sieve/score`
+- [Experiments](/api-reference/experiments) — for sweeps larger than a single bulk request (uses experiment lifecycle instead)
+- [Creating a strategy](/guides/creating-a-strategy) — strategy-object shape, status transitions, and the wallet/allocation gating for `live`
+- [`mangroveai` Python SDK](/sdks/mangroveai)

--- a/docs/mangrove-agent/mcp-tools.mdx
+++ b/docs/mangrove-agent/mcp-tools.mdx
@@ -1,189 +1,1792 @@
 ---
 title: "MCP tools catalog"
-description: "The ~90 tools the agent exposes over MCP, with their REST mirrors at /api/v1/agent/*."
+description: "All 90 MCP tools the agent exposes, grouped into 14 domains. Each tool documents its arguments and access tier. REST mirrors at /api/v1/agent/*."
 ---
 
 # MCP tools catalog
 
-The agent exposes **~90 MCP tools** (plus the `hello_mangrove` x402 demo) over Streamable HTTP, plus a mirrored REST surface at `/api/v1/agent/*`. Both paths call the same service layer — pick whichever fits your caller.
+The agent registers **90 MCP tools** across **14 domains**. Every tool is exposed over Streamable HTTP MCP **and** as a mirrored REST endpoint at `/api/v1/agent/*` — pick whichever fits your caller. Both paths call the same service layer.
 
-## Discovery (free, no auth)
+Each domain section below renders as a collapsed accordion list. Click a tool to expand its description, argument table, and access tier. Use your browser's find-in-page (ctrl-F / cmd-F) to locate a tool by name — collapsed accordions are still text-searchable.
 
-| Tool | Purpose |
-|---|---|
-| `status` | Health + version + capability snapshot. |
-| `list_tools` | Tool catalog (what you're reading, queryable). |
-| `hello_mangrove` | x402 payment demo. |
+## How to read this catalog
+
+- **Access** is one of:
+    - `free` — no auth, no charge (discovery, status, demo)
+    - `auth` — requires `X-API-Key` (or Bearer JWT)
+    - `x402` — pay-per-call via x402 micropayment; check the tool's price field
+- **Args** with `required = yes` must be supplied; the rest fall back to server defaults.
+- **Type** strings (`string`, `integer`, `array<Strategy>`, …) reflect the agent's MCP schema, not Python types.
+
+<Note>
+This page is **generated** from [`mangrove-agent/server/src/mcp/tools.py`](https://github.com/MangroveTechnologies/mangrove-agent/blob/main/server/src/mcp/tools.py) via `scripts/generate-mcp-tools-catalog.py`. When the agent adds or renames a tool, re-run the generator and commit the regenerated MDX.
+</Note>
+
+## Discovery
+
+_2 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="list_tools" description="free — MCP tool catalog (name, tier, params, pricing). Free, no auth.">
+
+MCP tool catalog (name, tier, params, pricing). Free, no auth.
+
+_No arguments._
+
+**Access:** free
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="status" description="free — Agent status + counts + uptime. Free, no auth.">
+
+Agent status + counts + uptime. Free, no auth.
+
+_No arguments._
+
+**Access:** free
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## Wallet
 
-| Tool | Purpose |
-|---|---|
-| `create_wallet` | Generate a new wallet. Returns a `vault_token`, never the secret. |
-| `import_wallet` | Bring in an existing wallet by encrypted vault entry. |
-| `list_wallets` | Wallets registered with this agent. |
-| `get_balances` | Native + ERC-20 balances per chain. |
-| `portfolio_value` | USD value across all tracked addresses. |
-| `portfolio_pnl` | Realized + unrealized P&L. |
+_9 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="create_wallet" description="auth — Create + encrypt a wallet. Response carries only vault_token + reveal_cmd — plaintext never enter…">
+
+Create + encrypt a wallet. Response carries only vault_token + reveal_cmd — plaintext never enters the Claude Code transcript. EVM only in v1.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chain` | `string` | no | evm (default). xrpl stubbed 501 in v1. |
+| `network` | `string` | no | mainnet (default) \| testnet |
+| `chain_id` | `integer` | no | Default 8453 (Base mainnet) |
+| `label` | `string` | no | Human-friendly name |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_balances" description="auth — Token balances for a wallet.">
+
+Token balances for a wallet.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `address` | `string` | **yes** | Wallet address |
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="import_wallet" description="auth — Import an existing wallet from a stashed vault_token. The user must obtain the id by running scri…">
+
+Import an existing wallet from a stashed vault_token. The user must obtain the id by running scripts/stash-secret.sh in a terminal FIRST — this tool refuses raw keys by design.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `vault_token` | `string` | **yes** | From scripts/stash-secret.sh output |
+| `chain` | `string` | no | evm (default) |
+| `network` | `string` | no | mainnet (default) \| testnet |
+| `chain_id` | `integer` | no | Default 8453 (Base mainnet) |
+| `label` | `string` | no | Human-friendly name |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_wallets" description="auth — List stored wallets (secrets never returned).">
+
+List stored wallets (secrets never returned).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="portfolio_defi" description="auth — DeFi positions (LP, lending, staking) across wallets.">
+
+DeFi positions (LP, lending, staking) across wallets.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `addresses` | `string` | **yes** | Comma-separated wallet addresses |
+| `chain_id` | `integer` | no | Optional: pin to a single chain |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="portfolio_history" description="auth — On-chain tx history for a single wallet (all txs, not just strategy-driven).">
+
+On-chain tx history for a single wallet (all txs, not just strategy-driven).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `address` | `string` | **yes** | Single wallet address |
+| `limit` | `integer` | no | Max results (default 50) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="portfolio_pnl" description="auth — Realized + unrealized P&L for one or more wallets.">
+
+Realized + unrealized P&L for one or more wallets.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `addresses` | `string` | **yes** | Comma-separated wallet addresses |
+| `chain_id` | `integer` | no | Optional: pin to a single chain |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="portfolio_tokens" description="auth — Per-token holdings with USD value + per-position P&L.">
+
+Per-token holdings with USD value + per-position P&L.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `addresses` | `string` | **yes** | Comma-separated wallet addresses |
+| `chain_id` | `integer` | no | Optional: pin to a single chain |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="portfolio_value" description="auth — Aggregate USD value of one or more wallet addresses.">
+
+Aggregate USD value of one or more wallet addresses.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `addresses` | `string` | **yes** | Comma-separated wallet addresses |
+| `chain_id` | `integer` | no | Optional: pin to a single chain |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## DEX
 
-| Tool | Purpose |
-|---|---|
-| `list_dex_venues` | Supported venues (1inch, XPMarket, Jupiter, …). |
-| `get_swap_quote` | Quote a swap — input/output token, amount, chain. |
-| `execute_swap` | Sign locally + broadcast. Refuses on un-backed-up wallets. |
-| `get_tx_status` | Tx confirmation status. |
-| `get_token_info` | Token metadata. |
-| `get_spot_price` | Spot price by chain. |
-| `get_gas_price` | Current gas. |
-| `get_oneinch_chart` | 1inch chart proxy. |
+_10 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="execute_swap" description="auth — Execute a DEX swap (requires confirm=true + explicit slippage_pct). Single code path shared with…">
+
+Execute a DEX swap (requires confirm=true + explicit slippage_pct). Single code path shared with cron-driven trades. Slippage is always user-specified — no default — because picking a tolerance is a risk decision.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `input_token` | `string` | **yes** | Input token |
+| `output_token` | `string` | **yes** | Output token |
+| `amount` | `number` | **yes** | Input amount |
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `wallet_address` | `string` | **yes** | Wallet from local store |
+| `slippage_pct` | `number` | **yes** | Slippage tolerance as DECIMAL, capped at 0.0025 (0.25%). Typical: 0.001 (0.1%), 0.002 (0.2%), 0.0025 (max). Higher values refused. |
+| `venue_id` | `string` | no | Optional specific venue |
+| `confirm` | `boolean` | **yes** | Must be true |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_allowances" description="auth — Check ERC-20 allowances a wallet has granted a spender (approve_token output).">
+
+Check ERC-20 allowances a wallet has granted a spender (approve_token output).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `wallet` | `string` | **yes** | Wallet address |
+| `spender` | `string` | **yes** | Spender contract address (e.g. a router) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_dex_chart" description="auth — ⚠️ BROKEN upstream (SDK sends token0/token1, server wants `address`). Use get_ohlcv for price his…">
+
+⚠️ BROKEN upstream (SDK sends token0/token1, server wants `address`). Use get_ohlcv for price history until fixed.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `token0` | `string` | **yes** | Base token (symbol or address) |
+| `token1` | `string` | **yes** | Quote token (symbol or address) |
+| `period` | `string` | no | Bar period (default '1h') |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_gas_price" description="auth — Gas price estimate for a chain (pre-flight before execute_swap).">
+
+Gas price estimate for a chain (pre-flight before execute_swap).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_spot_price" description="auth — Current spot price for one or more tokens on a chain.">
+
+Current spot price for one or more tokens on a chain.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `tokens` | `string` | **yes** | Comma-separated token symbols or addresses |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_swap_quote" description="auth — Get a DEX swap quote. Optionally pin a venue + mode.">
+
+Get a DEX swap quote. Optionally pin a venue + mode.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `input_token` | `string` | **yes** | Input token |
+| `output_token` | `string` | **yes** | Output token |
+| `amount` | `number` | **yes** | Input amount |
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `venue_id` | `string` | no | Optional specific venue |
+| `mode` | `string` | no | Optional routing hint (venue-specific) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_token_info" description="auth — ⚠️ BROKEN upstream (MangroveMarkets-MCP-Server#62). Use kb_glossary_get / kb_search for token con…">
+
+⚠️ BROKEN upstream (MangroveMarkets-MCP-Server#62). Use kb_glossary_get / kb_search for token concepts until SDK bump.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `address` | `string` | **yes** | Token contract address |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_token_search" description="auth — Fuzzy token search by symbol / partial name. Returns candidate contract addresses.">
+
+Fuzzy token search by symbol / partial name. Returns candidate contract addresses.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chain_id` | `integer` | **yes** | EVM chain id |
+| `query` | `string` | **yes** | Symbol or partial name (e.g. 'USDC', 'Pepe') |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_tx_status" description="auth — Verify a broadcast transaction's final state. Call after execute_swap — the returned tx_hash isn'…">
+
+Verify a broadcast transaction's final state. Call after execute_swap — the returned tx_hash isn't confirmed yet. Returns status: confirmed | pending | failed + block info.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `tx_hash` | `string` | **yes** | Transaction hash returned by execute_swap |
+| `chain_id` | `integer` | **yes** | EVM chain id (8453 = Base mainnet) |
+| `venue_id` | `string` | no | Optional: pin to a specific venue |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_dex_venues" description="auth — List supported DEX venues.">
+
+List supported DEX venues.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## Market data
 
-| Tool | Purpose |
-|---|---|
-| `get_ohlcv` | OHLCV by symbol and timeframe. |
-| `get_market_data` | Aggregated market metadata. |
-| `get_crypto_assets` | Asset list with filters. |
-| `get_trending_coins` | Trending list. |
-| `search_crypto_assets` | Asset search. |
+_6 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="get_asset" description="auth — Single-asset metadata + score + approval state.">
+
+Single-asset metadata + score + approval state.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | **yes** | Asset symbol (e.g. BTC, ETH) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_global_market" description="auth — Global market overview (total cap, BTC dominance, 24h change).">
+
+Global market overview (total cap, BTC dominance, 24h change).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_market_data" description="auth — Current price, market cap, volume, 24h/7d change. Optionally pin a provider.">
+
+Current price, market cap, volume, 24h/7d change. Optionally pin a provider.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | **yes** | Asset symbol |
+| `provider` | `string` | no | Optional data provider override |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_ohlcv" description="auth — OHLCV bars for an asset. Bar granularity is set by the data provider (typically 1h). No `timefram…">
+
+OHLCV bars for an asset. Bar granularity is set by the data provider (typically 1h). No `timeframe` parameter — the SDK / upstream endpoint don't support overriding bar size at this call site.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | **yes** | Asset symbol (e.g. BTC, ETH) |
+| `lookback_days` | `integer` | no | History window in days (default 30) |
+| `provider` | `string` | no | Optional CEX provider override |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_trending" description="auth — Trending crypto assets right now.">
+
+Trending crypto assets right now.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_approved_assets" description="auth — Approved crypto asset universe (agent-safe set).">
+
+Approved crypto asset universe (agent-safe set).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `min_score` | `number` | no | Optional quality threshold |
+| `limit` | `integer` | no | Max results (default 100) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## On-chain (Nansen + WhaleAlert)
 
-Pass-throughs to the `client.on_chain` SDK surface — full Nansen Pro plan + WhaleAlert Enterprise. Filters and sort orders pass straight through to the upstream provider, so you can use the same vocabulary the Nansen API itself accepts (e.g. `include_smart_money_labels: ["Fund"]`, `order_by: [{"field": "block_timestamp", "direction": "DESC"}]`).
+_11 tool(s) in this domain._
 
-**Wallet-scoped (Smart Money):**
+<AccordionGroup>
 
-| Tool | Purpose |
-|---|---|
-| `get_smart_money_sentiment` | Net accumulation vs. distribution by Smart Money on a token. |
-| `screen_smart_money` | Screen for tokens with highest Smart Money activity across chains. |
-| `get_smart_money_historical_holdings` | Date-stamped Smart Money holdings snapshots across chains. |
-| `get_smart_money_dex_trades` | Recent DEX trades from Smart Money wallets. |
-| `get_smart_money_perp_trades` | Smart Money perp trades on Hyperliquid (no chain filter — Hyperliquid-only). |
+<Accordion title="get_exchange_flows" description="auth — Net exchange inflows/outflows (selling pressure vs accumulation).">
 
-**Token-scoped:**
+Net exchange inflows/outflows (selling pressure vs accumulation).
 
-| Tool | Purpose |
-|---|---|
-| `get_token_holders` | Holder distribution + concentration for a token. |
-| `get_token_dex_trades` | All DEX trades on a token over a date window (every counterparty, not just Smart Money). |
-| `get_token_flows` | Per-wallet-category flow data for a token (stablecoins not supported — Nansen returns 404). |
+**Args**
 
-**Whale activity (WhaleAlert):**
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | no | Optional filter by asset |
+| `hours_back` | `integer` | no | Window (default 24) |
+| `api_key` | `string` | **yes** | Valid API key |
 
-| Tool | Purpose |
-|---|---|
-| `get_whale_transactions` | Whale-tier transactions filtered by token + minimum USD. |
-| `get_whale_activity` | Whale activity summary for a token over N hours. |
-| `get_exchange_flows` | Net exchange inflows / outflows — risk-off vs. risk-on proxy. |
+**Access:** auth
 
-## Oracle (sweep + corpus + backtest)
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
 
-Pass-throughs to the `client.oracle` SDK surface — score candidates through Mangrove SIEVE, query the curated Oracle corpus, run single or batch backtests, or drive full sweep experiments end-to-end.
+</Accordion>
 
-**Catalog discovery (free, non-billable):**
+<Accordion title="get_smart_money_dex_trades" description="auth — Recent DEX trades from Smart Money wallets (Nansen).">
 
-| Tool | Purpose |
-|---|---|
-| `oracle_list_datasets` | Curated OHLCV datasets experiments can run against (~2,200 dataset entries across asset / timeframe pairs). |
-| `oracle_list_signals` | Signal catalog with typed param specs (223 signals: trend / momentum / patterns / volume / volatility). |
-| `oracle_list_templates` | Predefined strategy templates to seed experiments from. |
+Recent DEX trades from Smart Money wallets (Nansen).
 
-**SIEVE scoring:**
+**Args**
 
-| Tool | Purpose |
-|---|---|
-| `sieve_score` | Score 1–99 strategies through the Mangrove SIEVE classifier (binary go / no-go + 4-class outcome probabilities + provenance). Run BEFORE paying for backtests. |
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chains` | `array` | no | Chain filter. |
+| `filters` | `object` | no | Nansen filter dict. |
+| `order_by` | `array` | no | Sort spec. |
+| `page` | `integer` | no | Page (default 1). |
+| `per_page` | `integer` | no | Items per page (default 100). |
+| `api_key` | `string` | **yes** | Valid API key |
 
-**Backtests:**
+**Access:** auth
 
-| Tool | Purpose |
-|---|---|
-| `oracle_backtest` | Synchronous single-strategy backtest. Blocks until engine finishes (typically 30–120s on multi-month windows). |
-| `oracle_backtest_async` | Submit a backtest for async execution. Returns a `backtest_id` to poll. |
-| `oracle_backtest_poll` | Poll status / full result of an async backtest by ID. |
-| `oracle_backtest_bulk` | Bulk-evaluate many strategies against a shared date range with shared OHLCV fetches. |
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
 
-**Data corpus query (BigQuery proxy):**
+</Accordion>
 
-| Tool | Purpose |
-|---|---|
-| `oracle_data_query` | Query the curated corpus (`results` / `ohlcv`). Columns + filter ops whitelisted server-side; tenancy enforced by Oracle. |
+<Accordion title="get_smart_money_historical_holdings" description="auth — Smart Money historical holdings snapshots across chains (Nansen).">
 
-**Experiments lifecycle (sweep authoring):**
+Smart Money historical holdings snapshots across chains (Nansen).
 
-| Tool | Purpose |
-|---|---|
-| `oracle_create_experiment` | Create a draft experiment from a config dict (`name` required at minimum). |
-| `oracle_list_experiments` | List experiments for the calling org (compact summary view). |
-| `oracle_get_experiment` | Full experiment config + current progress (`completed_runs`). |
-| `oracle_update_experiment` | Replace a draft experiment's config (PUT — drafts only). |
-| `oracle_delete_experiment` | Delete an experiment + cancel any in-flight children. |
-| `oracle_validate_experiment` | Validate a draft — required transition before launch. Server returns structured `errors` if config is incomplete. |
-| `oracle_launch_experiment` | Fan out a validated experiment into up to 99 child backtests. Returns immediately; poll progress. |
-| `oracle_pause_experiment` | Halt a running experiment without losing completed results. |
-| `oracle_list_results` | Paginated read of materializing backtest results under an experiment. |
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chains` | `array` | no | Chain filter, e.g. ['ethereum', 'solana']. Default ['ethereum']. |
+| `date_from` | `string` | no | ISO date 'YYYY-MM-DD'. |
+| `date_to` | `string` | no | ISO date 'YYYY-MM-DD'. |
+| `filters` | `object` | no | Nansen filter dict (include_smart_money_labels, etc.) |
+| `order_by` | `array` | no | Sort spec, e.g. [{'field': 'block_timestamp', 'direction': 'DESC'}] |
+| `page` | `integer` | no | Page (default 1) |
+| `per_page` | `integer` | no | Items per page (default 100) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_smart_money_perp_trades" description="auth — Smart Money perp trades on Hyperliquid (Nansen).">
+
+Smart Money perp trades on Hyperliquid (Nansen).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `filters` | `object` | no | Nansen filter dict. |
+| `order_by` | `array` | no | Sort spec. |
+| `page` | `integer` | no | Page (default 1). |
+| `per_page` | `integer` | no | Items per page (default 100). |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_smart_money_sentiment" description="auth — Smart-money sentiment for an asset (aggregate of tracked wallets).">
+
+Smart-money sentiment for an asset (aggregate of tracked wallets).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | **yes** | Asset symbol |
+| `chain` | `string` | no | Optional chain filter |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_token_dex_trades" description="auth — All DEX trades for a single token in a date window (Nansen).">
+
+All DEX trades for a single token in a date window (Nansen).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | **yes** | Token symbol (e.g. 'uniswap'). |
+| `chain` | `string` | no | Chain (default 'ethereum'). |
+| `date_from` | `string` | no | ISO 'YYYY-MM-DD'. |
+| `date_to` | `string` | no | ISO 'YYYY-MM-DD'. |
+| `filters` | `object` | no | Nansen filter dict. |
+| `order_by` | `array` | no | Sort spec. |
+| `page` | `integer` | no | Page (default 1). |
+| `per_page` | `integer` | no | Items per page (default 100). |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_token_flows" description="auth — Per-wallet-category flow data for a token across a date window (Nansen).">
+
+Per-wallet-category flow data for a token across a date window (Nansen).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | **yes** | Token symbol (non-stablecoin). |
+| `chain` | `string` | no | Chain (default 'ethereum'). |
+| `date_from` | `string` | no | ISO 'YYYY-MM-DD'. |
+| `date_to` | `string` | no | ISO 'YYYY-MM-DD'. |
+| `filters` | `object` | no | Nansen filter dict. |
+| `order_by` | `array` | no | Sort spec. |
+| `page` | `integer` | no | Page (default 1). |
+| `per_page` | `integer` | no | Items per page (default 100). |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_token_holders" description="auth — Top holders + distribution for a token.">
+
+Top holders + distribution for a token.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | **yes** | Asset symbol |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_whale_activity" description="auth — Whale buying/selling activity for an asset.">
+
+Whale buying/selling activity for an asset.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | **yes** | Asset symbol (e.g. ETH) |
+| `hours_back` | `integer` | no | Window (default 24) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_whale_transactions" description="auth — Whale transactions above a USD threshold.">
+
+Whale transactions above a USD threshold.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `symbol` | `string` | no | Optional filter by asset |
+| `min_value` | `number` | no | Min USD value (default 500000) |
+| `hours_back` | `integer` | no | Window (default 24) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="screen_smart_money" description="auth — Screen assets smart money is currently accumulating.">
+
+Screen assets smart money is currently accumulating.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chains` | `array` | no | Optional list of chain names |
+| `timeframe` | `string` | no | Lookback (default '24h') |
+| `limit` | `integer` | no | Max results (default 20) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
+
+## Oracle
+
+_18 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="oracle_backtest" description="auth — Backtest one strategy through Oracle's engine (synchronous).">
+
+Backtest one strategy through Oracle's engine (synchronous).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `asset` | `string` | **yes** | e.g. BTC, ETH |
+| `interval` | `string` | **yes** | e.g. 1h, 4h, 1d |
+| `strategy_json` | `string` | **yes** | Strategy JSON (MangroveAI shape). |
+| `lookback_months` | `integer` | no | Default 12. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_backtest_async" description="auth — Submit an Oracle backtest for async execution. Returns backtest_id to poll.">
+
+Submit an Oracle backtest for async execution. Returns backtest_id to poll.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `asset` | `string` | **yes** | e.g. BTC, ETH |
+| `interval` | `string` | **yes** | e.g. 1h, 4h, 1d |
+| `strategy_json` | `string` | **yes** | Strategy JSON (MangroveAI shape). |
+| `lookback_months` | `integer` | no | Default 12. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_backtest_bulk" description="auth — Bulk-evaluate N strategies via Oracle with shared market-data fetches.">
+
+Bulk-evaluate N strategies via Oracle with shared market-data fetches.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `request` | `object` | **yes** | OracleBulkBacktestRequest dict (strategy_ids, strategy_configs, shared risk + date fields). |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_backtest_poll" description="auth — Poll the status / full result of an async Oracle backtest.">
+
+Poll the status / full result of an async Oracle backtest.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `backtest_id` | `string` | **yes** | ID returned by oracle_backtest_async. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_create_experiment" description="auth — Create an Oracle sweep experiment in draft status.">
+
+Create an Oracle sweep experiment in draft status.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `config` | `object` | **yes** | ExperimentConfig dict (name required). |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_data_query" description="auth — Query the curated Oracle corpus (results / ohlcv). Whitelist-enforced columns + filter ops; tenan…">
+
+Query the curated Oracle corpus (results / ohlcv). Whitelist-enforced columns + filter ops; tenancy injected server-side.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `table` | `string` | **yes** | 'results' \| 'ohlcv' |
+| `select` | `array<string>` | **yes** | Columns to return. |
+| `filters` | `array<{col,op,value}>` | no | Filter clauses. |
+| `order_by` | `array<string>` | no | Optional ORDER BY clauses. |
+| `limit` | `integer` | no | Default 100, max 1000. |
+| `offset` | `integer` | no | Default 0. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_delete_experiment" description="auth — Delete an Oracle experiment and cancel in-flight children.">
+
+Delete an Oracle experiment and cancel in-flight children.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `experiment_id` | `string` | **yes** | Experiment to delete. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_get_experiment" description="auth — Get full Oracle experiment config + live progress.">
+
+Get full Oracle experiment config + live progress.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `experiment_id` | `string` | **yes** | ID returned by oracle_create_experiment. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_launch_experiment" description="auth — Launch a validated Oracle experiment into up to 99 child backtests.">
+
+Launch a validated Oracle experiment into up to 99 child backtests.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `experiment_id` | `string` | **yes** | Validated experiment to launch. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_list_datasets" description="auth — List curated OHLCV datasets available to Oracle experiments.">
+
+List curated OHLCV datasets available to Oracle experiments.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_list_experiments" description="auth — List Oracle experiments (summary view) for the calling org.">
+
+List Oracle experiments (summary view) for the calling org.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_list_results" description="auth — Paginated read of Oracle backtest results under an experiment.">
+
+Paginated read of Oracle backtest results under an experiment.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `experiment_id` | `string` | **yes** | Experiment whose results to read. |
+| `limit` | `integer` | no | Default 100; max 1000. |
+| `offset` | `integer` | no | Default 0. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_list_signals" description="auth — List signals with typed param specs available to Oracle experiments.">
+
+List signals with typed param specs available to Oracle experiments.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_list_templates" description="auth — List predefined strategy templates to seed Oracle experiments.">
+
+List predefined strategy templates to seed Oracle experiments.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_pause_experiment" description="auth — Pause a running Oracle experiment without losing completed results.">
+
+Pause a running Oracle experiment without losing completed results.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `experiment_id` | `string` | **yes** | Running experiment to pause. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_update_experiment" description="auth — Replace a draft Oracle experiment's config (PUT semantics).">
+
+Replace a draft Oracle experiment's config (PUT semantics).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `experiment_id` | `string` | **yes** | Experiment to update. |
+| `config` | `object` | **yes** | Full replacement ExperimentConfig. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="oracle_validate_experiment" description="auth — Validate a draft Oracle experiment (transition draft -> validated).">
+
+Validate a draft Oracle experiment (transition draft -> validated).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `experiment_id` | `string` | **yes** | Draft experiment to validate. |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="sieve_score" description="auth — Score 1-99 strategies through Mangrove SIEVE before paying for backtests. Returns binary + 4-clas…">
+
+Score 1-99 strategies through Mangrove SIEVE before paying for backtests. Returns binary + 4-class probabilities per item, with model + code provenance.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `strategies` | `array<Strategy>` | **yes** | MangroveAI-shaped Strategy objects (1-99 items). |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## Signals
 
-| Tool | Purpose |
-|---|---|
-| `list_signals` | The 223-signal MangroveAI catalog. |
-| `kb_list_indicators` | The 99-indicator KB catalog. |
+_4 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="get_signal" description="auth — Fetch a single signal's full metadata + param schema.">
+
+Fetch a single signal's full metadata + param schema.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `signal_name` | `string` | **yes** | Exact signal name (e.g. 'rsi_cross_up') |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_signals" description="auth — List / search available signals.">
+
+List / search available signals.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `category` | `string` | no | Filter by category |
+| `search` | `string` | no | Search query |
+| `limit` | `integer` | no | Max results |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="match_signals" description="auth — Semantic match of signals against a natural-language description.">
+
+Semantic match of signals against a natural-language description.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `description` | `string` | **yes** | Natural-language description of what you want |
+| `top_k` | `integer` | no | Max results (default 5) |
+| `similarity_threshold` | `number` | no | Min similarity (default 0.5) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="search_signals" description="auth — Text search signals (keyword/name). For intent-based matching, prefer match_signals.">
+
+Text search signals (keyword/name). For intent-based matching, prefer match_signals.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `query` | `string` | **yes** | Text query |
+| `limit` | `integer` | no | Page size (default 50) |
+| `offset` | `integer` | no | Page offset |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## Strategy
 
-| Tool | Purpose |
-|---|---|
-| `create_strategy_autonomous` | Agent picks rules from a goal description. |
-| `create_strategy_manual` | You specify entry/exit rules. |
-| `list_strategies` | Strategies registered locally. |
-| `get_strategy` | Strategy detail. |
-| `update_strategy_status` | Promote between draft / paper / live. |
-| `delete_strategy` | Tombstone. |
-| `backtest_strategy` | Run the platform's backtest against this strategy. |
-| `evaluate_strategy` | One-shot evaluation against current bar. |
-| `search_reference_strategies` | Curated MangroveAI reference set. |
-| `build_strategy_from_reference` | Clone a reference + tune for your symbol/timeframe. |
+_13 tool(s) in this domain._
 
-## Execution
+<AccordionGroup>
 
-| Tool | Purpose |
-|---|---|
-| `list_positions` | Open positions. |
-| `get_position` | Position detail. |
-| `list_trade_history` | Per-wallet trade log. |
+<Accordion title="backtest_strategy" description="auth — Backtest a strategy (quick or full). Window precedence: start+end > hours > days > months > timef…">
+
+Backtest a strategy (quick or full). Window precedence: start+end > hours > days > months > timeframe-aware auto (5m-1h=3mo, 4h=6mo, 1d=12mo). `config` is a single dict that merges over trading_defaults.json — use it for slippage_pct, fee_pct, max_hold_time_hours, initial_balance, max_risk_per_trade, reward_factor, atr_period, or any other BacktestRequest field. Returns full SDK metrics, trade history, and a resolved_window block for fallback detection.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `strategy_id` | `string` | **yes** | Agent strategy UUID |
+| `mode` | `string` | no | quick \| full (default full) |
+| `lookback_months` | `integer` | no | Window in months (auto by timeframe if all window fields omitted) |
+| `lookback_days` | `integer` | no | Window in days (overrides lookback_months) |
+| `lookback_hours` | `integer` | no | Window in hours — use for short backtests |
+| `start_date` | `string` | no | ISO 8601 — paired with end_date, overrides all lookback_* fields |
+| `end_date` | `string` | no | ISO 8601 |
+| `config` | `object` | no | Merges over trading_defaults.json (slippage_pct, max_risk_per_trade, initial_balance, reward_factor, atr_*, etc.) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="build_strategy_from_reference" description="auth — After search_reference_strategies returns candidates, call this to produce a create_strategy_manu…">
+
+After search_reference_strategies returns candidates, call this to produce a create_strategy_manual payload. Signals and params are copied exactly — the agent must NOT modify them. `timeframe` and `asset` are free overrides: a reference is a portable combo, so retarget onto the user's asset/TF and bulk-backtest the top matches rather than single-pick by label.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `reference_id` | `string` | **yes** | e.g. ref-001 — from search_reference_strategies |
+| `timeframe` | `string` | no | Override the reference's timeframe (canonicalized) |
+| `asset` | `string` | no | Retarget onto a different asset — reference strategies are portable |
+| `name` | `string` | no | Optional strategy name override |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="create_strategy_autonomous" description="auth — Create a strategy from a natural-language goal.">
+
+Create a strategy from a natural-language goal.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `goal` | `string` | **yes** | Natural-language goal |
+| `asset` | `string` | **yes** | Asset symbol |
+| `timeframe` | `string` | **yes** | 5m \| 15m \| 30m \| 1h \| 4h \| 1d (1m not supported) |
+| `candidate_count` | `integer` | no | 5-10 |
+| `backtest_lookback_months` | `integer` | no | Default: auto by timeframe (5m-1h=3mo, 4h=6mo, 1d=12mo) |
+| `seed` | `integer` | no | Reproducibility seed |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="create_strategy_manual" description="auth — Create a strategy with explicit entry/exit rules.">
+
+Create a strategy with explicit entry/exit rules.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `name` | `string` | **yes** | Strategy name |
+| `asset` | `string` | **yes** | Asset symbol |
+| `timeframe` | `string` | **yes** | 5m \| 15m \| 30m \| 1h \| 4h \| 1d (1m not supported) |
+| `entry` | `array` | **yes** | Entry rules |
+| `exit` | `array` | no | Exit rules |
+| `execution_config` | `object` | no | Override exec params |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="delete_strategy" description="auth — Delete a strategy upstream (local audit trail preserved).">
+
+Delete a strategy upstream (local audit trail preserved).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `strategy_id` | `string` | **yes** | Agent (local) strategy UUID |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="evaluate_strategy" description="auth — Manually trigger one evaluation tick.">
+
+Manually trigger one evaluation tick.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `strategy_id` | `string` | **yes** | Agent strategy UUID |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_account_position" description="auth — Fetch a single MangroveAI execution position.">
+
+Fetch a single MangroveAI execution position.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `position_id` | `string` | **yes** | Position id |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_strategy" description="auth — Get a strategy by ID.">
+
+Get a strategy by ID.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `strategy_id` | `string` | **yes** | Agent strategy UUID |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_account_positions" description="auth — List positions on MangroveAI's execution side (copilot-authored strategies).">
+
+List positions on MangroveAI's execution side (copilot-authored strategies).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `account_id` | `string` | no | Optional filter |
+| `status` | `string` | no | Optional: open \| closed \| etc |
+| `skip` | `integer` | no | Page offset |
+| `limit` | `integer` | no | Page size |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_account_trades" description="auth — List trades on MangroveAI's execution side (copilot-authored strategies).">
+
+List trades on MangroveAI's execution side (copilot-authored strategies).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `account_id` | `string` | no | Optional filter |
+| `asset` | `string` | no | Optional asset filter |
+| `outcome` | `string` | no | Optional outcome filter |
+| `skip` | `integer` | no | Page offset |
+| `limit` | `integer` | no | Page size |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_strategies" description="auth — List strategies.">
+
+List strategies.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `status` | `string` | no | Filter: draft\|inactive\|paper\|live\|archived |
+| `limit` | `integer` | no | Page size |
+| `offset` | `integer` | no | Page offset |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="search_reference_strategies" description="auth — Find curated reference strategies that match the user's goal and asset. Returns ranked candidates…">
+
+Find curated reference strategies that match the user's goal and asset. Returns ranked candidates with signals + parameter choices that have worked in backtests. ALWAYS call this before picking signals manually — it's the primary source of parameter intuition.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `asset` | `string` | **yes** | Asset symbol (e.g. BTC, ETH) |
+| `timeframe` | `string` | no | 5m \| 15m \| 30m \| 1h \| 4h \| 1d |
+| `category` | `string` | no | momentum \| mean_reversion \| trend_following \| breakout \| volatility |
+| `goal_hint` | `string` | no | Free text from the user's goal — auto-detects category if category is not supplied |
+| `limit` | `integer` | no | Max results (default 5) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="update_strategy_status" description="auth — Transition strategy lifecycle status.">
+
+Transition strategy lifecycle status.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `strategy_id` | `string` | **yes** | Agent strategy UUID |
+| `status` | `string` | **yes** | Target status |
+| `confirm` | `boolean` | no | Required for live + live→inactive |
+| `allocation` | `object` | no | Required for live |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## Logs
 
-| Tool | Purpose |
-|---|---|
-| `list_evaluations` | Per-strategy evaluation log. |
-| `list_trades` | Per-strategy trade log. |
-| `list_all_trades` | All trades across the agent. |
+_3 tool(s) in this domain._
 
-## Knowledge Base
+<AccordionGroup>
 
-| Tool | Purpose |
-|---|---|
-| `kb_search` | Full-text search over the MangroveKnowledgeBase docs. |
-| `list_docs` | KB document index. |
-| `get_doc` | Full markdown of a single doc. |
+<Accordion title="list_all_trades" description="auth — All trades across strategies (optional filters).">
+
+All trades across strategies (optional filters).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `limit` | `integer` | no | Max results |
+| `strategy_id` | `string` | no | Filter |
+| `mode` | `string` | no | live \| paper |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_evaluations" description="auth — Evaluation log for a strategy.">
+
+Evaluation log for a strategy.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `strategy_id` | `string` | **yes** | Strategy UUID |
+| `limit` | `integer` | no | Page size |
+| `offset` | `integer` | no | Page offset |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_trades" description="auth — Trades for a strategy.">
+
+Trades for a strategy.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `strategy_id` | `string` | **yes** | Strategy UUID |
+| `limit` | `integer` | no | Page size |
+| `offset` | `integer` | no | Page offset |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
+
+## Knowledge base
+
+_5 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="kb_get_document" description="auth — Fetch a KB document by slug (full body, not search snippet).">
+
+Fetch a KB document by slug (full body, not search snippet).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `slug` | `string` | **yes** | Document slug (e.g. 'momentum-strategies') |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="kb_glossary_get" description="auth — Look up a KB glossary term (definition + backlinks).">
+
+Look up a KB glossary term (definition + backlinks).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `term` | `string` | **yes** | Glossary term (exact match) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="kb_list_indicators" description="auth — List KB indicator docs (optionally by category).">
+
+List KB indicator docs (optionally by category).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `category` | `string` | no | Filter: momentum \| trend \| mean_reversion \| volatility \| volume \| pattern |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="kb_list_tags" description="auth — List KB tags (navigation + kb_search filtering).">
+
+List KB tags (navigation + kb_search filtering).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="kb_search" description="auth — Full-text KB search.">
+
+Full-text KB search.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `q` | `string` | **yes** | Search query |
+| `limit` | `integer` | no | Max results |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## DeFi
 
-| Tool | Purpose |
-|---|---|
-| `get_protocol_tvl` | DeFiLlama TVL by protocol. |
+_3 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="get_chain_tvl" description="auth — Total value locked (TVL) in DeFi on a given chain.">
+
+Total value locked (TVL) in DeFi on a given chain.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `chain` | `string` | **yes** | Chain (e.g. 'base', 'ethereum') |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_protocol_tvl" description="auth — TVL for a specific DeFi protocol (e.g. 'aave', 'uniswap').">
+
+TVL for a specific DeFi protocol (e.g. 'aave', 'uniswap').
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `protocol` | `string` | **yes** | Protocol slug |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_stablecoin_metrics" description="auth — Stablecoin supply + flow metrics (macro liquidity proxy).">
+
+Stablecoin supply + flow metrics (macro liquidity proxy).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
+
+## Social
+
+_3 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="get_influence_score" description="auth — Influence score for a social username.">
+
+Influence score for a social username.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `username` | `string` | **yes** | Social username (no @) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_mentions" description="auth — Recent social mentions of a topic (raw posts).">
+
+Recent social mentions of a topic (raw posts).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `topic` | `string` | **yes** | Asset symbol or keyword |
+| `hours_back` | `integer` | no | Window (default 24) |
+| `limit` | `integer` | no | Max posts (default 20) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="get_sentiment" description="auth — Aggregate social (X/Twitter) sentiment for a topic or asset.">
+
+Aggregate social (X/Twitter) sentiment for a topic or asset.
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `topic` | `string` | **yes** | Asset symbol or keyword |
+| `hours_back` | `integer` | no | Window (default 24) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
+
+## Documentation
+
+_2 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="get_doc_content" description="auth — Fetch a MangroveAI developer doc by path (API reference, guides).">
+
+Fetch a MangroveAI developer doc by path (API reference, guides).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `path` | `string` | **yes** | Doc path (from list_docs) |
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+<Accordion title="list_docs" description="auth — List MangroveAI developer docs (API reference + guides).">
+
+List MangroveAI developer docs (API reference + guides).
+
+**Args**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `api_key` | `string` | **yes** | Valid API key |
+
+**Access:** auth
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
+
+## x402 demo (hello_mangrove)
+
+_1 tool(s) in this domain._
+
+<AccordionGroup>
+
+<Accordion title="hello_mangrove" description="x402 — x402 demo: $0.05 USDC on Base. Smoke test for the payment path.">
+
+x402 demo: $0.05 USDC on Base. Smoke test for the payment path.
+
+_No arguments._
+
+**Access:** x402 · **Price:** $0.05 USDC · **Network:** base
+
+REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).
+
+</Accordion>
+
+</AccordionGroup>
 
 ## REST mirror
 
-Every tool has a mirrored REST endpoint at `/api/v1/agent/<resource>/...` (HTTP method matches the underlying call — typically `POST` for action / `GET` for read). Same service layer, same auth, same response shape. Use REST when the caller isn't an MCP client.
+Every MCP tool above has a mirrored REST endpoint at `/api/v1/agent/<resource>/...`. HTTP method matches the underlying call — typically `POST` for actions, `GET` for reads. Same service layer, same auth, same response shape. Use REST when the caller isn't an MCP client.
 
 Examples:
 
 - `POST /api/v1/agent/oracle/experiments` mirrors the `oracle_create_experiment` MCP tool.
 - `POST /api/v1/agent/on-chain/smart-money/historical-holdings` mirrors `get_smart_money_historical_holdings`.
 - `GET /api/v1/agent/oracle/datasets` mirrors `oracle_list_datasets`.
+
+---
+
+_Generated from `mangrove-agent/server/src/mcp/tools.py`. 90 tools across 14 domains. Re-run `python scripts/generate-mcp-tools-catalog.py` to refresh._

--- a/docs/mangrove-agent/mcp-tools.mdx
+++ b/docs/mangrove-agent/mcp-tools.mdx
@@ -595,7 +595,7 @@ Smart Money historical holdings snapshots across chains (Nansen).
 | `date_from` | `string` | no | ISO date 'YYYY-MM-DD'. |
 | `date_to` | `string` | no | ISO date 'YYYY-MM-DD'. |
 | `filters` | `object` | no | Nansen filter dict (include_smart_money_labels, etc.) |
-| `order_by` | `array` | no | Sort spec, e.g. [{'field': 'block_timestamp', 'direction': 'DESC'}] |
+| `order_by` | `array` | no | Sort spec, e.g. [&#123;'field': 'block_timestamp', 'direction': 'DESC'&#125;] |
 | `page` | `integer` | no | Page (default 1) |
 | `per_page` | `integer` | no | Items per page (default 100) |
 | `api_key` | `string` | **yes** | Valid API key |
@@ -874,7 +874,7 @@ Query the curated Oracle corpus (results / ohlcv). Whitelist-enforced columns + 
 |---|---|---|---|
 | `table` | `string` | **yes** | 'results' \| 'ohlcv' |
 | `select` | `array<string>` | **yes** | Columns to return. |
-| `filters` | `array<{col,op,value}>` | no | Filter clauses. |
+| `filters` | `array<&#123;col,op,value&#125;>` | no | Filter clauses. |
 | `order_by` | `array<string>` | no | Optional ORDER BY clauses. |
 | `limit` | `integer` | no | Default 100, max 1000. |
 | `offset` | `integer` | no | Default 0. |

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -141,7 +141,7 @@
         "guides/running-a-backtest",
         "guides/backtesting-guide",
         "guides/using-sieve-prefilter",
-        "guides/sieve-to-live-strategy",
+        "guides/sieve-end-to-end-workflow",
         "guides/using-the-ai-copilot",
         "guides/risk-management"
       ]

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -64,6 +64,7 @@
         "api-reference/signals",
         "api-reference/backtesting",
         "api-reference/experiments",
+        "api-reference/oracle-backtest",
         "api-reference/oracle-deployed",
         "api-reference/sieve",
         "api-reference/ai-copilot",

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -141,6 +141,7 @@
         "guides/running-a-backtest",
         "guides/backtesting-guide",
         "guides/using-sieve-prefilter",
+        "guides/sieve-to-live-strategy",
         "guides/using-the-ai-copilot",
         "guides/risk-management"
       ]

--- a/scripts/generate-mcp-tools-catalog.py
+++ b/scripts/generate-mcp-tools-catalog.py
@@ -267,8 +267,20 @@ def _escape_attr(text: str) -> str:
 
 
 def _md_escape(text: str) -> str:
-    """Escape pipes for use inside a Markdown table cell."""
-    return text.replace("|", "\\|").replace("\n", " ").strip()
+    """Escape pipes + JSX braces for use inside a Markdown table cell in MDX.
+
+    MDX treats `{` as the start of a JSX expression. Tool descriptions
+    that happen to contain example JSON (e.g. `[{'field': 'x'}]`) break
+    Mintlify's acorn parser. Replace `{` and `}` with their HTML entities
+    so the literal braces survive.
+    """
+    return (
+        text.replace("|", "\\|")
+        .replace("{", "&#123;")
+        .replace("}", "&#125;")
+        .replace("\n", " ")
+        .strip()
+    )
 
 
 def _render_tool_accordion(t: ToolEntry) -> list[str]:

--- a/scripts/generate-mcp-tools-catalog.py
+++ b/scripts/generate-mcp-tools-catalog.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Generate the MCP tools catalog page from the agent's tools.py source.
+
+Usage:
+    cd /path/to/MangroveKnowledgeBase
+    python scripts/generate-mcp-tools-catalog.py
+
+Reads `mangrove-agent/server/src/mcp/tools.py` via `ast.parse` (no imports of
+the agent's code — robust to its runtime dependencies), walks every
+`_register_<domain>(server)` function for `register_tool(ToolEntry(...))`
+calls, and writes `docs/mangrove-agent/mcp-tools.mdx` as a static prologue
+plus 1 `<AccordionGroup>` per domain with 1 `<Accordion>` per tool.
+
+Why generated, not hand-written:
+    The agent registers ~90 tools; hand-syncing args tables drifts on the
+    first new parameter. The signal catalog already follows this generator
+    pattern (see `generate-signal-catalog.py`). When `tools.py` changes,
+    re-run this script and commit the regenerated MDX.
+
+Cross-repo path:
+    Expects sibling layout:
+        ~/mangrove/MangroveKnowledgeBase/scripts/  <- this script
+        ~/mangrove/mangrove-agent/server/src/mcp/tools.py  <- input
+    Override with --agent-tools <path>.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Domain display names — _register_<key> -> human-readable
+# Keys not in this map fall back to title-case of the suffix.
+# ---------------------------------------------------------------------------
+DOMAIN_DISPLAY_NAMES: dict[str, str] = {
+    "discovery": "Discovery",
+    "wallet": "Wallet",
+    "dex": "DEX",
+    "market": "Market data",
+    "signals": "Signals",
+    "on_chain": "On-chain (Nansen + WhaleAlert)",
+    "defi": "DeFi",
+    "social": "Social",
+    "strategy": "Strategy",
+    "logs": "Logs",
+    "kb": "Knowledge base",
+    "oracle": "Oracle",
+    "docs": "Documentation",
+    "hello_mangrove": "x402 demo (hello_mangrove)",
+}
+
+# Order domains in the rendered MDX — anything not listed here goes to the end.
+DOMAIN_ORDER = [
+    "discovery",
+    "wallet",
+    "dex",
+    "market",
+    "on_chain",
+    "oracle",
+    "signals",
+    "strategy",
+    "logs",
+    "kb",
+    "defi",
+    "social",
+    "docs",
+    "hello_mangrove",
+]
+
+
+@dataclass
+class ToolParam:
+    name: str
+    type: str
+    required: bool
+    description: str = ""
+
+
+@dataclass
+class ToolEntry:
+    name: str
+    description: str
+    access: str  # "free" | "auth" | "x402"
+    parameters: list[ToolParam] = field(default_factory=list)
+    price: str | None = None
+    network: str | None = None
+    domain: str = ""
+
+
+def _literal(node: ast.AST) -> Any:
+    """Return the Python literal for a constant / list / tuple AST node.
+
+    We only need to support what shows up in ToolEntry / ToolParam call
+    sites: strings, bools, integers, None. Anything else returns the
+    raw node so the caller can detect and skip it.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.List):
+        return [_literal(elt) for elt in node.elts]
+    if isinstance(node, ast.Tuple):
+        return tuple(_literal(elt) for elt in node.elts)
+    # JoinedStr (f-string) — render the constant chunks; descriptions sometimes
+    # use f-string concatenation but never with dynamic values.
+    if isinstance(node, ast.JoinedStr):
+        out = []
+        for v in node.values:
+            if isinstance(v, ast.Constant):
+                out.append(str(v.value))
+            else:
+                out.append("…")
+        return "".join(out)
+    # Parenthesised concatenation: ast.BinOp(Add) on two strings, etc.
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return f"{_literal(node.left)}{_literal(node.right)}"
+    # Name reference (e.g. `_APIKEY`) — we don't resolve cross-tool aliases here.
+    if isinstance(node, ast.Name):
+        return node  # caller filters
+    return node
+
+
+def _build_tool_param(call: ast.Call) -> ToolParam | None:
+    """Parse a ToolParam(...) call into a ToolParam dataclass."""
+    kw = {k.arg: _literal(k.value) for k in call.keywords if k.arg is not None}
+    name = kw.get("name")
+    if not isinstance(name, str):
+        return None
+    return ToolParam(
+        name=name,
+        type=str(kw.get("type", "")),
+        required=bool(kw.get("required", False)) if isinstance(kw.get("required"), bool) else False,
+        description=str(kw.get("description", "")),
+    )
+
+
+def _resolve_apikey_param(module_tree: ast.Module) -> ToolParam | None:
+    """Find `_APIKEY = ToolParam(...)` at module scope and parse it.
+
+    `tools.py` defines `_APIKEY` once near the top and re-uses it across every
+    auth-gated tool's parameter list. We resolve it so the rendered Args
+    tables actually show the `api_key` row instead of an opaque reference.
+    """
+    for node in module_tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            continue
+        if node.targets[0].id != "_APIKEY":
+            continue
+        if isinstance(node.value, ast.Call) and getattr(node.value.func, "id", "") == "ToolParam":
+            return _build_tool_param(node.value)
+    return None
+
+
+def _build_tool_entry(call: ast.Call, *, apikey: ToolParam | None) -> ToolEntry | None:
+    """Parse a ToolEntry(...) call into a ToolEntry dataclass.
+
+    Resolves the `_APIKEY` reference in `parameters` to its actual ToolParam
+    so the args table renders correctly.
+    """
+    kw = {k.arg: k.value for k in call.keywords if k.arg is not None}
+    name_node = kw.get("name")
+    if not isinstance(name_node, ast.Constant) or not isinstance(name_node.value, str):
+        return None
+    name = name_node.value
+
+    description = _literal(kw.get("description", ast.Constant("")))
+    access = _literal(kw.get("access", ast.Constant("auth")))
+    price_node = kw.get("price")
+    price = _literal(price_node) if price_node is not None else None
+    network_node = kw.get("network")
+    network = _literal(network_node) if network_node is not None else None
+
+    params: list[ToolParam] = []
+    params_node = kw.get("parameters")
+    if isinstance(params_node, ast.List):
+        for elt in params_node.elts:
+            if isinstance(elt, ast.Call) and getattr(elt.func, "id", "") == "ToolParam":
+                p = _build_tool_param(elt)
+                if p is not None:
+                    params.append(p)
+            elif isinstance(elt, ast.Name) and elt.id == "_APIKEY" and apikey is not None:
+                params.append(apikey)
+
+    # Defensive: description/access may not be strings if exotic; coerce.
+    return ToolEntry(
+        name=name,
+        description=description if isinstance(description, str) else str(description),
+        access=access if isinstance(access, str) else str(access),
+        parameters=params,
+        price=price if isinstance(price, str) else None,
+        network=network if isinstance(network, str) else None,
+    )
+
+
+def _walk_register_calls(func_node: ast.FunctionDef, *, apikey: ToolParam | None) -> list[ToolEntry]:
+    """Find all `register_tool(ToolEntry(...))` calls inside a function body."""
+    tools: list[ToolEntry] = []
+    for node in ast.walk(func_node):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        if not (isinstance(callee, ast.Name) and callee.id == "register_tool"):
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Call):
+            continue
+        inner = node.args[0]
+        if getattr(inner.func, "id", "") != "ToolEntry":
+            continue
+        t = _build_tool_entry(inner, apikey=apikey)
+        if t is not None:
+            tools.append(t)
+    return tools
+
+
+def parse_tools_file(path: str) -> list[ToolEntry]:
+    """Parse the agent's tools.py and return every registered tool.
+
+    Each tool's `.domain` is set to the suffix of its enclosing
+    `_register_<domain>(server)` function — that's how we group in the MDX.
+    """
+    with open(path) as f:
+        source = f.read()
+    tree = ast.parse(source, filename=path)
+    apikey = _resolve_apikey_param(tree)
+
+    tools: list[ToolEntry] = []
+    seen_functions: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not node.name.startswith("_register_"):
+            continue
+        domain = node.name[len("_register_"):]
+        seen_functions.add(domain)
+        for t in _walk_register_calls(node, apikey=apikey):
+            t.domain = domain
+            tools.append(t)
+
+    assert tools, f"No tools parsed from {path} — file structure may have changed"
+    return tools
+
+
+def _display_name(domain: str) -> str:
+    if domain in DOMAIN_DISPLAY_NAMES:
+        return DOMAIN_DISPLAY_NAMES[domain]
+    return domain.replace("_", " ").title()
+
+
+def _domain_sort_key(domain: str) -> tuple[int, str]:
+    try:
+        return (DOMAIN_ORDER.index(domain), domain)
+    except ValueError:
+        return (len(DOMAIN_ORDER), domain)
+
+
+def _escape_attr(text: str) -> str:
+    """Escape a string for use inside an MDX attribute value (`"..."`)."""
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ").strip()
+
+
+def _md_escape(text: str) -> str:
+    """Escape pipes for use inside a Markdown table cell."""
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _render_tool_accordion(t: ToolEntry) -> list[str]:
+    out: list[str] = []
+    # Short header description: <access tier> — <truncated tool description>
+    header_desc = t.description.split("\n", 1)[0]
+    if len(header_desc) > 100:
+        header_desc = header_desc[:97].rstrip() + "…"
+    header_desc = f"{t.access} — {header_desc}" if t.access else header_desc
+
+    out.append(f'<Accordion title="{t.name}" description="{_escape_attr(header_desc)}">')
+    out.append("")
+    if t.description:
+        out.append(t.description.strip())
+        out.append("")
+
+    # Args table
+    if t.parameters:
+        out.append("**Args**")
+        out.append("")
+        out.append("| Name | Type | Required | Description |")
+        out.append("|---|---|---|---|")
+        for p in t.parameters:
+            req = "**yes**" if p.required else "no"
+            out.append(
+                f"| `{p.name}` | `{_md_escape(p.type)}` | {req} "
+                f"| {_md_escape(p.description)} |"
+            )
+        out.append("")
+    else:
+        out.append("_No arguments._")
+        out.append("")
+
+    # Pricing footer (only when set)
+    meta_bits = []
+    if t.access:
+        meta_bits.append(f"**Access:** {t.access}")
+    if t.price:
+        meta_bits.append(f"**Price:** {t.price}")
+    if t.network:
+        meta_bits.append(f"**Network:** {t.network}")
+    if meta_bits:
+        out.append(" · ".join(meta_bits))
+        out.append("")
+
+    # REST mirror hint — derivable from the tool's name + the catalog's
+    # convention `/api/v1/agent/<resource>/...`.
+    out.append(f"REST mirror: `/api/v1/agent/...` (see [REST mirror](#rest-mirror) for the pattern).")
+    out.append("")
+    out.append("</Accordion>")
+    out.append("")
+    return out
+
+
+def render_mdx(tools: list[ToolEntry]) -> str:
+    grouped: OrderedDict[str, list[ToolEntry]] = OrderedDict()
+    for domain in sorted({t.domain for t in tools}, key=_domain_sort_key):
+        grouped[domain] = [t for t in tools if t.domain == domain]
+
+    total_tools = len(tools)
+    total_domains = len(grouped)
+
+    lines: list[str] = []
+    lines.append("---")
+    lines.append('title: "MCP tools catalog"')
+    lines.append(
+        f'description: "All {total_tools} MCP tools the agent exposes, '
+        f'grouped into {total_domains} domains. Each tool documents its '
+        f'arguments and access tier. REST mirrors at /api/v1/agent/*."'
+    )
+    lines.append("---")
+    lines.append("")
+    lines.append("# MCP tools catalog")
+    lines.append("")
+    lines.append(
+        f"The agent registers **{total_tools} MCP tools** across "
+        f"**{total_domains} domains**. Every tool is exposed over Streamable "
+        "HTTP MCP **and** as a mirrored REST endpoint at `/api/v1/agent/*` — "
+        "pick whichever fits your caller. Both paths call the same service "
+        "layer."
+    )
+    lines.append("")
+    lines.append(
+        "Each domain section below renders as a collapsed accordion list. "
+        "Click a tool to expand its description, argument table, and access "
+        "tier. Use your browser's find-in-page (ctrl-F / cmd-F) to locate a "
+        "tool by name — collapsed accordions are still text-searchable."
+    )
+    lines.append("")
+    lines.append("## How to read this catalog")
+    lines.append("")
+    lines.append("- **Access** is one of:")
+    lines.append("    - `free` — no auth, no charge (discovery, status, demo)")
+    lines.append("    - `auth` — requires `X-API-Key` (or Bearer JWT)")
+    lines.append("    - `x402` — pay-per-call via x402 micropayment; check the tool's price field")
+    lines.append("- **Args** with `required = yes` must be supplied; the rest fall back to server defaults.")
+    lines.append("- **Type** strings (`string`, `integer`, `array<Strategy>`, …) reflect the agent's MCP schema, not Python types.")
+    lines.append("")
+    lines.append('<Note>')
+    lines.append(
+        "This page is **generated** from "
+        "[`mangrove-agent/server/src/mcp/tools.py`](https://github.com/MangroveTechnologies/mangrove-agent/blob/main/server/src/mcp/tools.py) "
+        "via `scripts/generate-mcp-tools-catalog.py`. When the agent adds or "
+        "renames a tool, re-run the generator and commit the regenerated MDX."
+    )
+    lines.append("</Note>")
+    lines.append("")
+
+    # Per-domain sections
+    for domain, ds_tools in grouped.items():
+        display = _display_name(domain)
+        lines.append(f"## {display}")
+        lines.append("")
+        lines.append(f"_{len(ds_tools)} tool(s) in this domain._")
+        lines.append("")
+        lines.append("<AccordionGroup>")
+        lines.append("")
+        for t in sorted(ds_tools, key=lambda x: x.name):
+            lines.extend(_render_tool_accordion(t))
+        lines.append("</AccordionGroup>")
+        lines.append("")
+
+    # REST mirror section
+    lines.append("## REST mirror")
+    lines.append("")
+    lines.append(
+        "Every MCP tool above has a mirrored REST endpoint at "
+        "`/api/v1/agent/<resource>/...`. HTTP method matches the underlying "
+        "call — typically `POST` for actions, `GET` for reads. Same service "
+        "layer, same auth, same response shape. Use REST when the caller "
+        "isn't an MCP client."
+    )
+    lines.append("")
+    lines.append("Examples:")
+    lines.append("")
+    lines.append("- `POST /api/v1/agent/oracle/experiments` mirrors the `oracle_create_experiment` MCP tool.")
+    lines.append("- `POST /api/v1/agent/on-chain/smart-money/historical-holdings` mirrors `get_smart_money_historical_holdings`.")
+    lines.append("- `GET /api/v1/agent/oracle/datasets` mirrors `oracle_list_datasets`.")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        f"_Generated from `mangrove-agent/server/src/mcp/tools.py`. "
+        f"{total_tools} tools across {total_domains} domains. "
+        "Re-run `python scripts/generate-mcp-tools-catalog.py` to refresh._"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument(
+        "--agent-tools",
+        default=None,
+        help="Path to mangrove-agent/server/src/mcp/tools.py "
+        "(default: sibling checkout at ~/mangrove/mangrove-agent/server/src/mcp/tools.py)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output MDX path (default: docs/mangrove-agent/mcp-tools.mdx)",
+    )
+    args = parser.parse_args()
+
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    project_root = os.path.dirname(script_dir)
+
+    agent_tools = args.agent_tools or os.path.expanduser(
+        "~/mangrove/mangrove-agent/server/src/mcp/tools.py"
+    )
+    if not os.path.exists(agent_tools):
+        print(f"ERROR: agent tools file not found at {agent_tools}", file=sys.stderr)
+        print("Pass --agent-tools <path> if mangrove-agent lives elsewhere.", file=sys.stderr)
+        return 2
+
+    output = args.output or os.path.join(project_root, "docs", "mangrove-agent", "mcp-tools.mdx")
+
+    tools = parse_tools_file(agent_tools)
+    mdx = render_mdx(tools)
+
+    os.makedirs(os.path.dirname(output), exist_ok=True)
+    with open(output, "w") as f:
+        f.write(mdx)
+
+    domain_counts = {}
+    for t in tools:
+        domain_counts[t.domain] = domain_counts.get(t.domain, 0) + 1
+    print(f"Generated {output}")
+    print(f"  Total tools: {len(tools)}")
+    print(f"  Domains: {len(domain_counts)}")
+    for d, c in sorted(domain_counts.items(), key=lambda kv: _domain_sort_key(kv[0])):
+        print(f"    {_display_name(d):<35} {c} tool(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three KB documentation additions, shipping as one PR with four commits so each can be reviewed independently:

- **Commit 1** — `docs(api-reference)`: new `oracle-backtest.mdx` page documenting the 5 single-strategy / corpus-query endpoints
- **Commit 2** — `docs(guides)`: new `sieve-to-live-strategy.mdx` end-to-end walkthrough (signals → SIEVE → bulk backtest → paper)
- **Commit 3** — `docs(mcp-tools)`: generator-driven catalog (90 tools × 14 domains) replacing the manual two-column tables
- **Commit 4** — `fix(docs)`: reconciles examples with server source-of-truth after live E2E verification

## Why commit 4 exists

Initial pass tracked the SDK Pydantic models. Live verification against prod with the Beginner test key surfaced multiple SDK ↔ server mismatches:

| Concern | SDK says | Server says |
|---|---|---|
| `OracleBacktestRequest` risk-mgmt fields | `Optional[float] = None` ("server-default-fillable") | All 18 fields **required** explicitly per `MangroveOracle/src/api/routes/backtest.py:102-108` |
| `DataQueryRequest.order_by` | `list[str]` (SQL-style) | `list[OrderBy]` where `OrderBy = {col, dir}` |
| `DataQueryRequest.offset` | exists | Doesn't exist — server uses `page_token` |
| `DataQueryResponse.table` | Required `str` | Not in real response (validation fails on every 200) |
| Async poll cost | "free (metadata)" in my draft | Bills $0.10 / 1 api_calls unit per `_PROXY_METERING` |
| Data query cost | "$0.01 x402" in my draft | Actually $0.10 x402 |

Commit 4 corrects all of these against the source code (route handlers + `_PROXY_METERING` dict + Pydantic models in MangroveOracle).

Python examples for the backtest endpoints + data_query now use raw `requests` HTTP (not the SDK) until the SDK's typing is reconciled. A Warning callout in `oracle-backtest.mdx` explains the SDK ↔ server gap so customers don't trip.

## Source-code references (the source-of-truth)

- `MangroveOracle/src/api/routes/backtest.py` — sync/async/bulk required_fields lists
- `MangroveOracle/src/models/data_query.py` — `QueryRequest`/`QueryResponse`/`Filter`/`OrderBy` shapes
- `MangroveOracle/src/services/backtest.py:1170-1195` — `position_size_calc` enforcement
- `MangroveAI/src/MangroveAI/domains/backtesting/oracle_proxy.py::_PROXY_METERING` — per-endpoint pricing table

## Verification (live E2E, this turn)

Ran the full Phase 1 → 2 → 3 chain from `sieve-to-live-strategy.mdx` against api.mangrovedeveloper.ai:

```
✓ Phase 1: client.oracle.list_signals() → 223 signals
✓ Phase 2: client.oracle.sieve_score(SieveScoreRequest(strategies=[6])) → 6 predictions
✓ Phase 3: POST /api/v1/oracle/backtest/bulk → HTTP 200, 6 results, data_fetches reported
```

Individual oracle-backtest.mdx snippets independently verified:
- Sync /backtest with full 18-field body + top-level execution_config → HTTP 200
- /data/query with OrderBy objects + corrected response shape → HTTP 200

## Open follow-ups (out of scope for this PR)

These are SDK / server bugs commit 4 documents around but doesn't fix. To file separately:

1. **MangroveAI-SDK**: OracleBacktestRequest should either honor server defaults or stop typing risk-mgmt fields as Optional. Same for OracleBulkBacktestRequest.
2. **MangroveAI-SDK**: DataQueryResponse.table is in the model but not in the server response — drop it.
3. **MangroveAI-SDK**: DataQueryRequest.order_by should be list[OrderBy] not list[str]; replace offset with page_token.
4. **MangroveAI proxy**: optional — make /api/v1/oracle/backtest honor trading_defaults.json for missing risk fields, matching the SDK's docstring claim.

## Re-generating the MCP catalog (commit 3)

```
cd MangroveKnowledgeBase
python scripts/generate-mcp-tools-catalog.py
```

Defaults to ~/mangrove/mangrove-agent/server/src/mcp/tools.py; pass --agent-tools <path> to override. Output: docs/mangrove-agent/mcp-tools.mdx. Idempotent — re-run produces byte-identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)