### PR TITLE
feat(signals): add On-Chain signal category (10 signals)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ curl -X POST http://localhost:8081/api/evaluate \
 
 Open-source trading signals, technical indicators, and knowledge base. Three components:
 
-1. **Python Package** (`mangrove_kb`) -- 223 signal functions, 99 indicator classes (including 27 pattern indicators), RuleRegistry, docstring parser. Published on PyPI as `mangrove-kb`.
+1. **Python Package** (`mangrove_kb`) -- 233 signal functions, 99 indicator classes (including 27 pattern indicators), RuleRegistry, docstring parser. Published on PyPI as `mangrove-kb`.
 2. **KB Server** (`kb_server/`) -- Unified server with dual protocol access (REST + MCP) on the same port. FastAPI REST API + FastMCP tools. SQLite FTS5 full-text search, 11 trading education documents, glossary, cross-references, synonym expansion. Signal/indicator metadata (free) and computation (x402 gated).
 3. **Knowledge Base Content** (`knowledge-base/`) -- 11 markdown documents covering market foundations through quantitative analysis
 
@@ -161,8 +161,9 @@ Terraform module: `MangroveAI/infra/terraform/modules/app-mangroveai-kb/`
 - Every signal docstring must include `Type:` (TRIGGER or FILTER) and `Requires:` (comma-separated column names)
 - Every parameter must include `Range: min-max` and `Default: value` in the Args section
 - Use `window` for all windowing parameters (not `lookback`, `period`, `length`)
-- Signal counts: 223 signals (108 TRIGGER, 115 FILTER) across 5 categories
-- Categories: Momentum (42), Trend (88), Volume (33), Volatility (20), Patterns (40)
+- Signal counts: 233 signals (112 TRIGGER, 121 FILTER) across 6 categories
+- Categories: Momentum (42), Trend (88), Volume (33), Volatility (20), Patterns (40), On-Chain (10)
+- On-Chain signals consume alternative-data columns (SmartMoneyNetflow, SmartMoneyHoldings, ExchangeNetflow, WhaleNetInflow, HolderConcentration) the caller populates time-aligned to OHLCV bars; sourced from Nansen tgm/flows + historical-top-holders via the MangroveAI data layer. There is no total-holder-count series upstream, so holder-count signals are intentionally not shipped.
 
 ## GitHub
 

--- a/docs/data-providers.mdx
+++ b/docs/data-providers.mdx
@@ -13,8 +13,8 @@ We surface coverage honestly. Where we expose 100% of a provider's plan, we say 
 
 | Provider | Plan | Mangrove route prefix | Coverage |
 |---|---|---|---|
-| **Nansen** | Pro | `/on-chain/*` + `/crypto-assets/{token-holders,flow-intelligence,smart-money/*}` | **100% of plan** (11 routes) |
-| **WhaleAlert** | Enterprise REST | `/on-chain/{whale-transactions,exchange-flows,whale-activity}` | 100% of available surface |
+| **Nansen** | Pro | `/on-chain/*` + `/crypto-assets/{token-holders,flow-intelligence,smart-money/*}` | Smart-money, Token God Mode (incl. hourly `tgm/flows` series), + `/v1beta1` backtesting family |
+| **WhaleAlert** | **Developer** | `/on-chain/{whale-transactions,exchange-flows,whale-activity}` | Full Developer surface; **30-day history cap**, ~10 req/min |
 | **X (Twitter)** | Pro v2 | `/social/*` | partial -- sentiment, mentions, influence |
 | **DeFiLlama** | API tier | `/defi/*` | partial -- protocol TVL, chain TVL, stablecoin metrics |
 | **CoinAPI** | Startup | `/crypto-assets/{ohlcv,market-data,symbols,exchanges}` | partial -- OHLCV + market data |
@@ -53,11 +53,38 @@ result = client.on_chain.get_smart_money_dex_trades(
 )
 ```
 
-**Not in our Pro plan** (return 404 if called directly against the upstream): Wallet Profiler, Chain Analytics, NFT collection analytics, Hot Contracts. Contact us if any of these are critical -- they may be available on a higher Nansen tier.
+**On-chain time series.** `tgm/flows` returns an hourly per-wallet-category series for a token
+over any date range, scoped by a top-level `label` (`smart_money`, `exchange`, `whale`,
+`public_figure`, `top_100_holders`). The same call serves a live trailing window (e.g. the last
+10 days, ending now) or a long historical range -- it is just a different `start`. For
+point-in-time historical state there is also a `/v1beta1` **backtesting** family
+(`historical-top-holders`, `historical-token-flow-summary`, `historical-token-balances`, ...).
 
-## WhaleAlert -- 100% of (narrow) surface
+**Not in our Pro plan** (return 404 if called directly against the upstream): Wallet Profiler,
+Chain Analytics, NFT collection analytics, Hot Contracts. Contact us if any of these are critical.
 
-WhaleAlert's REST surface is small by design: transactions and status. We expose all of it.
+## On-chain signal columns
+
+The KB On-Chain signals consume per-bar columns the caller supplies on the DataFrame,
+time-aligned to OHLCV bars (the MangroveAI data layer derives them from the series above):
+
+| Column | Source | Derivation |
+|---|---|---|
+| `SmartMoneyNetflow` | `tgm/flows` label=smart_money | Δ token_amount × price_usd (USD net flow) |
+| `SmartMoneyHoldings` | `tgm/flows` label=smart_money | `value_usd` level |
+| `ExchangeNetflow` | `tgm/flows` label=exchange | Δ token_amount × price_usd (+ = into exchanges) |
+| `WhaleNetInflow` | `tgm/flows` label=whale | Δ token_amount × price_usd (+ = accumulation) |
+| `HolderConcentration` | `historical-top-holders` | sum of top-N `ownership_percentage` (0.0-1.0) |
+
+A **total token-holder-count** series is not available upstream (Nansen exposes per-category
+holder counts only), so holder-count signals are intentionally not shipped.
+
+## WhaleAlert -- Developer tier (fallback source)
+
+WhaleAlert's REST surface is small by design: transactions and status. We are on the **Developer
+tier** (not Enterprise), which caps transaction history at **30 days** and ~10 req/min. It is used
+as a **fallback / cross-check** for `ExchangeNetflow` / `WhaleNetInflow` when the Nansen series is
+unavailable; Nansen `tgm/flows` is the primary (uncapped) source.
 
 | Capability | Mangrove route | SDK method |
 |---|---|---|

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -127,7 +127,8 @@
             "signals/catalog/trend",
             "signals/catalog/volume",
             "signals/catalog/volatility",
-            "signals/catalog/patterns"
+            "signals/catalog/patterns",
+            "signals/catalog/on-chain"
           ]
         }
       ]

--- a/docs/signals/catalog.mdx
+++ b/docs/signals/catalog.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Signal Catalog"
-description: "Index of all 223 trading signals across 5 categories."
+description: "Index of all 233 trading signals across 6 categories."
 ---
 
 # Signal Catalog
 
-Complete reference for all **223** trading signals 
-(108 TRIGGER, 115 FILTER) organized by category.
+Complete reference for all **233** trading signals 
+(112 TRIGGER, 121 FILTER) organized by category.
 
 See [Signals Overview](/signals/overview) for an introduction to how signals work.
 
@@ -19,6 +19,7 @@ See [Signals Overview](/signals/overview) for an introduction to how signals wor
 | Volume | 33 | [/signals/catalog/volume](/signals/catalog/volume) |
 | Volatility | 20 | [/signals/catalog/volatility](/signals/catalog/volatility) |
 | Patterns | 40 | [/signals/catalog/patterns](/signals/catalog/patterns) |
+| On-Chain | 10 | [/signals/catalog/on-chain](/signals/catalog/on-chain) |
 
 ## All signals
 
@@ -247,7 +248,17 @@ See [Signals Overview](/signals/overview) for an introduction to how signals wor
 | [`tweezer_tops_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
 | [`two_bar_reversal_bearish_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
 | [`two_bar_reversal_bullish_trigger`](/signals/catalog/patterns) | TRIGGER | Patterns | Open, High, Low, Close |
+| [`exchange_net_outflow`](/signals/catalog/on-chain) | FILTER | On-Chain | ExchangeNetflow |
+| [`exchange_outflow_spike`](/signals/catalog/on-chain) | TRIGGER | On-Chain | ExchangeNetflow |
+| [`holder_concentration_falling`](/signals/catalog/on-chain) | FILTER | On-Chain | HolderConcentration |
+| [`holder_concentration_low`](/signals/catalog/on-chain) | FILTER | On-Chain | HolderConcentration |
+| [`smart_money_holdings_cross`](/signals/catalog/on-chain) | TRIGGER | On-Chain | SmartMoneyHoldings |
+| [`smart_money_holdings_rising`](/signals/catalog/on-chain) | FILTER | On-Chain | SmartMoneyHoldings |
+| [`smart_money_inflow_spike`](/signals/catalog/on-chain) | TRIGGER | On-Chain | SmartMoneyNetflow |
+| [`smart_money_net_positive`](/signals/catalog/on-chain) | FILTER | On-Chain | SmartMoneyNetflow |
+| [`whale_accumulation_trigger`](/signals/catalog/on-chain) | TRIGGER | On-Chain | WhaleNetInflow |
+| [`whale_net_accumulation`](/signals/catalog/on-chain) | FILTER | On-Chain | WhaleNetInflow |
 
 ---
 
-_Generated from docstring metadata. 223 signals total (108 TRIGGER, 115 FILTER)._
+_Generated from docstring metadata. 233 signals total (112 TRIGGER, 121 FILTER)._

--- a/docs/signals/catalog/on-chain.mdx
+++ b/docs/signals/catalog/on-chain.mdx
@@ -1,0 +1,452 @@
+---
+title: "On-Chain Signals"
+description: "10 on-chain trading signals with parameters, descriptions, and examples."
+---
+
+# On-Chain Signals
+
+_10 signals in this category._
+
+See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.
+
+Click a signal to expand parameters and examples.
+
+<AccordionGroup>
+
+<Accordion title="exchange_net_outflow" description="FILTER - requires ExchangeNetflow">
+
+Check whether exchanges saw net outflows over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Number of bars to sum |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "exchange_net_outflow",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "exchange_net_outflow",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="exchange_outflow_spike" description="TRIGGER - requires ExchangeNetflow">
+
+Detect an unusually large net outflow from exchanges on the latest bar. Coins leaving exchanges reduce immediately sellable supply and are typically read as bullish.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 5 -- 200 | `20` | Number of prior bars forming the rolling baseline (the latest bar is excluded from its own baseline) |
+| `z_threshold` | `float` | 0.5 -- 5.0 | `2.0` | How many standard deviations below the baseline mean the latest flow must be to fire |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "exchange_outflow_spike",
+    "parameters": {
+        "window": 20,
+        "z_threshold": 2.0
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "exchange_outflow_spike",
+  "parameters": {
+    "window": 20,
+    "z_threshold": 2.0
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="holder_concentration_falling" description="FILTER - requires HolderConcentration">
+
+Check whether top-holder concentration is declining over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Lookback for the comparison |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "holder_concentration_falling",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "holder_concentration_falling",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="holder_concentration_low" description="FILTER - requires HolderConcentration">
+
+Check whether top-holder concentration is below a threshold. Lower concentration means supply is more widely distributed and less exposed to a single-wallet dump.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `threshold` | `float` | 0.0 -- 1.0 | `0.5` | Maximum acceptable top-holder share |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "holder_concentration_low",
+    "parameters": {
+        "threshold": 0.5
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "holder_concentration_low",
+  "parameters": {
+    "threshold": 0.5
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="smart_money_holdings_cross" description="TRIGGER - requires SmartMoneyHoldings">
+
+Detect smart-money holdings crossing above their moving average.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 3 -- 200 | `20` | Moving-average window for the holdings baseline |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "smart_money_holdings_cross",
+    "parameters": {
+        "window": 20
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "smart_money_holdings_cross",
+  "parameters": {
+    "window": 20
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="smart_money_holdings_rising" description="FILTER - requires SmartMoneyHoldings">
+
+Check whether smart-money holdings are higher than window bars ago.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Lookback for the comparison |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "smart_money_holdings_rising",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "smart_money_holdings_rising",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="smart_money_inflow_spike" description="TRIGGER - requires SmartMoneyNetflow">
+
+Detect an unusually large smart-money inflow on the latest bar.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 5 -- 200 | `20` | Number of prior bars forming the rolling baseline (the latest bar is excluded from its own baseline) |
+| `z_threshold` | `float` | 0.5 -- 5.0 | `2.0` | How many standard deviations above the baseline mean the latest inflow must be to fire |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "smart_money_inflow_spike",
+    "parameters": {
+        "window": 20,
+        "z_threshold": 2.0
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "smart_money_inflow_spike",
+  "parameters": {
+    "window": 20,
+    "z_threshold": 2.0
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="smart_money_net_positive" description="FILTER - requires SmartMoneyNetflow">
+
+Check whether smart money has been a net buyer over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Number of bars to sum |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "smart_money_net_positive",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "smart_money_net_positive",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="whale_accumulation_trigger" description="TRIGGER - requires WhaleNetInflow">
+
+Detect whale net flow flipping to accumulation.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 100 | `7` | Smoothing window for the net-flow moving average |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "whale_accumulation_trigger",
+    "parameters": {
+        "window": 7
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "whale_accumulation_trigger",
+  "parameters": {
+    "window": 7
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="whale_net_accumulation" description="FILTER - requires WhaleNetInflow">
+
+Check whether whales were net accumulators over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 200 | `14` | Number of bars to sum |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "whale_net_accumulation",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "whale_net_accumulation",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+</AccordionGroup>

--- a/kb_server/services/signal_service.py
+++ b/kb_server/services/signal_service.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from mangrove_kb.registry import RuleRegistry
 from mangrove_kb.docstring_parser import parse_all_signals
-from mangrove_kb.signals import momentum, trend, volume, volatility, patterns
+from mangrove_kb.signals import momentum, trend, volume, volatility, patterns, onchain
 
 _MODULE_CATEGORY = {
     "momentum": "Momentum",
@@ -16,9 +16,10 @@ _MODULE_CATEGORY = {
     "volume": "Volume",
     "volatility": "Volatility",
     "patterns": "Patterns",
+    "onchain": "On-Chain",
 }
 
-_SIGNAL_MODULES = [momentum, trend, volume, volatility, patterns]
+_SIGNAL_MODULES = [momentum, trend, volume, volatility, patterns, onchain]
 
 
 class SignalService:

--- a/mangrove_kb/signals/__init__.py
+++ b/mangrove_kb/signals/__init__.py
@@ -10,6 +10,7 @@ Signal Categories:
     - volume: OBV, CMF, MFI, VWAP, ADI, Force Index, etc.
     - volatility: Bollinger Bands, ATR, Keltner Channel, Donchian, etc.
     - patterns: Doji, Hammer, Engulfing, MorningStar, InsideBar, NR7, etc.
+    - onchain: smart-money flows, exchange flows, whale activity, holder concentration
 """
 
 # Import all signal modules to trigger registration with RuleRegistry
@@ -18,3 +19,4 @@ from mangrove_kb.signals import trend
 from mangrove_kb.signals import volume
 from mangrove_kb.signals import volatility
 from mangrove_kb.signals import patterns
+from mangrove_kb.signals import onchain

--- a/mangrove_kb/signals/onchain.py
+++ b/mangrove_kb/signals/onchain.py
@@ -1,0 +1,345 @@
+"""On-chain trading signals.
+
+Signal functions based on on-chain data feeds that Mangrove exposes through its
+API (Nansen smart-money + token analytics and WhaleAlert transaction flows).
+Unlike the price/volume signals in the other modules, these consume
+alternative-data columns alongside (or instead of) OHLCV.
+
+The caller is responsible for populating these columns on the DataFrame,
+time-aligned to the same bars as OHLCV -- exactly the way OHLCV itself is
+supplied. The MangroveAI data layer derives them from Nansen's tgm/flows
+(hourly per-wallet-category series) and historical-top-holders. Each value is
+the metric for that bar:
+
+    SmartMoneyNetflow   Per-bar net USD flow of smart-money wallets into the
+                        token (Δ holdings × price). Positive = net accumulation.
+                        (Nansen tgm/flows, label=smart_money.)
+    SmartMoneyHoldings  Aggregate USD held by smart-money wallets, level per bar.
+                        (Nansen tgm/flows, label=smart_money, value_usd.)
+    ExchangeNetflow     Per-bar net USD flow INTO exchanges. Positive = inflow
+                        (potential sell pressure); negative = outflow (coins
+                        leaving exchanges, typically bullish).
+                        (Nansen tgm/flows, label=exchange.)
+    WhaleNetInflow      Per-bar net whale flow. Positive = whale accumulation.
+                        (Nansen tgm/flows, label=whale.)
+    HolderConcentration Share of supply held by the top holders, 0.0-1.0.
+                        Higher = more concentrated (higher dump risk).
+                        (Nansen historical-top-holders, sum of top-N ownership.)
+
+See docs/data-providers.mdx for the upstream provider coverage map and how a
+series is fetched and time-aligned to OHLCV bars.
+
+Note: a total token-holder-count series is intentionally NOT provided -- Nansen
+exposes per-wallet-category holder counts but no clean total-holders time
+series, so signals that would depend on it are not shipped.
+"""
+
+import logging
+
+import pandas as pd
+
+from mangrove_kb.registry import RuleRegistry
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _clean_series(df: pd.DataFrame, column: str) -> "pd.Series | None":
+    """Return the named column as a float Series with NaNs dropped.
+
+    Returns None if the column is absent or has no usable values, so callers
+    can fail closed (return False) the same way the OHLCV signals do.
+    """
+    if column not in df.columns:
+        return None
+    series = pd.to_numeric(df[column], errors="coerce").dropna()
+    if series.empty:
+        return None
+    return series
+
+
+# =============================================================================
+# Smart-money signals (Nansen)
+# =============================================================================
+
+@RuleRegistry.register("smart_money_inflow_spike")
+def smart_money_inflow_spike(df: pd.DataFrame, window: int = 20, z_threshold: float = 2.0) -> bool:
+    """
+    Detect an unusually large smart-money inflow on the latest bar.
+
+    Type: TRIGGER
+    Requires: SmartMoneyNetflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with a SmartMoneyNetflow column.
+        window (int): Number of prior bars forming the rolling baseline (the
+            latest bar is excluded from its own baseline). Range: 5-200. Default: 20.
+        z_threshold (float): How many standard deviations above the baseline
+            mean the latest inflow must be to fire. Range: 0.5-5.0. Default: 2.0.
+
+    Returns:
+        bool: True if the latest net inflow is positive and at least
+            z_threshold standard deviations above the mean of the preceding
+            window bars.
+    """
+    series = _clean_series(df, "SmartMoneyNetflow")
+    if series is None or len(series) < window + 1:
+        return False
+
+    baseline = series.iloc[-(window + 1):-1]  # the window bars BEFORE the latest
+    last = float(series.iloc[-1])
+    std = float(baseline.std())
+    if std == 0 or pd.isna(std):
+        return False
+
+    z = (last - float(baseline.mean())) / std
+    return last > 0 and z >= z_threshold
+
+
+@RuleRegistry.register("smart_money_holdings_cross")
+def smart_money_holdings_cross(df: pd.DataFrame, window: int = 20) -> bool:
+    """
+    Detect smart-money holdings crossing above their moving average.
+
+    Type: TRIGGER
+    Requires: SmartMoneyHoldings
+
+    Args:
+        df (pd.DataFrame): DataFrame with a SmartMoneyHoldings column.
+        window (int): Moving-average window for the holdings baseline.
+            Range: 3-200. Default: 20.
+
+    Returns:
+        bool: True if holdings were at/below their moving average on the prior
+            bar and are above it on the latest bar.
+    """
+    series = _clean_series(df, "SmartMoneyHoldings")
+    if series is None or len(series) < window + 1:
+        return False
+
+    ma = series.rolling(window=window).mean()
+    prev, last = series.iloc[-2], series.iloc[-1]
+    prev_ma, last_ma = ma.iloc[-2], ma.iloc[-1]
+    if pd.isna(prev_ma) or pd.isna(last_ma):
+        return False
+
+    return prev <= prev_ma and last > last_ma
+
+
+@RuleRegistry.register("smart_money_net_positive")
+def smart_money_net_positive(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether smart money has been a net buyer over the window.
+
+    Type: FILTER
+    Requires: SmartMoneyNetflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with a SmartMoneyNetflow column.
+        window (int): Number of bars to sum. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the summed net inflow over the window is positive.
+    """
+    series = _clean_series(df, "SmartMoneyNetflow")
+    if series is None or len(series) < window:
+        return False
+
+    return float(series.iloc[-window:].sum()) > 0
+
+
+@RuleRegistry.register("smart_money_holdings_rising")
+def smart_money_holdings_rising(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether smart-money holdings are higher than window bars ago.
+
+    Type: FILTER
+    Requires: SmartMoneyHoldings
+
+    Args:
+        df (pd.DataFrame): DataFrame with a SmartMoneyHoldings column.
+        window (int): Lookback for the comparison. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the latest holdings exceed the value window bars ago.
+    """
+    series = _clean_series(df, "SmartMoneyHoldings")
+    if series is None or len(series) < window + 1:
+        return False
+
+    return float(series.iloc[-1]) > float(series.iloc[-1 - window])
+
+
+# =============================================================================
+# Exchange-flow signals (Nansen tgm/flows label=exchange; WhaleAlert fallback)
+# =============================================================================
+
+@RuleRegistry.register("exchange_outflow_spike")
+def exchange_outflow_spike(df: pd.DataFrame, window: int = 20, z_threshold: float = 2.0) -> bool:
+    """
+    Detect an unusually large net outflow from exchanges on the latest bar.
+
+    Coins leaving exchanges reduce immediately sellable supply and are
+    typically read as bullish.
+
+    Type: TRIGGER
+    Requires: ExchangeNetflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with an ExchangeNetflow column (positive
+            = inflow to exchanges, negative = outflow).
+        window (int): Number of prior bars forming the rolling baseline (the
+            latest bar is excluded from its own baseline). Range: 5-200. Default: 20.
+        z_threshold (float): How many standard deviations below the baseline
+            mean the latest flow must be to fire. Range: 0.5-5.0. Default: 2.0.
+
+    Returns:
+        bool: True if the latest flow is a net outflow (negative) and at least
+            z_threshold standard deviations below the mean of the preceding
+            window bars.
+    """
+    series = _clean_series(df, "ExchangeNetflow")
+    if series is None or len(series) < window + 1:
+        return False
+
+    baseline = series.iloc[-(window + 1):-1]  # the window bars BEFORE the latest
+    last = float(series.iloc[-1])
+    std = float(baseline.std())
+    if std == 0 or pd.isna(std):
+        return False
+
+    z = (last - float(baseline.mean())) / std
+    return last < 0 and z <= -z_threshold
+
+
+@RuleRegistry.register("exchange_net_outflow")
+def exchange_net_outflow(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether exchanges saw net outflows over the window.
+
+    Type: FILTER
+    Requires: ExchangeNetflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with an ExchangeNetflow column.
+        window (int): Number of bars to sum. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the summed exchange flow over the window is negative
+            (more leaving exchanges than entering).
+    """
+    series = _clean_series(df, "ExchangeNetflow")
+    if series is None or len(series) < window:
+        return False
+
+    return float(series.iloc[-window:].sum()) < 0
+
+
+# =============================================================================
+# Whale-flow signals (Nansen tgm/flows label=whale; WhaleAlert fallback)
+# =============================================================================
+
+@RuleRegistry.register("whale_accumulation_trigger")
+def whale_accumulation_trigger(df: pd.DataFrame, window: int = 7) -> bool:
+    """
+    Detect whale net flow flipping to accumulation.
+
+    Type: TRIGGER
+    Requires: WhaleNetInflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with a WhaleNetInflow column.
+        window (int): Smoothing window for the net-flow moving average.
+            Range: 2-100. Default: 7.
+
+    Returns:
+        bool: True if the smoothed whale net inflow was at/below zero on the
+            prior bar and is positive on the latest bar.
+    """
+    series = _clean_series(df, "WhaleNetInflow")
+    if series is None or len(series) < window + 1:
+        return False
+
+    ma = series.rolling(window=window).mean()
+    prev_ma, last_ma = ma.iloc[-2], ma.iloc[-1]
+    if pd.isna(prev_ma) or pd.isna(last_ma):
+        return False
+
+    return prev_ma <= 0 and last_ma > 0
+
+
+@RuleRegistry.register("whale_net_accumulation")
+def whale_net_accumulation(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether whales were net accumulators over the window.
+
+    Type: FILTER
+    Requires: WhaleNetInflow
+
+    Args:
+        df (pd.DataFrame): DataFrame with a WhaleNetInflow column.
+        window (int): Number of bars to sum. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the summed whale net inflow over the window is positive.
+    """
+    series = _clean_series(df, "WhaleNetInflow")
+    if series is None or len(series) < window:
+        return False
+
+    return float(series.iloc[-window:].sum()) > 0
+
+
+# =============================================================================
+# Holder-distribution signals (Nansen historical-top-holders)
+# =============================================================================
+
+@RuleRegistry.register("holder_concentration_low")
+def holder_concentration_low(df: pd.DataFrame, threshold: float = 0.5) -> bool:
+    """
+    Check whether top-holder concentration is below a threshold.
+
+    Lower concentration means supply is more widely distributed and less
+    exposed to a single-wallet dump.
+
+    Type: FILTER
+    Requires: HolderConcentration
+
+    Args:
+        df (pd.DataFrame): DataFrame with a HolderConcentration column (0.0-1.0).
+        threshold (float): Maximum acceptable top-holder share. Range: 0.0-1.0.
+            Default: 0.5.
+
+    Returns:
+        bool: True if the latest concentration is below the threshold.
+    """
+    series = _clean_series(df, "HolderConcentration")
+    if series is None:
+        return False
+
+    return float(series.iloc[-1]) < threshold
+
+
+@RuleRegistry.register("holder_concentration_falling")
+def holder_concentration_falling(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether top-holder concentration is declining over the window.
+
+    Type: FILTER
+    Requires: HolderConcentration
+
+    Args:
+        df (pd.DataFrame): DataFrame with a HolderConcentration column (0.0-1.0).
+        window (int): Lookback for the comparison. Range: 2-200. Default: 14.
+
+    Returns:
+        bool: True if the latest concentration is below the value window bars ago.
+    """
+    series = _clean_series(df, "HolderConcentration")
+    if series is None or len(series) < window + 1:
+        return False
+
+    return float(series.iloc[-1]) < float(series.iloc[-1 - window])

--- a/scripts/generate-signal-catalog.py
+++ b/scripts/generate-signal-catalog.py
@@ -27,7 +27,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import mangrove_kb  # noqa: E402
 from mangrove_kb.registry import RuleRegistry  # noqa: E402
 from mangrove_kb.docstring_parser import parse_all_signals  # noqa: E402
-from mangrove_kb.signals import momentum, trend, volume, volatility, patterns  # noqa: E402
+from mangrove_kb.signals import momentum, trend, volume, volatility, patterns, onchain  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Category classification
@@ -39,6 +39,7 @@ MODULE_CATEGORY = {
     "volume": "Volume",
     "volatility": "Volatility",
     "patterns": "Patterns",
+    "onchain": "On-Chain",
 }
 
 
@@ -154,7 +155,7 @@ def generate_catalog():
     """Generate the docs/signals/catalog.mdx file."""
 
     # Parse all signals
-    signal_modules = [momentum, trend, volume, volatility, patterns]
+    signal_modules = [momentum, trend, volume, volatility, patterns, onchain]
     all_signals = parse_all_signals(signal_modules)
 
     # Attach category info
@@ -170,7 +171,7 @@ def generate_catalog():
         })
 
     # Sort by category then name
-    category_order = ["Momentum", "Trend", "Volume", "Volatility", "Patterns", "Other"]
+    category_order = ["Momentum", "Trend", "Volume", "Volatility", "Patterns", "On-Chain", "Other"]
     enriched.sort(key=lambda s: (category_order.index(s["category"]) if s["category"] in category_order else 99, s["name"]))
 
     # Group by category
@@ -252,7 +253,7 @@ def generate_catalog():
     index_lines = []
     index_lines.append("---")
     index_lines.append('title: "Signal Catalog"')
-    index_lines.append(f'description: "Index of all {total} trading signals across 5 categories."')
+    index_lines.append(f'description: "Index of all {total} trading signals across {len(grouped)} categories."')
     index_lines.append("---")
     index_lines.append("")
     index_lines.append("# Signal Catalog")

--- a/tests/test_api_signals.py
+++ b/tests/test_api_signals.py
@@ -12,7 +12,7 @@ class TestSignalEndpoints:
         resp = client.get("/api/signals")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 223
+        assert data["total"] == 233
 
     def test_list_signals_filter_category(self):
         resp = client.get("/api/signals?category=Momentum")
@@ -22,7 +22,7 @@ class TestSignalEndpoints:
     def test_list_signals_filter_type(self):
         resp = client.get("/api/signals?signal_type=TRIGGER")
         assert resp.status_code == 200
-        assert resp.json()["total"] == 108
+        assert resp.json()["total"] == 112
 
     def test_get_signal(self):
         resp = client.get("/api/signals/rsi_oversold")

--- a/tests/test_onchain_signals.py
+++ b/tests/test_onchain_signals.py
@@ -1,0 +1,173 @@
+"""
+Validation and behavioral tests for on-chain signals.
+
+Parses all signal functions in the onchain module and validates structural
+correctness (required tags, param types, ranges, defaults), then exercises each
+signal against synthetic on-chain data to confirm it fires (and stays quiet)
+under the expected conditions.
+
+Usage:
+    pytest tests/test_onchain_signals.py -v
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mangrove_kb.registry import RuleRegistry
+from mangrove_kb.signals import onchain as onchain_signals
+from mangrove_kb.docstring_parser import parse_all_signals
+
+
+@pytest.fixture(scope="session")
+def parsed_onchain() -> dict:
+    return parse_all_signals([onchain_signals])
+
+
+# --------------------------------------------------------------------------- #
+# Coverage                                                                    #
+# --------------------------------------------------------------------------- #
+class TestOnChainCoverage:
+    EXPECTED_TRIGGER_COUNT = 4
+    EXPECTED_FILTER_COUNT = 6
+    EXPECTED_TOTAL = EXPECTED_TRIGGER_COUNT + EXPECTED_FILTER_COUNT
+
+    def test_total_count(self, parsed_onchain):
+        assert len(parsed_onchain) == self.EXPECTED_TOTAL, sorted(parsed_onchain)
+
+    def test_trigger_count(self, parsed_onchain):
+        triggers = [k for k, v in parsed_onchain.items() if v["type"] == "TRIGGER"]
+        assert len(triggers) == self.EXPECTED_TRIGGER_COUNT, sorted(triggers)
+
+    def test_filter_count(self, parsed_onchain):
+        filters = [k for k, v in parsed_onchain.items() if v["type"] == "FILTER"]
+        assert len(filters) == self.EXPECTED_FILTER_COUNT, sorted(filters)
+
+    def test_all_registered(self, parsed_onchain):
+        for name in parsed_onchain:
+            assert name in RuleRegistry._registry, name
+
+
+# --------------------------------------------------------------------------- #
+# Structural validation                                                       #
+# --------------------------------------------------------------------------- #
+class TestOnChainMetadata:
+    VALID_COLUMNS = {
+        "SmartMoneyNetflow",
+        "SmartMoneyHoldings",
+        "ExchangeNetflow",
+        "WhaleNetInflow",
+        "HolderConcentration",
+    }
+
+    def test_type_and_requires(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            assert meta["type"] in ("TRIGGER", "FILTER"), name
+            assert isinstance(meta["requires"], list) and meta["requires"], name
+            for col in meta["requires"]:
+                assert col in self.VALID_COLUMNS, f"{name} requires unknown column '{col}'"
+
+    def test_no_total_holder_count(self, parsed_onchain):
+        # TokenHolderCount has no upstream series and must not be required by any signal.
+        for name, meta in parsed_onchain.items():
+            assert "TokenHolderCount" not in meta["requires"], name
+
+    def test_description_present(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            assert len(meta["description"]) > 10, name
+
+    def test_numeric_params_have_valid_range(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            for pname, pspec in meta.get("params", {}).items():
+                if pspec["type"] in ("int", "float"):
+                    assert "min" in pspec and "max" in pspec, f"{name}.{pname}"
+                    assert pspec["min"] < pspec["max"], f"{name}.{pname}"
+
+    def test_defaults_within_range(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            for pname, pspec in meta.get("params", {}).items():
+                if "default" in pspec and "min" in pspec:
+                    assert pspec["min"] <= pspec["default"] <= pspec["max"], f"{name}.{pname}"
+
+    def test_df_excluded(self, parsed_onchain):
+        for name, meta in parsed_onchain.items():
+            assert "df" not in meta.get("params", {}), name
+
+
+# --------------------------------------------------------------------------- #
+# Behavioral tests                                                            #
+# --------------------------------------------------------------------------- #
+def _evaluate(name, df, params=None):
+    return RuleRegistry.evaluate({"name": name, "params": params or {}}, df)
+
+
+def _noisy(center, n, seed=0):
+    """Deterministic small-variance baseline (nonzero std so a z-score is defined)."""
+    rng = np.random.default_rng(seed)
+    return list(center + rng.normal(0, 1.0, n))
+
+
+class TestOnChainBehavior:
+    def test_smart_money_inflow_spike(self):
+        flow = _noisy(10.0, 25) + [500.0]
+        df = pd.DataFrame({"SmartMoneyNetflow": flow})
+        assert _evaluate("smart_money_inflow_spike", df, {"window": 20, "z_threshold": 2.0})
+        # No spike -> no fire.
+        assert not _evaluate("smart_money_inflow_spike",
+                             pd.DataFrame({"SmartMoneyNetflow": _noisy(10.0, 26, seed=1)}))
+
+    def test_inflow_spike_excludes_current_bar_from_baseline(self):
+        # Regression for the z-score bug: the latest bar must NOT be part of its own
+        # baseline. Baseline = five tight bars (mean 10, std 1); a 12.5 spike is z=2.5
+        # against the prior bars (fires), but only z~1.5 if the spike inflates its own
+        # mean/std (the old buggy behavior), which would NOT fire.
+        df = pd.DataFrame({"SmartMoneyNetflow": [9.0, 11.0, 9.0, 11.0, 10.0, 12.5]})
+        assert _evaluate("smart_money_inflow_spike", df, {"window": 5, "z_threshold": 2.0})
+
+    def test_smart_money_holdings_cross(self):
+        holdings = [100.0] * 25 + [400.0]
+        assert _evaluate("smart_money_holdings_cross",
+                         pd.DataFrame({"SmartMoneyHoldings": holdings}), {"window": 20})
+
+    def test_smart_money_net_positive(self):
+        assert _evaluate("smart_money_net_positive", pd.DataFrame({"SmartMoneyNetflow": [5.0] * 14}))
+        assert not _evaluate("smart_money_net_positive", pd.DataFrame({"SmartMoneyNetflow": [-5.0] * 14}))
+
+    def test_smart_money_holdings_rising(self):
+        assert _evaluate("smart_money_holdings_rising",
+                         pd.DataFrame({"SmartMoneyHoldings": list(np.arange(20, dtype=float))}), {"window": 14})
+        assert not _evaluate("smart_money_holdings_rising",
+                             pd.DataFrame({"SmartMoneyHoldings": list(np.arange(20, 0, -1, dtype=float))}), {"window": 14})
+
+    def test_exchange_outflow_spike(self):
+        df = pd.DataFrame({"ExchangeNetflow": _noisy(0.0, 25, seed=2) + [-500.0]})
+        assert _evaluate("exchange_outflow_spike", df, {"window": 20, "z_threshold": 2.0})
+        # A large *inflow* must not fire this bullish (outflow) signal.
+        assert not _evaluate("exchange_outflow_spike",
+                             pd.DataFrame({"ExchangeNetflow": _noisy(0.0, 25, seed=3) + [500.0]}),
+                             {"window": 20, "z_threshold": 2.0})
+
+    def test_exchange_net_outflow(self):
+        assert _evaluate("exchange_net_outflow", pd.DataFrame({"ExchangeNetflow": [-3.0] * 14}))
+        assert not _evaluate("exchange_net_outflow", pd.DataFrame({"ExchangeNetflow": [3.0] * 14}))
+
+    def test_whale_accumulation_trigger(self):
+        flow = [-10.0] * 10 + [5.0, 5.0, 5.0]
+        assert _evaluate("whale_accumulation_trigger", pd.DataFrame({"WhaleNetInflow": flow}), {"window": 3})
+
+    def test_whale_net_accumulation(self):
+        assert _evaluate("whale_net_accumulation", pd.DataFrame({"WhaleNetInflow": [2.0] * 14}))
+        assert not _evaluate("whale_net_accumulation", pd.DataFrame({"WhaleNetInflow": [-2.0] * 14}))
+
+    def test_holder_concentration_low(self):
+        assert _evaluate("holder_concentration_low", pd.DataFrame({"HolderConcentration": [0.3]}), {"threshold": 0.5})
+        assert not _evaluate("holder_concentration_low", pd.DataFrame({"HolderConcentration": [0.8]}), {"threshold": 0.5})
+
+    def test_holder_concentration_falling(self):
+        falling = pd.DataFrame({"HolderConcentration": list(np.linspace(0.8, 0.4, 20))})
+        assert _evaluate("holder_concentration_falling", falling, {"window": 14})
+
+    def test_missing_column_returns_false(self):
+        empty = pd.DataFrame({"Close": [1.0, 2.0, 3.0]})
+        for name in parse_all_signals([onchain_signals]):
+            assert _evaluate(name, empty) is False, f"{name} should fail closed on missing data"

--- a/tests/test_signal_service.py
+++ b/tests/test_signal_service.py
@@ -8,7 +8,7 @@ class TestSignalServiceMetadata:
 
     def test_list_signals_returns_all(self):
         signals = self.service.list_signals()
-        assert len(signals) == 223
+        assert len(signals) == 233
 
     def test_list_signals_filter_by_category(self):
         momentum = self.service.list_signals(category="Momentum")
@@ -16,7 +16,7 @@ class TestSignalServiceMetadata:
 
     def test_list_signals_filter_by_type(self):
         triggers = self.service.list_signals(signal_type="TRIGGER")
-        assert len(triggers) == 108
+        assert len(triggers) == 112
 
     def test_get_signal_exists(self):
         signal = self.service.get_signal("rsi_oversold")


### PR DESCRIPTION
## What

Phase 4 of the on-chain-signals program: a rework of **#57** against the real data contract the data layer produces (MangroveRoots PR #55 → `tgm/flows` + `historical-top-holders`). Independent of the data plane — lands on its own.

## Signals (10: 4 TRIGGER, 6 FILTER)
smart_money_inflow_spike, smart_money_holdings_cross, smart_money_net_positive, smart_money_holdings_rising, exchange_outflow_spike, exchange_net_outflow, whale_accumulation_trigger, whale_net_accumulation, holder_concentration_low, holder_concentration_falling.

## Changes vs #57
- **Dropped** `holder_growth_breakout` + `holder_base_expanding` — they need a **total token-holder-count series that has no upstream source** (Nansen exposes per-category counts only). Live-verified during investigation.
- **Fixed z-score baseline bug** in the two spike signals: the latest bar was included in its own rolling baseline (`iloc[-window:]`), damping the z-score. Now uses the preceding `window` bars (`iloc[-(window+1):-1]`). Added a regression test.
- Tightened column/unit docstrings to match the real derivation (netflow = Δtoken_amount × price_usd; holdings = value_usd level; concentration = top-N ownership share).

## Wiring + counts
- Registered in `signals/__init__`, `SignalService`, catalog generator (new **On-Chain** category); regenerated catalog + `mint.json` nav.
- Counts synced to **233 total (112 TRIGGER, 121 FILTER), 6 categories, On-Chain 10** across `CLAUDE.md`, `test_api_signals.py`, `test_signal_service.py`.
- `docs/data-providers.mdx`: corrected **WhaleAlert → Developer tier / 30-day cap** (was wrongly "Enterprise REST"); documented the `tgm/flows` series + `/v1beta1` backtesting family + on-chain column derivations.

## Verification
- Full suite: **109 passed, 17 skipped** (the documented fastmcp/external-env skips).
- **Live E2E:** a real **697-row Nansen WETH hourly series** (fetched via the data layer) fed through `RuleRegistry.evaluate` produced real signal decisions (`whale_net_accumulation=True`, others False for the window).

Supersedes #57 (on a contributor fork; data contract materially changed) — please close #57 with credit to the original author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)