### PR TITLE
ci(release): push tag with GH_PAT so KB image + docs builds cascade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # Push the release tag with GH_PAT (not the default GITHUB_TOKEN) so the
+          # tag push CASCADES to the tag-triggered workflows (build-and-push.yaml +
+          # build-docs.yml). GITHUB_TOKEN-pushed tags do NOT trigger other workflows,
+          # which is why the KB image/docs builds previously had to be dispatched by hand.
+          token: ${{ secrets.GH_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
release.yml pushed its tag with the default GITHUB_TOKEN — which by GitHub design does **not** trigger other workflows. So `build-and-push.yaml` (KB server image) and `build-docs.yml` (docs image) never fired on a release, forcing manual `gh workflow run` every time (exactly what happened with v1.1.0). Checking out with `secrets.GH_PAT` makes the tag push cascade to those builds. GH_PAT secret is already set on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)