### PR TITLE
docs(backtesting): backtest a saved strategy by strategy_id

### DIFF
--- a/docs/api-reference/backtesting.mdx
+++ b/docs/api-reference/backtesting.mdx
@@ -115,10 +115,28 @@ metrics = response.json().get("metrics", {})
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `asset` | string | Asset symbol (e.g., "BTC", "ETH") |
+| `asset` | string | Asset symbol (e.g., "BTC", "ETH"). Optional when `strategy_id` is supplied (defaults from the saved strategy). |
 | `interval` | string | Time interval ("1h", "4h", "1d") |
 | `initial_balance` | number | Starting account balance |
-| `strategy_json` | string | Stringified JSON strategy configuration |
+| `strategy_json` | string | Stringified JSON strategy configuration. Provide this **or** `strategy_id`. |
+
+### Strategy Source: `strategy_json` or `strategy_id`
+
+Provide exactly one of:
+
+- **`strategy_json`** (string) -- the stringified strategy configuration shown below.
+- **`strategy_id`** (string) -- the UUID of a strategy you already created. The API loads its definition and defaults `asset` and `execution_config` from the saved strategy when you omit them.
+
+Sending both returns `400`; an unknown or inaccessible `strategy_id` returns `404`. The same `strategy_id` option is accepted by the async endpoint `POST /api/v2/backtests/`.
+
+```json
+{
+  "strategy_id": "550e8400-e29b-41d4-a716-446655440000",
+  "interval": "1h",
+  "lookback_months": 12,
+  "initial_balance": 10000.0
+}
+```
 
 ### Strategy JSON Format
 

--- a/docs/guides/running-a-backtest.mdx
+++ b/docs/guides/running-a-backtest.mdx
@@ -206,6 +206,102 @@ const result = await response.json();
 The `strategy_json` field must be a **stringified** JSON object, not a nested object. Use `JSON.stringify()` in JavaScript or `json.dumps()` in Python.
 </Note>
 
+### Reuse a saved strategy by ID
+
+If you already [created a strategy](/guides/creating-a-strategy) and have its `strategy_id`, you can backtest it directly instead of re-supplying the full `strategy_json`. Pass `strategy_id` and the run parameters (date range, account, and risk settings); the API loads the strategy's definition for you and defaults `asset` and `execution_config` from the saved strategy when you omit them.
+
+<CodeGroup>
+```bash cURL
+curl -s -X POST "https://api.mangrovedeveloper.ai/api/v1/backtesting/backtest" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "strategy_id": "550e8400-e29b-41d4-a716-446655440000",
+    "interval": "1h",
+    "lookback_months": 12,
+    "initial_balance": 10000.0,
+    "min_balance_threshold": 0.1,
+    "min_trade_amount": 25.0,
+    "max_open_positions": 5,
+    "max_trades_per_day": 50,
+    "max_risk_per_trade": 0.01,
+    "max_units_per_trade": 100.0,
+    "max_trade_amount": 10000.0,
+    "volatility_window": 24,
+    "target_volatility": 0.02,
+    "volatility_mode": "stddev",
+    "enable_volatility_adjustment": false,
+    "cooldown_bars": 24,
+    "daily_momentum_limit": 3.0,
+    "weekly_momentum_limit": 3.0
+  }' | python3 -m json.tool
+```
+
+```python Python
+backtest_payload = {
+    "strategy_id": "550e8400-e29b-41d4-a716-446655440000",
+    "interval": "1h",
+    "lookback_months": 12,
+    "initial_balance": 10000.0,
+    "min_balance_threshold": 0.1,
+    "min_trade_amount": 25.0,
+    "max_open_positions": 5,
+    "max_trades_per_day": 50,
+    "max_risk_per_trade": 0.01,
+    "max_units_per_trade": 100.0,
+    "max_trade_amount": 10000.0,
+    "volatility_window": 24,
+    "target_volatility": 0.02,
+    "volatility_mode": "stddev",
+    "enable_volatility_adjustment": False,
+    "cooldown_bars": 24,
+    "daily_momentum_limit": 3.0,
+    "weekly_momentum_limit": 3.0,
+}
+
+response = requests.post(
+    f"{BASE_URL}/api/v1/backtesting/backtest",
+    headers=HEADERS,
+    json=backtest_payload,
+)
+result = response.json()
+```
+
+```javascript JavaScript
+const backtestPayload = {
+  strategy_id: "550e8400-e29b-41d4-a716-446655440000",
+  interval: "1h",
+  lookback_months: 12,
+  initial_balance: 10000.0,
+  min_balance_threshold: 0.1,
+  min_trade_amount: 25.0,
+  max_open_positions: 5,
+  max_trades_per_day: 50,
+  max_risk_per_trade: 0.01,
+  max_units_per_trade: 100.0,
+  max_trade_amount: 10000.0,
+  volatility_window: 24,
+  target_volatility: 0.02,
+  volatility_mode: "stddev",
+  enable_volatility_adjustment: false,
+  cooldown_bars: 24,
+  daily_momentum_limit: 3.0,
+  weekly_momentum_limit: 3.0,
+};
+
+const response = await fetch(`${BASE_URL}/api/v1/backtesting/backtest`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify(backtestPayload),
+});
+const result = await response.json();
+```
+</CodeGroup>
+
+<Note>
+Provide **either** `strategy_id` **or** `strategy_json`, not both. Sending both returns a `400`; an unknown or inaccessible `strategy_id` returns a `404`. To override the saved strategy's market, include `asset` (and `execution_config`) explicitly alongside `strategy_id`.
+</Note>
+
 ## Step 2: Choose your date range
 
 The backtesting API supports four modes for specifying the time window:


### PR DESCRIPTION
## What & why

Companion docs for MangroveTechnologies/MangroveAI#629. Tester `tom_wang.` (Discord #testing-log) created a strategy, got a `strategy_id`, then followed the "Running a Backtest" guide and found it only showed the inline `strategy_json` payload -- so reusing the id wasn't discoverable.

## Changes

- **docs/guides/running-a-backtest.mdx** -- new "Reuse a saved strategy by ID" section under Step 1 (cURL / Python / JS) showing a backtest driven by `strategy_id`, with a note on the either/or rule and `asset`/`execution_config` defaulting.
- **docs/api-reference/backtesting.mdx** -- documents the `strategy_json`-or-`strategy_id` choice, the `400` (both) / `404` (unknown id) behavior, and that the same option works on the async `POST /api/v2/backtests/`.

## Verification

```
$ mintlify broken-links
success no broken links found
```

`<CodeGroup>`/`<Note>` tags balanced in both files; example JSON payloads parse. The internal link `/guides/creating-a-strategy` resolves. (The unrelated OpenAPI-schema warning is pre-existing on main.)

> Depends on MangroveTechnologies/MangroveAI#629 shipping the `strategy_id` support these docs describe.

cc @mangrove-one @nirajg0408
