### PR TITLE
docs(signals): add required Authorization header to signal-discovery examples

### DIFF
--- a/docs/api-reference/signals.mdx
+++ b/docs/api-reference/signals.mdx
@@ -20,6 +20,23 @@ Entry conditions must include exactly one TRIGGER and exactly one FILTER.
 https://api.mangrovedeveloper.ai/api/v1/signals
 ```
 
+## Authentication
+
+All signals endpoints require a Bearer token (a JWT or an API key) in the `Authorization` header. Requests without it return `401 Unauthorized`. See the [Authentication guide](/authentication) for how to obtain a token. The examples below assume the token is available as `$TOKEN` (cURL) / `headers` (Python):
+
+<CodeGroup>
+```bash cURL
+export TOKEN="your-jwt-token-here"
+```
+
+```python Python
+import requests
+
+TOKEN = "your-jwt-token-here"
+headers = {"Authorization": f"Bearer {TOKEN}"}
+```
+</CodeGroup>
+
 ## Endpoints
 
 ### List All Signals
@@ -32,7 +49,8 @@ https://api.mangrovedeveloper.ai/api/v1/signals
 
 <CodeGroup>
 ```bash cURL
-curl -X GET "https://api.mangrovedeveloper.ai/api/v1/signals?limit=10&offset=0"
+curl -X GET "https://api.mangrovedeveloper.ai/api/v1/signals?limit=10&offset=0" \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 ```python Python
@@ -40,6 +58,7 @@ import requests
 
 response = requests.get(
     "https://api.mangrovedeveloper.ai/api/v1/signals",
+    headers=headers,
     params={"limit": 10, "offset": 0}
 )
 signals = response.json()["signals"]
@@ -76,7 +95,8 @@ signals = response.json()["signals"]
 `GET /api/v1/signals/{signal_name}`
 
 ```bash
-curl -X GET https://api.mangrovedeveloper.ai/api/v1/signals/rsi_oversold
+curl -X GET https://api.mangrovedeveloper.ai/api/v1/signals/rsi_oversold \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 ### Search Signals
@@ -88,6 +108,7 @@ Search for signals by name, parameters, or keywords.
 <CodeGroup>
 ```bash cURL
 curl -X POST https://api.mangrovedeveloper.ai/api/v1/signals/search \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "query": "moving average",
@@ -99,6 +120,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/signals/search \
 ```python Python
 response = requests.post(
     "https://api.mangrovedeveloper.ai/api/v1/signals/search",
+    headers=headers,
     json={"query": "moving average", "search_type": "keywords", "limit": 20}
 )
 ```
@@ -115,6 +137,7 @@ Intent-aware semantic signal matching using natural language descriptions.
 <CodeGroup>
 ```bash cURL
 curl -X POST https://api.mangrovedeveloper.ai/api/v1/signals/match \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "user_description": "I want to buy when RSI is low and showing oversold conditions",
@@ -126,6 +149,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/signals/match \
 ```python Python
 response = requests.post(
     "https://api.mangrovedeveloper.ai/api/v1/signals/match",
+    headers=headers,
     json={
         "user_description": "I want to buy when RSI is low",
         "num_results": 3,
@@ -163,6 +187,7 @@ Evaluate a signal against provided market data. Returns a boolean result.
 <CodeGroup>
 ```bash cURL
 curl -X POST https://api.mangrovedeveloper.ai/api/v1/signals/is_above_sma/evaluate \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "market_data": [
@@ -176,6 +201,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/signals/is_above_sma/evalua
 ```python Python
 response = requests.post(
     "https://api.mangrovedeveloper.ai/api/v1/signals/is_above_sma/evaluate",
+    headers=headers,
     json={
         "market_data": [
             {"Close": 100}, {"Close": 102}, {"Close": 101},
@@ -196,6 +222,7 @@ Evaluate chart data for a date range with multiple signals across different time
 
 ```bash
 curl -X POST https://api.mangrovedeveloper.ai/api/v1/signals/evaluate-multiple-series \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "symbol": "BTC",
@@ -217,6 +244,7 @@ Validate parameters for a signal without evaluating it.
 
 ```bash
 curl -X POST https://api.mangrovedeveloper.ai/api/v1/signals/is_above_sma/validate-params \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"parameters": {"window": 20}}'
 ```

--- a/docs/guides/creating-a-strategy.mdx
+++ b/docs/guides/creating-a-strategy.mdx
@@ -48,11 +48,12 @@ Start by exploring what signals are available. The signals endpoint returns all 
 
 <CodeGroup>
 ```bash cURL
-curl -s "https://api.mangrovedeveloper.ai/api/v1/signals?limit=100" | python3 -m json.tool
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/signals?limit=100" | python3 -m json.tool
 ```
 
 ```python Python
-response = requests.get(f"{BASE_URL}/api/v1/signals", params={"limit": 100})
+response = requests.get(f"{BASE_URL}/api/v1/signals", headers=HEADERS, params={"limit": 100})
 signals = response.json()
 
 print(f"Total signals: {signals['total']}")
@@ -61,7 +62,7 @@ for sig in signals["signals"][:5]:
 ```
 
 ```javascript JavaScript
-const response = await fetch(`${BASE_URL}/api/v1/signals?limit=100`);
+const response = await fetch(`${BASE_URL}/api/v1/signals?limit=100`, { headers });
 const data = await response.json();
 
 console.log(`Total signals: ${data.total}`);
@@ -76,6 +77,7 @@ You can also search for signals by name or keyword:
 <CodeGroup>
 ```bash cURL
 curl -s -X POST "https://api.mangrovedeveloper.ai/api/v1/signals/search" \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"query": "macd", "search_type": "name"}'
 ```
@@ -83,6 +85,7 @@ curl -s -X POST "https://api.mangrovedeveloper.ai/api/v1/signals/search" \
 ```python Python
 response = requests.post(
     f"{BASE_URL}/api/v1/signals/search",
+    headers=HEADERS,
     json={"query": "macd", "search_type": "name"},
 )
 for sig in response.json()["signals"]:
@@ -93,7 +96,7 @@ for sig in response.json()["signals"]:
 ```javascript JavaScript
 const response = await fetch(`${BASE_URL}/api/v1/signals/search`, {
   method: "POST",
-  headers: { "Content-Type": "application/json" },
+  headers,
   body: JSON.stringify({ query: "macd", search_type: "name" }),
 });
 const data = await response.json();
@@ -108,6 +111,7 @@ Not sure which signals to use? Describe your trading idea in plain English using
 
 ```bash
 curl -X POST "https://api.mangrovedeveloper.ai/api/v1/signals/match" \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"user_description": "I want to buy when momentum is turning bullish", "num_results": 5}'
 ```
@@ -129,21 +133,23 @@ First, inspect each signal to understand its parameters:
 <CodeGroup>
 ```bash cURL
 # Check the TRIGGER signal
-curl -s "https://api.mangrovedeveloper.ai/api/v1/signals/macd_bullish_cross" | python3 -m json.tool
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/signals/macd_bullish_cross" | python3 -m json.tool
 
 # Check the FILTER signal
-curl -s "https://api.mangrovedeveloper.ai/api/v1/signals/is_above_sma" | python3 -m json.tool
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "https://api.mangrovedeveloper.ai/api/v1/signals/is_above_sma" | python3 -m json.tool
 ```
 
 ```python Python
 # Inspect TRIGGER
-trigger = requests.get(f"{BASE_URL}/api/v1/signals/macd_bullish_cross").json()
+trigger = requests.get(f"{BASE_URL}/api/v1/signals/macd_bullish_cross", headers=HEADERS).json()
 print(f"TRIGGER: {trigger['name']}")
 print(f"  Description: {trigger['metadata']['description']}")
 print(f"  Parameters: {list(trigger['metadata']['params'].keys())}")
 
 # Inspect FILTER
-filter_sig = requests.get(f"{BASE_URL}/api/v1/signals/is_above_sma").json()
+filter_sig = requests.get(f"{BASE_URL}/api/v1/signals/is_above_sma", headers=HEADERS).json()
 print(f"\nFILTER: {filter_sig['name']}")
 print(f"  Description: {filter_sig['metadata']['description']}")
 print(f"  Parameters: {list(filter_sig['metadata']['params'].keys())}")
@@ -151,7 +157,7 @@ print(f"  Parameters: {list(filter_sig['metadata']['params'].keys())}")
 
 ```javascript JavaScript
 // Inspect TRIGGER
-const trigger = await fetch(`${BASE_URL}/api/v1/signals/macd_bullish_cross`).then((r) =>
+const trigger = await fetch(`${BASE_URL}/api/v1/signals/macd_bullish_cross`, { headers }).then((r) =>
   r.json()
 );
 console.log(`TRIGGER: ${trigger.name}`);
@@ -159,7 +165,7 @@ console.log(`  Description: ${trigger.metadata.description}`);
 console.log(`  Parameters: ${Object.keys(trigger.metadata.params).join(", ")}`);
 
 // Inspect FILTER
-const filter = await fetch(`${BASE_URL}/api/v1/signals/is_above_sma`).then((r) =>
+const filter = await fetch(`${BASE_URL}/api/v1/signals/is_above_sma`, { headers }).then((r) =>
   r.json()
 );
 console.log(`\nFILTER: ${filter.name}`);

--- a/docs/guides/understanding-signals.mdx
+++ b/docs/guides/understanding-signals.mdx
@@ -137,17 +137,24 @@ An entry only occurs when `macd_bullish_cross` fires **and** `is_above_sma` is `
 
 ## Parameter tuning basics
 
-Every signal has configurable parameters with documented ranges and defaults. You can view these via the API:
+Every signal has configurable parameters with documented ranges and defaults. You can view these via the API. The signals endpoints require authentication, so include your Bearer token (see the [Authentication guide](/authentication) for how to obtain one):
 
 <CodeGroup>
 ```bash cURL
-curl https://api.mangrovedeveloper.ai/api/v1/signals/rsi_oversold
+curl -H "Authorization: Bearer $TOKEN" \
+  https://api.mangrovedeveloper.ai/api/v1/signals/rsi_oversold
 ```
 
 ```python Python
 import requests
 
-response = requests.get("https://api.mangrovedeveloper.ai/api/v1/signals/rsi_oversold")
+TOKEN = "your-jwt-token-here"
+headers = {"Authorization": f"Bearer {TOKEN}"}
+
+response = requests.get(
+    "https://api.mangrovedeveloper.ai/api/v1/signals/rsi_oversold",
+    headers=headers,
+)
 signal = response.json()
 
 for param_name, param_info in signal["metadata"]["params"].items():
@@ -156,7 +163,11 @@ for param_name, param_info in signal["metadata"]["params"].items():
 ```
 
 ```javascript JavaScript
-const response = await fetch("https://api.mangrovedeveloper.ai/api/v1/signals/rsi_oversold");
+const TOKEN = "your-jwt-token-here";
+const response = await fetch(
+  "https://api.mangrovedeveloper.ai/api/v1/signals/rsi_oversold",
+  { headers: { Authorization: `Bearer ${TOKEN}` } }
+);
 const signal = await response.json();
 
 for (const [name, info] of Object.entries(signal.metadata.params)) {


### PR DESCRIPTION
Fixes #62

## What

The signal-discovery code examples in the developer guides and the Signals API reference omitted the required `Authorization` header, so a new developer copying them hit `401 Unauthorized` out of the box — exactly the "Cold start" friction the tester reported.

Adds `Authorization: Bearer` auth (cURL / Python / JavaScript) to every example that calls an auth-gated signals endpoint:

- `docs/guides/creating-a-strategy.mdx` — Step 1 (`GET /signals`, `POST /signals/search`), Step 2 (two `GET /signals/{name}`), and the semantic-match Tip. Wired to the `$TOKEN` / `HEADERS` / `headers` the guide's Prerequisites already set up.
- `docs/guides/understanding-signals.mdx` — "Parameter tuning basics" (`GET /signals/{name}`), made self-contained with a token note + inline header.
- `docs/api-reference/signals.mdx` — added an Authentication section and the header to List / Get details / Search / Match / Evaluate / evaluate-multiple-series / validate-params.

Docs-only — no code or behavior change.

## Why this is correct (verified against real code)

Every `/api/v1/signals*` resource in `MangroveAI/src/MangroveAI/domains/signals/routes.py` is decorated with `@auth_required` + `@require_permission(SIGNAL_READ)`. `auth_required` → `get_token_from_header` (`utils/auth/middleware.py:311-323`) reads `Authorization: Bearer <token>` and returns 401 when it is absent. `Bearer` is this service's scheme (the MangroveAI portal API) — confirmed against its middleware, *not* the mangrove-agent `X-API-Key` scheme.

## Scope check — fixed everywhere it was wrong, left correct surfaces alone

Already correct (no change): `quickstart.mdx`, `authentication.mdx`, `api-reference/overview.mdx`, `signals/overview.mdx`, and the Step 4/5 strategy create/verify examples. The `MangroveAI-SDK` injects auth in its transport, so its examples never show raw headers. `api-reference/signals.mdx` is hand-authored (not emitted by `scripts/generate-api-reference.py`, whose default domains are config/defi/on-chain/promo-codes/social and which already emits auth).

Companion PR for the same root cause on the in-app reference: **MangroveAI** `frontend/public/docs/api/signals.md` (linked below).

## Verification

- **Live prod reproduction:** `GET https://api.mangrovedeveloper.ai/api/v1/signals?limit=1` with no header → `401 {"error":"Unauthorized","message":"Invalid or expired token"}`. Same for `POST /signals/search`. Confirms the examples were broken out of the box and the header is the required fix. (A 200 needs a real token, which the bot does not hold.)
- **Per-block audit:** script over all three files — 21/21 runnable signals-call blocks now contain an auth token; 0 missing.
- **Structure:** code-fence counts even and `<CodeGroup>` tags balanced in all three files; Mintlify CLI present.

## Claude session

```
Session: ce82e4a2-5219-4c05-93a8-6e86da843231
Resume:  claude --resume ce82e4a2-5219-4c05-93a8-6e86da843231
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
