### PR TITLE
docs: add PyPI downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MangroveKnowledgeBase
 
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/xUcn4R6zJR)
+[![PyPI Downloads](https://static.pepy.tech/badge/mangrove-kb)](https://pepy.tech/projects/mangrove-kb)
 
 Open-source trading signals, technical indicators, and knowledge base for quantitative finance and algorithmic trading.
 


### PR DESCRIPTION
Adds a pepy.tech total-downloads badge for the `mangrove-kb` package, next to the existing Discord badge.

Badge: ![](https://static.pepy.tech/badge/mangrove-kb) -> links to https://pepy.tech/projects/mangrove-kb

Verified the badge endpoint returns a valid SVG (HTTP 200). Docs-only change, single file.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>