### PR TITLE
fix(signals): coerce registry returns to native bool/Series (no more numpy.bool_ leak)

### DIFF
--- a/mangrove_kb/registry.py
+++ b/mangrove_kb/registry.py
@@ -1,11 +1,44 @@
+import functools
+
+import numpy as np
+import pandas as pd
+
+
+def _to_native(value):
+    """Coerce numpy return types to native Python / pandas containers.
+
+    Signal functions compute their result by comparing numpy/pandas scalars
+    (e.g. ``close.iloc[-1] > sma.iloc[-1]``), which yields a ``numpy.bool_``
+    rather than a native Python ``bool``. ``numpy.bool_`` is not
+    JSON-serializable, so passing a signal result straight into
+    ``json.dumps()`` or a webhook payload raises
+    ``TypeError: Object of type bool_ is not JSON serializable`` and silently
+    halts downstream automation.
+
+    Normalizing here -- at the single point every signal is registered through
+    -- guarantees the public return-type contract (native ``bool`` or a native
+    ``pd.Series``) for every signal, whether it is called directly or via
+    :meth:`RuleRegistry.evaluate`.
+    """
+    if isinstance(value, np.generic):  # numpy scalar (bool_, int64, float64, ...)
+        return value.item()
+    if isinstance(value, np.ndarray):  # array result -> native boolean container
+        return pd.Series(value)
+    return value
+
+
 class RuleRegistry:
     _registry = {}
 
     @classmethod
     def register(cls, name):
         def wrapper(fn):
-            cls._registry[name] = fn
-            return fn
+            @functools.wraps(fn)
+            def coerced(*args, **kwargs):
+                return _to_native(fn(*args, **kwargs))
+
+            cls._registry[name] = coerced
+            return coerced
 
         return wrapper
 

--- a/tests/test_signal_return_types.py
+++ b/tests/test_signal_return_types.py
@@ -1,0 +1,135 @@
+"""
+Return-type contract tests for the signal registry.
+
+Signal functions compute their result by comparing numpy/pandas scalars
+(e.g. ``close.iloc[-1] > sma.iloc[-1]``), which yields a ``numpy.bool_`` rather
+than a native Python ``bool``. ``numpy.bool_`` is not JSON-serializable, so a
+signal result passed straight into ``json.dumps()`` or a webhook payload raises
+``TypeError: Object of type bool_ is not JSON serializable`` and silently halts
+downstream automation.
+
+These tests assert the public contract: every registered signal returns a
+native Python ``bool`` (or a ``pd.Series``) that is JSON-serializable, both when
+called directly and via :meth:`RuleRegistry.evaluate`. Regression guard for the
+numpy primitive-leakage bug.
+
+Usage:
+    pytest tests/test_signal_return_types.py -v
+"""
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import mangrove_kb.signals  # noqa: F401  -- triggers signal registration
+from mangrove_kb.registry import RuleRegistry, _to_native
+
+
+# --------------------------------------------------------------------------- #
+# Realistic OHLCV + alt-data frame                                            #
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def df() -> pd.DataFrame:
+    n = 300
+    idx = pd.date_range("2024-01-01", periods=n, freq="h")
+    # A deterministic but non-trivial price path so signals reach their
+    # comparison return paths (not just the early "insufficient data" guard).
+    drift = np.linspace(100.0, 160.0, n)
+    wiggle = 5.0 * np.sin(np.linspace(0.0, 12.0, n))
+    close = drift + wiggle
+    frame = pd.DataFrame(
+        {
+            "Open": close - 0.5,
+            "High": close + 1.0,
+            "Low": close - 1.0,
+            "Close": close,
+            "Volume": np.linspace(1_000.0, 2_000.0, n),
+        },
+        index=idx,
+    )
+    # On-chain signals consume alternative-data columns time-aligned to bars.
+    for col in (
+        "SmartMoneyNetflow",
+        "SmartMoneyHoldings",
+        "ExchangeNetflow",
+        "WhaleNetInflow",
+        "HolderConcentration",
+    ):
+        frame[col] = wiggle
+    return frame
+
+
+# Signals explicitly called out in the bug report, with the args each needs to
+# reach its comparison return path (is_above_sma has no default window).
+REPORTED = [
+    ("rsi_cross_up", {"window": 14, "threshold": 50.0}),
+    ("rsi_cross_down", {"window": 14, "threshold": 50.0}),
+    ("is_above_sma", {"window": 50}),
+    ("supertrend_long", {"window": 10, "multiplier": 3.0}),
+    ("supertrend_short", {"window": 10, "multiplier": 3.0}),
+]
+
+
+def _native_type(value) -> bool:
+    return isinstance(value, (bool, pd.Series))
+
+
+class TestToNativeHelper:
+    def test_numpy_bool_becomes_native_bool(self):
+        coerced = _to_native(np.bool_(True))
+        assert coerced is True
+        assert type(coerced) is bool
+
+    def test_native_bool_passes_through(self):
+        assert _to_native(True) is True
+        assert _to_native(False) is False
+
+    def test_numpy_array_becomes_series(self):
+        out = _to_native(np.array([True, False]))
+        assert isinstance(out, pd.Series)
+
+    def test_series_passes_through(self):
+        s = pd.Series([True, False])
+        assert _to_native(s) is s
+
+
+class TestReportedSignals:
+    """The five signals named in the bug report must honor the contract."""
+
+    @pytest.mark.parametrize("name,kwargs", REPORTED)
+    def test_returns_native_and_json_serializable(self, name, kwargs, df):
+        value = RuleRegistry._registry[name](df, **kwargs)
+        assert _native_type(value), f"{name} returned {type(value)!r}"
+        assert not isinstance(value, np.generic), f"{name} leaked a numpy scalar"
+        # The exact downstream failure mode from the report.
+        json.dumps(value if not isinstance(value, pd.Series) else value.tolist())
+
+
+class TestEverySignalContract:
+    """No registered signal may leak a numpy primitive on realistic data."""
+
+    def test_no_numpy_leakage_across_registry(self, df):
+        offenders = []
+        for name, fn in RuleRegistry._registry.items():
+            try:
+                value = fn(df)
+            except TypeError:
+                # Signals with required positional args (e.g. window_fast)
+                # can't be called with df alone; their return path is covered
+                # by the parametrized/evaluate tests instead.
+                continue
+            if isinstance(value, np.generic) or not _native_type(value):
+                offenders.append((name, type(value).__name__))
+        assert not offenders, f"signals leaking non-native return types: {offenders}"
+
+
+class TestEvaluatePath:
+    """The same contract must hold through RuleRegistry.evaluate()."""
+
+    def test_evaluate_returns_native_bool(self, df):
+        rule = {"name": "rsi_cross_down", "params": {"window": 14, "threshold": 50.0}}
+        value = RuleRegistry.evaluate(rule, df)
+        assert type(value) is bool
+        json.dumps(value)


### PR DESCRIPTION
Fixes #66

## Problem

Signal functions compute their boolean result by comparing pandas/numpy scalars, e.g. `return closes.iloc[-1] > sma.iloc[-1]` or `return prev_rsi <= threshold and curr_rsi > threshold`. Those comparisons return a **`numpy.bool_`**, not a native Python `bool`. `numpy.bool_` is **not JSON-serializable**, so a signal result passed into `json.dumps()`, a webhook payload, or the `/api/evaluate` response raises `TypeError: Object of type bool is not JSON serializable` and silently halts downstream automation.

A tester's fuzz audit flagged 5 signals (`rsi_cross_up`, `rsi_cross_down`, `is_above_sma`, `supertrend_long`, `supertrend_short`). A full-registry sweep on a real BTC frame found **9** leakers — the fixed-frame fuzzer simply never reached the comparison path on the other 4 (`atr_trailing_stop_long/short`, `strong_body_recent`, `smart_money_holdings_cross`, `whale_accumulation_trigger`). Signals that already wrap their result (`rsi_overbought` → `float(...) > threshold`) were clean.

## Fix

Coerce return types at the **single chokepoint** every signal is registered and invoked through — the `@RuleRegistry.register` decorator — instead of editing ~148 return sites:

```python
def _to_native(value):
    if isinstance(value, np.generic):   # numpy scalar -> native bool/int/float
        return value.item()
    if isinstance(value, np.ndarray):   # array -> native pd.Series container
        return pd.Series(value)
    return value
```

- Covers **all 233 signals** (the 9 leakers + any future signal), whether called directly (the fuzzer's path, downstream `json.dumps()`) or via `RuleRegistry.evaluate()` (the REST `/api/evaluate` + MCP `evaluate_signal` backend).
- `functools.wraps(fn)` preserves `__doc__` / `__module__` / registry identity, so the docstring metadata parser is unaffected (verified: 233 signals still parse).
- This repo's convention is centralized normalization in the registry (param-name back-compat already lives in `RuleRegistry.evaluate()`), so this matches existing design.

No SDK change needed: `MangroveAI-SDK` consumes signal **metadata** and receives evaluation **results as JSON over HTTP** — the server's JSON boundary (now fixed) is the contract; there is no client-side signal computation that independently leaks.

## Verification (real, not mocked)

**Live HTTP route, before/after** — stood up the actual KB server (`uvicorn kb_server.main:app`, SQLite initialized via `init_db.py`), real 120-bar BTC daily OHLCV:

| | `POST /api/evaluate` (`supertrend_short`) |
|---|---|
| no `X-402-Payment` header | `HTTP 402` (gate intact) |
| **pre-fix** (with payment header) | **`HTTP 500` Internal Server Error** — numpy.bool_ not serializable |
| **post-fix** | **`HTTP 200`** `{"signal":"supertrend_short","result":true}` |

All 5 reported signals over the live route post-fix:
```
rsi_cross_down   -> {"signal":"rsi_cross_down","result":false}
rsi_cross_up     -> {"signal":"rsi_cross_up","result":false}
is_above_sma     -> {"signal":"is_above_sma","result":false}
supertrend_long  -> {"signal":"supertrend_long","result":false}
supertrend_short -> {"signal":"supertrend_short","result":true}
```

**Full-registry sweep** on real BTC data (`fn(df)` for all 233 signals, then `json.dumps`):
```
                     non-native returns   json.dumps failures
pre-fix                      9                    9
post-fix                     0                    0
```

**Direct-call repro** (the fuzzer's surface) post-fix: all 5 return `builtins.bool`, `json.dumps` OK.

**Test suite:** `120 passed, 17 skipped` (full `pytest tests/`, server deps installed as CI does), including the new `tests/test_signal_return_types.py` regression guard (helper coercion + reported signals + every-signal contract + `evaluate()` path).

## Risk

Low. Pure return-type normalization at one point; values that were already native `bool`/`pd.Series` pass through untouched. No signal in the repo is declared `-> pd.Series`, so the bool path is the live one.
