### PR TITLE
feat(indicators): uniform compute_frame() accessor (audit report #68 was a false positive)

### DIFF
--- a/mangrove_kb/indicators/indicator_interface.py
+++ b/mangrove_kb/indicators/indicator_interface.py
@@ -58,6 +58,39 @@ class IndicatorInterface:
         return cls._compute(data, params)
 
     @classmethod
+    def compute_frame(cls, data: dict[str, pd.Series], params: dict[str, any]) -> pd.DataFrame:
+        """
+        Compute the indicator and return its outputs as a single DataFrame.
+
+        Convenience wrapper over ``compute()``: assembles the
+        ``{output_name: pd.Series}`` result into one DataFrame whose columns
+        are the indicator's output names and whose index is the shared input
+        index. This is the uniform tabular surface for feature engineering --
+        because every indicator's output Series share the input index, frames
+        from different indicators outer-join cleanly into a feature matrix::
+
+            features = pd.concat(
+                [
+                    RSI.compute_frame(data, {"window": 14}),
+                    MACD.compute_frame(data, {"window_fast": 12, "window_slow": 26, "window_sign": 9}),
+                    OBV.compute_frame(data, {}),
+                ],
+                axis=1,
+            )
+
+        ``compute()`` (returning ``dict[str, pd.Series]``) remains the canonical
+        API; this method does not change it.
+
+        Args:
+            data: {'close': series, 'high': series, ...}
+            params: {'window': 14, ...}
+
+        Returns:
+            pd.DataFrame with one column per output name, indexed by the input index.
+        """
+        return pd.DataFrame(cls.compute(data=data, params=params))
+
+    @classmethod
     def _validate(cls, data: dict, params: dict):
         """Validate inputs."""
         missing_data = [f for f in cls._data if f not in data]

--- a/tests/test_indicator_frame.py
+++ b/tests/test_indicator_frame.py
@@ -1,0 +1,100 @@
+"""Tests for the uniform tabular accessor IndicatorInterface.compute_frame().
+
+Context: a contract-audit bug report claimed 14 indicators "violate the unified
+data pipeline contract" by returning raw dicts instead of pandas tabular
+objects. In fact ALL indicators return ``dict[str, pd.Series]`` -- that is the
+documented contract (the 14 flagged were simply the no-param indicators, the
+only ones the reporter's harness could execute with empty params). These tests
+pin down that uniform contract and exercise ``compute_frame()``, the additive,
+non-breaking tabular surface for feature stacking.
+"""
+import numpy as np
+import pandas as pd
+
+import mangrove_kb.indicators as ind
+from mangrove_kb.indicators.indicator_interface import IndicatorInterface
+
+# The 14 no-param indicators the audit harness flagged.
+NO_PARAM_INDICATORS = [
+    "ADI", "BOP", "CumulativeReturn", "DailyLogReturn", "DailyReturn",
+    "Engulfing", "Harami", "HeikinAshi", "InsideBar", "OBV", "OutsideBar",
+    "ThreeInsideDown", "ThreeInsideUp", "TrueRange",
+]
+
+
+def _ohlcv(n=120):
+    np.random.seed(0)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    close = pd.Series(100 + np.cumsum(np.random.randn(n)), index=idx)
+    high = close + np.abs(np.random.randn(n))
+    low = close - np.abs(np.random.randn(n))
+    open_ = close.shift(1).bfill()
+    volume = pd.Series(np.random.randint(1000, 5000, n).astype(float), index=idx)
+    return idx, {"open": open_, "high": high, "low": low, "close": close, "volume": volume}
+
+
+def test_all_no_param_indicators_share_dict_contract():
+    """compute() returns dict[str, pd.Series] for every flagged indicator."""
+    idx, full = _ohlcv()
+    for name in NO_PARAM_INDICATORS:
+        cls = getattr(ind, name)
+        data = {k: full[k] for k in cls._data}
+        result = cls.compute(data=data, params={})
+        assert isinstance(result, dict), f"{name} did not return a dict"
+        for key, series in result.items():
+            assert isinstance(series, pd.Series), f"{name}[{key}] is not a Series"
+            assert series.index.equals(idx), f"{name}[{key}] lost the input index"
+
+
+def test_compute_frame_returns_dataframe_with_output_columns():
+    """compute_frame() yields a DataFrame whose columns are the output names."""
+    idx, full = _ohlcv()
+    for name in NO_PARAM_INDICATORS:
+        cls = getattr(ind, name)
+        data = {k: full[k] for k in cls._data}
+        frame = cls.compute_frame(data=data, params={})
+        assert isinstance(frame, pd.DataFrame), f"{name}.compute_frame() is not a DataFrame"
+        assert list(frame.columns) == list(cls._outputs), f"{name} columns != _outputs"
+        assert frame.index.equals(idx), f"{name} frame lost the input index"
+
+
+def test_compute_frame_works_for_param_indicators():
+    """The accessor is uniform: param-taking indicators also yield DataFrames."""
+    idx, full = _ohlcv()
+    frame = ind.RSI.compute_frame(data={"close": full["close"]}, params={"window": 14})
+    assert isinstance(frame, pd.DataFrame)
+    assert list(frame.columns) == ["rsi"]
+    macd = ind.MACD.compute_frame(
+        data={"close": full["close"]},
+        params={"window_fast": 12, "window_slow": 26, "window_sign": 9},
+    )
+    assert list(macd.columns) == ["macd", "signal", "histogram"]
+    assert macd.index.equals(idx)
+
+
+def test_frames_outer_join_into_feature_matrix():
+    """The reporter's use case: stack many indicators into one matrix."""
+    idx, full = _ohlcv()
+    features = pd.concat(
+        [
+            ind.RSI.compute_frame({"close": full["close"]}, {"window": 14}),
+            ind.OBV.compute_frame({"close": full["close"], "volume": full["volume"]}, {}),
+            ind.TrueRange.compute_frame(
+                {"high": full["high"], "low": full["low"], "close": full["close"]}, {}
+            ),
+            ind.MACD.compute_frame(
+                {"close": full["close"]},
+                {"window_fast": 12, "window_slow": 26, "window_sign": 9},
+            ),
+        ],
+        axis=1,
+    )
+    assert isinstance(features, pd.DataFrame)
+    # No row explosion: concat aligned on the shared index, one row per bar.
+    assert len(features) == len(idx)
+    assert features.index.equals(idx)
+    assert set(["rsi", "obv", "true_range", "macd", "signal", "histogram"]).issubset(features.columns)
+
+
+def test_compute_frame_available_on_base_interface():
+    assert hasattr(IndicatorInterface, "compute_frame")


### PR DESCRIPTION
Fixes #68

## What the report claimed

Tester **fiftybps** ran a "compliance harness" and flagged 14 indicator classes (ADI, BOP, CumulativeReturn, DailyLogReturn, DailyReturn, Engulfing, Harami, HeikinAshi, InsideBar, OBV, OutsideBar, ThreeInsideDown, ThreeInsideUp, TrueRange) as returning "raw `dict`" instead of pandas tabular objects, "violating the unified data pipeline contract" and blocking feature-engineering workflows with `TypeError` / merge explosions on `pd.concat`.

## What's actually true

**The "14 vs the rest" inconsistency is a false positive.** All 99 indicators uniformly return `dict[str, pd.Series]` — that is the documented contract (`indicator_interface.py:46`). The 14 flagged are *exactly* the no-param indicators (`_params == []`); the harness called `compute(data, {})` with empty params, so only those executed "successfully" while the other 85 raised `missing params` and were excluded. (no-param set == flagged set, exactly 14/14.)

**But the underlying friction is real:** `pd.concat` over raw dicts does raise `TypeError`, and there was no first-class tabular/feature-matrix accessor anywhere in `mangrove_kb`. It just affects all indicators equally, not 14 of them.

## The change (additive, non-breaking)

- `IndicatorInterface.compute_frame(data, params) -> pd.DataFrame` — wraps `compute()` and assembles its `dict[str, pd.Series]` into one DataFrame (columns = output names, index = shared input index). `compute()` is **unchanged**; this is purely additive, so nothing downstream (MangroveAI / SDK / kb_server) breaks.

Changing `compute()` itself to return DataFrame would be a breaking cross-repo change — deliberately avoided.

## Verification (real, end-to-end — not just unit tests)

**Full test suite, CI-style** (`pip install -e ".[dev]"` + `kb_server/requirements.txt`, then `pytest tests/`):
```
114 passed, 17 skipped, 2 warnings in 3.01s
```
Includes 5 new tests in `tests/test_indicator_frame.py` pinning the uniform dict contract and the `compute_frame()` behavior.

**Live demo on REAL data** — BTC daily OHLCV from `data/btc_2022-08-01_2026-02-15_1d.csv` (1294 bars), reproducing the reporter's exact failure then fixing it:
```
=== BEFORE: raw compute() returns dict — does NOT pd.concat ===
OBV.compute(...) type: dict keys: ['obv']
pd.concat([dict, dict]) -> TypeError : cannot concatenate object of type '<class 'dict'>'; only Series and DataFrame objs are val

=== AFTER: compute_frame() — stack a feature matrix across the 14 flagged + param indicators ===
Stacked feature matrix: shape=(1294, 21)  (rows == bars: True)
Columns: ['adi', 'obv', 'true_range', 'cumulative_return', 'daily_return', 'daily_log_return',
          'ha_open', 'ha_high', 'ha_low', 'ha_close', 'engulfing', 'harami', 'inside_bar',
          'outside_bar', 'three_inside_up', 'three_inside_down', 'bop', 'rsi', 'macd', 'signal', 'histogram']
Index preserved (DatetimeIndex, no row explosion): True len==bars: True

Last 3 rows, selected columns:
                                 rsi         macd           obv  true_range  daily_return  engulfing
2026-02-12 00:00:00+00:00  29.331629 -5880.591113  1.279035e+06    3292.520     -1.228486          0
2026-02-13 00:00:00+00:00  35.314335 -5666.011562  1.296934e+06    3602.350      3.895746          0
2026-02-14 00:00:00+00:00  37.454506 -5356.025800  1.312766e+06    1829.875      1.407305          0
```
21-column feature matrix across all 14 "flagged" indicators + RSI/MACD, no row explosion, index preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
