### PR TITLE
docs(signals): category overview missing On-Chain (223→233) + add 'Scope & limitations' for unsupported session/ICT-SMC concepts (Fixes #72)

### DIFF
--- a/docs/guides/creating-a-strategy.mdx
+++ b/docs/guides/creating-a-strategy.mdx
@@ -44,7 +44,17 @@ const headers = {
 
 ## Step 1: Browse available signals
 
-Start by exploring what signals are available. The signals endpoint returns all 223 active signals with their metadata, parameters, and valid ranges.
+Start by exploring what signals are available. The signals endpoint returns every
+active signal with its metadata, parameters, and valid ranges.
+
+<Note>
+Signals are organised into six categories -- Momentum, Trend, Volume, Volatility,
+Patterns, and On-Chain. Before building, skim [Signals Overview → Scope &
+limitations](/signals/overview#scope--limitations) to confirm your idea is
+expressible: the library is OHLCV/indicator-based, so **session / time-of-day
+filters** (London open, etc.) and **ICT / Smart Money Concepts** (Fair Value Gap,
+Order Block, Breaker Block) are **not** currently available as built-in signals.
+</Note>
 
 <CodeGroup>
 ```bash cURL

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -7,7 +7,7 @@ description: "The Mangrove developer ecosystem — REST APIs, SDKs, MCP servers,
 
 Mangrove is a developer ecosystem for building **agent-native** trading, marketplace, and DEX-aggregation applications. Whether you are calling REST APIs, dropping in a Python SDK, or integrating an MCP server, Mangrove gives you the primitives.
 
-The core building blocks are open: 223 trading signals and 99 technical indicators are MIT-licensed in the `mangrove-kb` Python package. The full platform — strategy management, backtesting, AI copilot, DEX aggregation, social trading — is exposed as a unified developer surface across REST, MCP, and SDKs.
+The core building blocks are open: 233 trading signals and 99 technical indicators are MIT-licensed in the `mangrove-kb` Python package. The full platform — strategy management, backtesting, AI copilot, DEX aggregation, social trading — is exposed as a unified developer surface across REST, MCP, and SDKs.
 
 ## What's in the ecosystem
 
@@ -16,7 +16,7 @@ The core building blocks are open: 223 trading signals and 99 technical indicato
     The core trading strategy platform. Build, backtest, and run strategies with an AI copilot. REST API + Python SDK.
   </Card>
   <Card title="MangroveKnowledgeBase" icon="book" href="/sdks/mangrove-kb">
-    Open-source signals and indicators. 223 signals, 99 indicators, 11 trading-education docs. Python package.
+    Open-source signals and indicators. 233 signals, 99 indicators, 11 trading-education docs. Python package.
   </Card>
   <Card title="MangroveMarkets" icon="store" href="/mcp-servers/mangrove-markets">
     Agent marketplace + DEX aggregation. 56 MCP tools across marketplace, DEX, wallet, and CEX domains.

--- a/docs/knowledge-base/signals-quick-reference.mdx
+++ b/docs/knowledge-base/signals-quick-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Signals Quick Reference"
-description: "Alphabetical index of all 223 trading signals with type, category, and description."
+description: "Alphabetical index of all 233 trading signals with type, category, and description."
 ---
 
 # Signals Quick Reference
@@ -84,5 +84,5 @@ Each signal is listed with:
 | `shooting_star_trigger` | TRIGGER | Shooting star candlestick pattern |
 
 <Note>
-This is a representative subset. For the complete list of all 223 signals, use the `GET /api/v1/signals` endpoint or see `knowledge-base/10-signals-quick-reference.md` in the repository.
+This is a representative subset. For the complete list of all 233 signals, see the [Signal Catalog](/signals/catalog), query the `GET /api/v1/signals` endpoint, or see `knowledge-base/10-signals-quick-reference.md` in the repository.
 </Note>

--- a/docs/mcp-servers/mangrove-kb.mdx
+++ b/docs/mcp-servers/mangrove-kb.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MangroveKnowledgeBase MCP Server"
-description: "MCP access to 223 signals, 99 indicators, full-text KB search. Free metadata, x402-gated computation."
+description: "MCP access to 233 signals, 99 indicators, full-text KB search. Free metadata, x402-gated computation."
 ---
 
 # MangroveKnowledgeBase MCP Server

--- a/docs/sdks/mangrove-kb.mdx
+++ b/docs/sdks/mangrove-kb.mdx
@@ -1,11 +1,11 @@
 ---
 title: "mangrove-kb (Python SDK)"
-description: "Open-source Python library: 223 trading signals, 99 technical indicators, and the knowledge-base content."
+description: "Open-source Python library: 233 trading signals, 99 technical indicators, and the knowledge-base content."
 ---
 
 # `mangrove-kb` — Open-source signals and indicators
 
-`mangrove-kb` is the MIT-licensed Python package that backs everything in the Mangrove ecosystem. It contains the canonical implementations of all 223 trading signals and 99 technical indicators, plus the knowledge-base content as embedded markdown.
+`mangrove-kb` is the MIT-licensed Python package that backs everything in the Mangrove ecosystem. It contains the canonical implementations of all 233 trading signals and 99 technical indicators, plus the knowledge-base content as embedded markdown.
 
 If you do not need the hosted platform, you can use this library standalone. Compute indicators, evaluate signals on your own DataFrames, ship it in your own pipeline. No API key, no network call.
 
@@ -19,7 +19,7 @@ Requires Python 3.10+. Tested on 3.10, 3.11, 3.12.
 
 ## What's inside
 
-- **223 trading signals** decorated with `@RuleRegistry.register("name")`. 108 TRIGGER, 115 FILTER. Categories: Momentum (42), Trend (88), Volume (33), Volatility (20), Patterns (40).
+- **233 trading signals** decorated with `@RuleRegistry.register("name")`. 112 TRIGGER, 121 FILTER. Categories: Momentum (42), Trend (88), Volume (33), Volatility (20), Patterns (40), On-Chain (10).
 - **99 technical indicator classes** including 27 candlestick pattern indicators.
 - **11 trading-education documents** covering market foundations through quantitative analysis.
 

--- a/docs/signals/overview.mdx
+++ b/docs/signals/overview.mdx
@@ -161,7 +161,7 @@ curl https://api.mangrovedeveloper.ai/api/v1/signals/ \
 
 ## Signal Categories
 
-Signals are organized into five categories based on the underlying indicator type:
+Signals are organized into six categories based on the underlying indicator type:
 
 | Category | Count | Focus |
 |----------|-------|-------|
@@ -170,8 +170,27 @@ Signals are organized into five categories based on the underlying indicator typ
 | **Volume** | 33 | OBV, CMF, MFI, VWAP, ADI, Force Index, NVI, EOM, VPT, VWMA, ADOSC, KVO |
 | **Volatility** | 20 | Bollinger Bands, ATR, Keltner Channel, Donchian Channel, Ulcer Index, NATR, STARC Bands, ATR Trailing Stop, TTM Squeeze |
 | **Patterns** | 40 | Candlestick patterns (engulfing, hammer, doji, stars) and multi-bar pattern recognition |
+| **On-Chain** | 10 | Exchange netflow, smart-money flows, whale accumulation, holder concentration (consumes alternative-data columns alongside OHLCV) |
+
+## Scope & limitations
+
+The categories above describe what the library **can** express. Signals are
+stateless functions over OHLCV bars (plus, for On-Chain signals, the
+alternative-data columns the caller supplies) -- they carry no clock, calendar,
+or session context, and they do not model market-microstructure constructs. A
+few popular trading frameworks are therefore **not** currently available as
+built-in signals:
+
+| Not currently in the library | Why / closest in-library proxy |
+|------------------------------|--------------------------------|
+| **Session / time-of-day filters** -- London open, New York open, Asian session, etc. | Signals evaluate purely on bars and carry no time-of-day context, so a session window cannot be expressed. No proxy reproduces a calendar window. |
+| **ICT / Smart Money Concepts** -- Fair Value Gap (FVG), Order Block, Breaker Block, liquidity sweeps | Not implemented. For an institutional-reference price use `vwap_above` / `vwap_below`; for directional bias use `adx_strong_trend` or a moving-average filter such as `is_above_sma`; for price-action structure browse the **Patterns** category (engulfing, pin bar, inside/outside bar, ...). These approximate the intent but are not the same constructs. |
+
+Check this section **before** building a strategy so you know what is
+expressible. Adding session-based or ICT/SMC signals is a feature request, not a
+configuration the current library can satisfy.
 
 ## Full Reference
 
 See the [Signal Catalog](/signals/catalog) for the complete reference of all
-223 signals with parameters, descriptions, and usage examples.
+233 signals with parameters, descriptions, and usage examples.


### PR DESCRIPTION
Fixes #72

## Bug (Discord #testing-log, reporter: fiftybps — "Strategy Lifecycle")

A user asked the chatbot to build a **London Open + Fair Value Gap (FVG)** strategy. The assistant correctly reported that session/ICT-SMC concepts aren't available and offered VWAP/ADX proxies. Tester friction was **discoverability**: *"I could not easily determine from the documentation which trading concepts and signal categories were supported before attempting strategy creation."*

## Root cause (docs bug, not a code bug)

The signal library genuinely has **no** session/time-of-day filters and **no** ICT/SMC signals (FVG, Order Block, Breaker Block) — adding them is a **feature/product decision, out of scope here**. The fixable defect is in the docs that were supposed to give a category overview:

- `docs/signals/overview.mdx` → the **"Signal Categories"** table **omitted the entire On-Chain category** and said **223 signals across five categories**. The real catalog is **233 across six** (Momentum 42, Trend 88, Volume 33, Volatility 20, Patterns 40, **On-Chain 10**).
- **No surface stated what is _not_ in the library**, so a user with an ICT/session mental model had no upfront signal those methodologies aren't expressible.

## Changes (docs only)

1. **`signals/overview.mdx`** — add the missing **On-Chain** row; correct **223 → 233**; add a **"Scope & limitations"** section that explicitly lists what's *not* expressible (session filters; ICT/SMC: FVG, Order Block, Breaker Block) with the closest in-library proxies (`vwap_above`/`vwap_below`, `adx_strong_trend`, `is_above_sma`, Patterns category).
2. **`guides/creating-a-strategy.mdx`** — add a pre-build `<Note>` linking the Scope section; de-hardcode the stale "223" (this line describes the MangroveAI deployed `/api/v1/signals` response, whose live total I can't verify from here, so I used count-agnostic wording).
3. **Propagated the verified 223→233 count fix** to the other surfaces that are unambiguously about the **mangrove-kb package / KB catalog**: `sdks/mangrove-kb.mdx` (also adds On-Chain to the category list + 108/115→112/121), `mcp-servers/mangrove-kb.mdx`, `introduction.mdx`, `knowledge-base/signals-quick-reference.mdx`.

## Deliberately NOT changed — flagged for human reconciliation

These pages state "223 / five categories / 108 TRIGGER, 115 FILTER" but are attributed to the **deployed MangroveAI or Oracle API**, whose live counts differ by service (the cloned MangroveAI even resolves a *different* number) and can't be verified from this repo. Blanket-replacing would assert unverified live-service claims:

- `docs/api-reference/signals.mdx`, `docs/api-reference/overview.mdx`
- `docs/guides/signal-architecture.mdx`, `docs/guides/understanding-signals.mdx`, `docs/guides/sieve-end-to-end-workflow.mdx`

A maintainer with live-API access should reconcile these against the actual MangroveAI/Oracle deployed signal set. (Related: a follow-up should also reconcile `mangrove-agent/docs/api-reference.md`, which says "96 active signals … momentum, trend, volume, volatility" — stale + missing Patterns/On-Chain.)

## Verification (real, not mocked)

```
# Authoritative counts proven against the live mangrove_kb package (source of truth):
$ python3 -c "import importlib,mangrove_kb; ... RuleRegistry"
total registered signals: 233
by module/category: {'momentum': 42, 'trend': 88, 'volume': 33, 'volatility': 20, 'patterns': 40, 'onchain': 10}
by type: {'FILTER': 121, 'TRIGGER': 112}
session/ICT/SMC matches: NONE          # confirms the "not supported" claims are accurate

# Docs render + internal links (incl. the new #scope--limitations anchor):
$ cd docs && mintlify broken-links
success no broken links found
```

`mintlify --version` 4.2.391. The OpenAPI warning emitted by `broken-links` is pre-existing (about `openapi3.json`) and unrelated to these changes.

## Scope note

Direct support for session/ICT-SMC signals (the tester's EXPECTED option 1) is a **feature request**, tracked in the issue — not implemented here. This PR addresses EXPECTED option 2 (clearer upfront indication of available categories) + the DOCS gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
