### PR TITLE
docs(signals): category filter + 6-category/233 scope overview (SDK#26 + KB#72)

### DIFF
--- a/docs/api-reference/signals.mdx
+++ b/docs/api-reference/signals.mdx
@@ -46,10 +46,11 @@ headers = {"Authorization": f"Bearer {TOKEN}"}
 **Query Parameters:**
 - `limit` (optional, int, default=50): Maximum number of signals (1-100)
 - `offset` (optional, int, default=0): Pagination offset
+- `category` (optional, str): Filter by category. One of `momentum`, `trend`, `volume`, `volatility`. When provided, `total` reflects the filtered count.
 
 <CodeGroup>
 ```bash cURL
-curl -X GET "https://api.mangrovedeveloper.ai/api/v1/signals?limit=10&offset=0" \
+curl -X GET "https://api.mangrovedeveloper.ai/api/v1/signals?category=momentum&limit=10&offset=0" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -59,7 +60,7 @@ import requests
 response = requests.get(
     "https://api.mangrovedeveloper.ai/api/v1/signals",
     headers=headers,
-    params={"limit": 10, "offset": 0}
+    params={"category": "momentum", "limit": 10, "offset": 0}
 )
 signals = response.json()["signals"]
 ```

--- a/docs/api-reference/signals.mdx
+++ b/docs/api-reference/signals.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Signals API"
-description: "Discover, validate, and evaluate 223 trading signals across momentum, trend, volume, volatility, and patterns categories."
+description: "Discover, validate, and evaluate 233 trading signals across momentum, trend, volume, volatility, patterns, and on-chain categories."
 ---
 
 # Signals API
 
-The Signals API provides endpoints for discovering, validating, and evaluating trading signals. MangroveAI includes 223 active signals (108 TRIGGER, 115 FILTER) organized by category.
+The Signals API provides endpoints for discovering, validating, and evaluating trading signals. MangroveAI includes 233 active signals (112 TRIGGER, 121 FILTER) organized by category.
 
 ## Signal Classification
 

--- a/docs/api-reference/signals.mdx
+++ b/docs/api-reference/signals.mdx
@@ -46,7 +46,7 @@ headers = {"Authorization": f"Bearer {TOKEN}"}
 **Query Parameters:**
 - `limit` (optional, int, default=50): Maximum number of signals (1-100)
 - `offset` (optional, int, default=0): Pagination offset
-- `category` (optional, str): Filter by category. One of `momentum`, `trend`, `volume`, `volatility`. When provided, `total` reflects the filtered count.
+- `category` (optional, str): Filter by category. One of `momentum`, `trend`, `volume`, `volatility`, `patterns`, `onchain`. When provided, `total` reflects the filtered count.
 
 <CodeGroup>
 ```bash cURL

--- a/docs/guides/creating-a-strategy.mdx
+++ b/docs/guides/creating-a-strategy.mdx
@@ -44,7 +44,17 @@ const headers = {
 
 ## Step 1: Browse available signals
 
-Start by exploring what signals are available. The signals endpoint returns all 223 active signals with their metadata, parameters, and valid ranges.
+Start by exploring what signals are available. The signals endpoint returns every
+active signal with its metadata, parameters, and valid ranges.
+
+<Note>
+Signals are organised into six categories -- Momentum, Trend, Volume, Volatility,
+Patterns, and On-Chain. Before building, skim [Signals Overview → Scope &
+limitations](/signals/overview#scope--limitations) to confirm your idea is
+expressible: the library is OHLCV/indicator-based, so **session / time-of-day
+filters** (London open, etc.) and **ICT / Smart Money Concepts** (Fair Value Gap,
+Order Block, Breaker Block) are **not** currently available as built-in signals.
+</Note>
 
 <CodeGroup>
 ```bash cURL

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -7,7 +7,7 @@ description: "The Mangrove developer ecosystem — REST APIs, SDKs, MCP servers,
 
 Mangrove is a developer ecosystem for building **agent-native** trading, marketplace, and DEX-aggregation applications. Whether you are calling REST APIs, dropping in a Python SDK, or integrating an MCP server, Mangrove gives you the primitives.
 
-The core building blocks are open: 223 trading signals and 99 technical indicators are MIT-licensed in the `mangrove-kb` Python package. The full platform — strategy management, backtesting, AI copilot, DEX aggregation, social trading — is exposed as a unified developer surface across REST, MCP, and SDKs.
+The core building blocks are open: 233 trading signals and 99 technical indicators are MIT-licensed in the `mangrove-kb` Python package. The full platform — strategy management, backtesting, AI copilot, DEX aggregation, social trading — is exposed as a unified developer surface across REST, MCP, and SDKs.
 
 ## What's in the ecosystem
 
@@ -16,7 +16,7 @@ The core building blocks are open: 223 trading signals and 99 technical indicato
     The core trading strategy platform. Build, backtest, and run strategies with an AI copilot. REST API + Python SDK.
   </Card>
   <Card title="MangroveKnowledgeBase" icon="book" href="/sdks/mangrove-kb">
-    Open-source signals and indicators. 223 signals, 99 indicators, 11 trading-education docs. Python package.
+    Open-source signals and indicators. 233 signals, 99 indicators, 11 trading-education docs. Python package.
   </Card>
   <Card title="MangroveMarkets" icon="store" href="/mcp-servers/mangrove-markets">
     Agent marketplace + DEX aggregation. 56 MCP tools across marketplace, DEX, wallet, and CEX domains.

--- a/docs/knowledge-base/signals-quick-reference.mdx
+++ b/docs/knowledge-base/signals-quick-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Signals Quick Reference"
-description: "Alphabetical index of all 223 trading signals with type, category, and description."
+description: "Alphabetical index of all 233 trading signals with type, category, and description."
 ---
 
 # Signals Quick Reference
@@ -84,5 +84,5 @@ Each signal is listed with:
 | `shooting_star_trigger` | TRIGGER | Shooting star candlestick pattern |
 
 <Note>
-This is a representative subset. For the complete list of all 223 signals, use the `GET /api/v1/signals` endpoint or see `knowledge-base/10-signals-quick-reference.md` in the repository.
+This is a representative subset. For the complete list of all 233 signals, see the [Signal Catalog](/signals/catalog), query the `GET /api/v1/signals` endpoint, or see `knowledge-base/10-signals-quick-reference.md` in the repository.
 </Note>

--- a/docs/mcp-servers/mangrove-kb.mdx
+++ b/docs/mcp-servers/mangrove-kb.mdx
@@ -1,6 +1,6 @@
 ---
 title: "MangroveKnowledgeBase MCP Server"
-description: "MCP access to 223 signals, 99 indicators, full-text KB search. Free metadata, x402-gated computation."
+description: "MCP access to 233 signals, 99 indicators, full-text KB search. Free metadata, x402-gated computation."
 ---
 
 # MangroveKnowledgeBase MCP Server

--- a/docs/sdks/mangrove-kb.mdx
+++ b/docs/sdks/mangrove-kb.mdx
@@ -1,11 +1,11 @@
 ---
 title: "mangrove-kb (Python SDK)"
-description: "Open-source Python library: 223 trading signals, 99 technical indicators, and the knowledge-base content."
+description: "Open-source Python library: 233 trading signals, 99 technical indicators, and the knowledge-base content."
 ---
 
 # `mangrove-kb` — Open-source signals and indicators
 
-`mangrove-kb` is the MIT-licensed Python package that backs everything in the Mangrove ecosystem. It contains the canonical implementations of all 223 trading signals and 99 technical indicators, plus the knowledge-base content as embedded markdown.
+`mangrove-kb` is the MIT-licensed Python package that backs everything in the Mangrove ecosystem. It contains the canonical implementations of all 233 trading signals and 99 technical indicators, plus the knowledge-base content as embedded markdown.
 
 If you do not need the hosted platform, you can use this library standalone. Compute indicators, evaluate signals on your own DataFrames, ship it in your own pipeline. No API key, no network call.
 
@@ -19,7 +19,7 @@ Requires Python 3.10+. Tested on 3.10, 3.11, 3.12.
 
 ## What's inside
 
-- **223 trading signals** decorated with `@RuleRegistry.register("name")`. 108 TRIGGER, 115 FILTER. Categories: Momentum (42), Trend (88), Volume (33), Volatility (20), Patterns (40).
+- **233 trading signals** decorated with `@RuleRegistry.register("name")`. 112 TRIGGER, 121 FILTER. Categories: Momentum (42), Trend (88), Volume (33), Volatility (20), Patterns (40), On-Chain (10).
 - **99 technical indicator classes** including 27 candlestick pattern indicators.
 - **11 trading-education documents** covering market foundations through quantitative analysis.
 

--- a/docs/sdks/mangroveai.mdx
+++ b/docs/sdks/mangroveai.mdx
@@ -28,14 +28,14 @@ export MANGROVE_API_KEY=prod_your_key_here
 ## Hello world
 
 ```python
-from mangroveai import MangroveAI
+from mangrove_ai import MangroveAI
 
 client = MangroveAI()  # reads MANGROVE_API_KEY from env
 
-# Discover signals
+# Discover signals (category is optional: momentum, trend, volume, volatility)
 signals = client.signals.list(category="momentum", limit=10)
-for s in signals:
-    print(s.name, s.signal_type, s.description)
+for s in signals.items:
+    print(s.name, s.signal_type, s.metadata.description)
 ```
 
 ## Service modules

--- a/docs/sdks/mangroveai.mdx
+++ b/docs/sdks/mangroveai.mdx
@@ -32,7 +32,7 @@ from mangrove_ai import MangroveAI
 
 client = MangroveAI()  # reads MANGROVE_API_KEY from env
 
-# Discover signals (category is optional: momentum, trend, volume, volatility)
+# Discover signals (category is optional: momentum, trend, volume, volatility, patterns, onchain)
 signals = client.signals.list(category="momentum", limit=10)
 for s in signals.items:
     print(s.name, s.signal_type, s.metadata.description)

--- a/docs/signals/overview.mdx
+++ b/docs/signals/overview.mdx
@@ -161,7 +161,7 @@ curl https://api.mangrovedeveloper.ai/api/v1/signals/ \
 
 ## Signal Categories
 
-Signals are organized into five categories based on the underlying indicator type:
+Signals are organized into six categories based on the underlying indicator type:
 
 | Category | Count | Focus |
 |----------|-------|-------|
@@ -170,8 +170,27 @@ Signals are organized into five categories based on the underlying indicator typ
 | **Volume** | 33 | OBV, CMF, MFI, VWAP, ADI, Force Index, NVI, EOM, VPT, VWMA, ADOSC, KVO |
 | **Volatility** | 20 | Bollinger Bands, ATR, Keltner Channel, Donchian Channel, Ulcer Index, NATR, STARC Bands, ATR Trailing Stop, TTM Squeeze |
 | **Patterns** | 40 | Candlestick patterns (engulfing, hammer, doji, stars) and multi-bar pattern recognition |
+| **On-Chain** | 10 | Exchange netflow, smart-money flows, whale accumulation, holder concentration (consumes alternative-data columns alongside OHLCV) |
+
+## Scope & limitations
+
+The categories above describe what the library **can** express. Signals are
+stateless functions over OHLCV bars (plus, for On-Chain signals, the
+alternative-data columns the caller supplies) -- they carry no clock, calendar,
+or session context, and they do not model market-microstructure constructs. A
+few popular trading frameworks are therefore **not** currently available as
+built-in signals:
+
+| Not currently in the library | Why / closest in-library proxy |
+|------------------------------|--------------------------------|
+| **Session / time-of-day filters** -- London open, New York open, Asian session, etc. | Signals evaluate purely on bars and carry no time-of-day context, so a session window cannot be expressed. No proxy reproduces a calendar window. |
+| **ICT / Smart Money Concepts** -- Fair Value Gap (FVG), Order Block, Breaker Block, liquidity sweeps | Not implemented. For an institutional-reference price use `vwap_above` / `vwap_below`; for directional bias use `adx_strong_trend` or a moving-average filter such as `is_above_sma`; for price-action structure browse the **Patterns** category (engulfing, pin bar, inside/outside bar, ...). These approximate the intent but are not the same constructs. |
+
+Check this section **before** building a strategy so you know what is
+expressible. Adding session-based or ICT/SMC signals is a feature request, not a
+configuration the current library can satisfy.
 
 ## Full Reference
 
 See the [Signal Catalog](/signals/catalog) for the complete reference of all
-223 signals with parameters, descriptions, and usage examples.
+233 signals with parameters, descriptions, and usage examples.


### PR DESCRIPTION
Combined signals-docs PR (absorbs #73 to avoid two separate merges of related signals docs).

## From SDK#26 (Cold Start — category filter)
- Document the `category` query param on `GET /signals` — all **6** categories (momentum, trend, volume, volatility, patterns, onchain), matching the merged API (MangroveAI#649).
- Fix the SDK quickstart: `mangroveai`->`mangrove_ai`, `signals`->`signals.items`, `s.description`->`s.metadata.description`.
- Correct stale counts in api-reference/signals.mdx: 223->**233**, 108/115->**112/121** TRIGGER/FILTER, 5->6 categories.

## From KB#72 (ICT signals — scope)
- Add **On-Chain** as the 6th category; fix 223->233 across 6 docs files; TRIGGER/FILTER 108/115->112/121.
- Add a **'Scope & limitations'** section: session/time-of-day filters and ICT/SMC constructs are NOT built-in signals, with closest in-library proxies (vwap_above/below, adx_strong_trend, is_above_sma, Patterns). Documents scope rather than building the feature.

## Verification (independent)
Registry decorator counts: momentum 42 + trend 88 + volume 33 + volatility 20 + patterns 40 + on-chain 10 = **233**; TRIGGER 112 / FILTER 121. On-chain signals do read alt-data columns; all suggested proxy signals exist.

Closes #72.
