### PR TITLE
docs(sdk): fix broken Hello World — EthersSigner missing required supportedChainIds arg (TS2554)

### DIFF
--- a/docs/sdks/mangrove-markets.mdx
+++ b/docs/sdks/mangrove-markets.mdx
@@ -25,7 +25,7 @@ import { MangroveClient, EthersSigner } from "@mangrove-ai/sdk";
 import { Wallet, JsonRpcProvider } from "ethers";
 
 const provider = new JsonRpcProvider("https://mainnet.base.org");
-const signer = new EthersSigner(new Wallet(process.env.PRIVATE_KEY!, provider));
+const signer = new EthersSigner(new Wallet(process.env.PRIVATE_KEY!, provider), [8453]); // supported chain IDs (8453 = Base)
 
 const client = new MangroveClient({
   url: "https://api.mangrovemarkets.com",


### PR DESCRIPTION
## Summary

The `@mangrove-ai/sdk` **Hello World** example in the docs called `EthersSigner` with a single
argument, but the constructor requires two:

```ts
// MangroveMarkets/packages/sdk/src/signer/ethers.ts
constructor(wallet: EthersWallet, supportedChainIds: number[]) { ... }
```

Copy-pasting the documented snippet therefore failed to compile with
`error TS2554: Expected 2 arguments, but got 1` — exactly as reported by tester **sabaali9804** —
blocking the Cold Start onboarding flow.

### Fix
`docs/sdks/mangrove-markets.mdx` — added the required `supportedChainIds` argument:

```diff
-const signer = new EthersSigner(new Wallet(process.env.PRIVATE_KEY!, provider));
+const signer = new EthersSigner(new Wallet(process.env.PRIVATE_KEY!, provider), [8453]); // supported chain IDs (8453 = Base)
```

`[8453]` is the correct value: the example's provider is Base mainnet (`https://mainnet.base.org`)
and the rest of the snippet uses `chainId: 8453`. This matches the canonical form already shown in
the SDK's own README (`new EthersSigner(wallet, [8453]); // Base chain ID`).

### Scope
This was the **only** broken surface. Swept all allowed repos + the SDK source:
- **MangroveMarkets** SDK README, `packages/sdk/examples/*`, `scripts/swap-test.ts` — already correct (2-arg). No change.
- No other allowed repo references `EthersSigner`. Docs-only fix, single line.

## Verification (real compile, not mocked)

Reproduced the bug and proved the fix by running `tsc --strict` against the **actual** Hello World
block extracted from the doc, using type stubs whose `EthersSigner` constructor mirrors the real
signature verified from `MangroveMarkets/packages/sdk/src/signer/ethers.ts`.

```
# BROKEN (published doc, 1 arg):
snippet.ts(5,16): error TS2554: Expected 2 arguments, but got 1.   exit=2

# FIXED (this PR, 2 args):
<no errors>                                                        exit=0
```

The published example reproduces the tester's exact `TS2554`; the fixed example compiles clean.
Only variable changed between the two runs is the `EthersSigner` second argument.

Fixes #75
