### PR TITLE
docs(authentication): document enriched 401 response (hint + docs link)

### DIFF
--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -212,14 +212,21 @@ async function refreshAccessToken(refreshToken) {
 
 ## Error Responses
 
-**401 Unauthorized** -- Token missing, invalid, or expired:
+**401 Unauthorized** -- Token missing, invalid, or expired. The response carries
+a `hint` with the expected header format and a `docs` link so the failure is
+self-explanatory:
 
 ```json
 {
   "error": "Unauthorized",
-  "message": "Invalid or expired token"
+  "message": "Invalid or expired token",
+  "hint": "Include 'Authorization: Bearer <API_KEY>' in the request header",
+  "docs": "/docs/api/authentication"
 }
 ```
+
+A request sent with no credentials returns the same shape with
+`"message": "Missing or invalid authentication token"`.
 
 **403 Forbidden** -- Insufficient permissions:
 


### PR DESCRIPTION
Companion to MangroveAI #650 / MangroveAI#651.

The MangroveAI portal API now returns actionable guidance on auth failures: a
`hint` with the expected `Authorization: Bearer <API_KEY>` header format and a
`docs` link. This updates the public `authentication.mdx` 401 example to match
the real response shape (previously it showed only `error`/`message`).

No content/behavior change here beyond the documented JSON example.

## Verification
Markdown-only change; verified the 401 example now mirrors the live API response
produced and tested in MangroveAI#651 (booted the real Flask route, confirmed the
enriched body). Mintlify build not run locally; CI on this PR is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
