### PR TITLE
docs: backtest concurrency/503 + SDK Hello World + enriched 401 (combined)

### DIFF
--- a/docs/api-reference/backtesting.mdx
+++ b/docs/api-reference/backtesting.mdx
@@ -21,6 +21,10 @@ The Backtesting API runs historical strategy testing with performance metrics an
 
 Runs a synchronous backtest and returns metrics and trade history. Loads market data from CoinAPI for the specified asset and date range.
 
+<Note>
+**One backtest at a time.** The engine processes a single synchronous backtest per worker. If another backtest is already running, this endpoint returns **`503 Service Unavailable`** with a `Retry-After` header instead of blocking until the gateway times out (`504`). Honor `Retry-After` and retry, run requests sequentially, or use the [bulk endpoint](#bulk-backtest) to evaluate many strategies in one request. See the [Running a Backtest guide](/guides/running-a-backtest#concurrency-and-limits).
+</Note>
+
 ### Date Range Modes
 
 | Mode | Parameters | Behavior |

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -212,14 +212,21 @@ async function refreshAccessToken(refreshToken) {
 
 ## Error Responses
 
-**401 Unauthorized** -- Token missing, invalid, or expired:
+**401 Unauthorized** -- Token missing, invalid, or expired. The response carries
+a `hint` with the expected header format and a `docs` link so the failure is
+self-explanatory:
 
 ```json
 {
   "error": "Unauthorized",
-  "message": "Invalid or expired token"
+  "message": "Invalid or expired token",
+  "hint": "Include 'Authorization: Bearer <API_KEY>' in the request header",
+  "docs": "/docs/api/authentication"
 }
 ```
+
+A request sent with no credentials returns the same shape with
+`"message": "Missing or invalid authentication token"`.
 
 **403 Forbidden** -- Insufficient permissions:
 

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -221,7 +221,7 @@ self-explanatory:
   "error": "Unauthorized",
   "message": "Invalid or expired token",
   "hint": "Include 'Authorization: Bearer <API_KEY>' in the request header",
-  "docs": "/docs/api/authentication"
+  "docs": "https://docs.mangrovedeveloper.ai/authentication"
 }
 ```
 

--- a/docs/guides/running-a-backtest.mdx
+++ b/docs/guides/running-a-backtest.mdx
@@ -43,6 +43,10 @@ const headers = {
 
 The backtesting endpoint takes your strategy configuration, a date range, and risk parameters. It runs synchronously and returns results in the response.
 
+<Warning>
+**Backtests run one at a time.** The engine processes a single synchronous backtest per worker at a time. If you fire many backtests **in parallel**, only one runs immediately; the others queue, and a request that waits too long is rejected with a `503` (see [Concurrency and limits](#concurrency-and-limits)). Run backtests **sequentially**, or use the [bulk endpoint](#compare-multiple-strategies-at-once) to test many strategies in a single request.
+</Warning>
+
 This example backtests an ETH strategy using the MACD bullish cross + SMA filter, looking back 12 months of 1-hour data:
 
 <CodeGroup>
@@ -654,6 +658,24 @@ console.log(`Metrics:`, savedResult.metrics);
 The standalone backtesting endpoint (`POST /api/v1/backtesting/backtest`) returns results directly but does not create a persistent `backtest_runs` record. Only backtests initiated through the AI Copilot are persisted and retrievable by ID.
 </Note>
 
+## Concurrency and limits
+
+The synchronous backtest endpoint runs **one backtest at a time per worker**. This keeps results deterministic, but it means you cannot speed things up by firing many single-backtest requests in parallel — they serialize behind the running one.
+
+| Behavior | What happens |
+|----------|--------------|
+| One request at a time | Runs immediately and returns results in the response. |
+| A second request while one is running | Waits briefly for the first to finish. If it completes in time, your request then runs normally. |
+| Too many in parallel / long-running run ahead of you | Your request is rejected with **`503 Service Unavailable`** and a `Retry-After` header instead of hanging until the gateway times out (`504`). |
+
+To run many backtests efficiently:
+
+- **Run sequentially** — wait for each response before sending the next request.
+- **Honor `Retry-After`** — on a `503`, wait the indicated number of seconds and retry (an exponential backoff also works). Official SDKs do this automatically.
+- **Use the [bulk endpoint](#compare-multiple-strategies-at-once)** to evaluate many strategies in a *single* request — market data is fetched once and shared, which is both faster and avoids contention.
+
+A `503` here is transient and means "busy, try again" — it is **not** a problem with your strategy or parameters.
+
 ## Common errors
 
 | Error | Cause | Fix |
@@ -662,6 +684,7 @@ The standalone backtesting endpoint (`POST /api/v1/backtesting/backtest`) return
 | Invalid strategy format | `strategy_json` is malformed or missing entry/exit | Verify the JSON structure has `entry` with 1 TRIGGER + 1 FILTER |
 | Invalid date format | Date not in `YYYY-MM-DD` | Use ISO format: `"2025-01-01"` |
 | Market data unavailable | CoinAPI has no data for the requested range | Try a different date range or asset |
+| `503` engine busy | Another backtest was already running (you sent requests in parallel) | Wait for the `Retry-After` delay and retry, run sequentially, or use the bulk endpoint. See [Concurrency and limits](#concurrency-and-limits). |
 
 ## Next steps
 

--- a/docs/sdks/mangrove-markets.mdx
+++ b/docs/sdks/mangrove-markets.mdx
@@ -25,7 +25,7 @@ import { MangroveClient, EthersSigner } from "@mangrove-ai/sdk";
 import { Wallet, JsonRpcProvider } from "ethers";
 
 const provider = new JsonRpcProvider("https://mainnet.base.org");
-const signer = new EthersSigner(new Wallet(process.env.PRIVATE_KEY!, provider));
+const signer = new EthersSigner(new Wallet(process.env.PRIVATE_KEY!, provider), [8453]); // supported chain IDs (8453 = Base)
 
 const client = new MangroveClient({
   url: "https://api.mangrovemarkets.com",


### PR DESCRIPTION
Combined KB-docs PR — folds in #76 and #77 (disjoint files) so the remaining tester-batch doc fixes land in one merge.

## Backtest concurrency (KB#72-adjacent / MangroveAI#654)
`docs/api-reference/backtesting.mdx` + `docs/guides/running-a-backtest.mdx`: document one-backtest-at-a-time execution, the `503` + `Retry-After` busy response (vs the old opaque `504`), a "Concurrency and limits" section, and a common-errors row. Describes the behavior shipped by MangroveAI#655 / MangroveOracle#281.

## SDK Hello World (was #76)
`docs/sdks/mangrove-markets.mdx`: fix the broken `EthersSigner` example — add the required `supportedChainIds` arg (`new EthersSigner(wallet, [8453])`, 8453 = Base). Matches the canonical SDK signature.

## Auth 401 docs (was #77)
`docs/authentication.mdx`: document the enriched 401 (`hint` + `docs`). The `docs` value uses the **absolute** `https://docs.mangrovedeveloper.ai/authentication` the API actually returns (matching merged MangroveAI#651), not a relative path.

## Verification
- EthersSigner 2-arg signature confirmed against the canonical SDK.
- 401 shape matches the merged middleware (`hint`/`docs`, absolute URL).
- Backtest 503 guidance matches the merged Oracle #281 behavior.

Note: the backtest-503 docs describe behavior that is fully live once MangroveAI#655 deploys.
