### PR TITLE
docs: de-conflate SIEVE & sweep, fix 99-myth + stale payload, add sweep quickstart

### DIFF
--- a/docs/api-reference/experiments.mdx
+++ b/docs/api-reference/experiments.mdx
@@ -1,11 +1,15 @@
 ---
 title: "Experiments (sweep runs)"
-description: "Kick off and consume parameter-sweep experiments. Up to 99 strategies per experiment; results materialize as the sweep completes."
+description: "Kick off and consume parameter-sweep experiments. The engine generates and backtests the candidates; sweep size is bounded by your tier, and results materialize as the sweep completes."
 ---
 
 # Experiments
 
-The experiment API turns a single strategy template plus a parameter grid into a fan-out of up to 99 individual backtests. Use it for hyperparameter sweeps, dataset comparisons, or signal-combination searches.
+The experiment API takes a strategy template plus a **parameter space** and the **engine generates its own candidates** — grid enumeration or random/Monte-Carlo sampling — backtests each, and ranks the results. Use it for hyperparameter sweeps, dataset comparisons, or signal-combination searches.
+
+You do not hand it a list of strategies; you describe the space and the engine searches it. (Screening a *fixed* candidate list is a different workflow — see [SIEVE](/api-reference/sieve) → [bulk backtest](/api-reference/oracle-backtest).)
+
+Sweep size is bounded by your subscription tier's `max_backtests_per_sweep` (enforced at validate), **not** a fixed limit — see [Limits & caps](#limits-and-caps).
 
 All endpoints sit under `/api/v1/oracle/` on the MangroveAI gateway and are forwarded to the Oracle backtest engine with your identity attached. Auth: API key or JWT (same as the rest of `/api/v1/*`).
 
@@ -14,7 +18,8 @@ All endpoints sit under `/api/v1/oracle/` on the MangroveAI gateway and are forw
 | Method | Path | Purpose | Billable |
 |---|---|---|---|
 | `POST` | `/api/v1/oracle/experiments` | Create an experiment (the parameter grid + strategy template) | `oracle_experiment` (1 unit; x402 $0.25) |
-| `POST` | `/api/v1/oracle/experiments/{id}/launch` | Fan out the grid into up to 99 backtests | `oracle_experiment` |
+| `POST` | `/api/v1/oracle/experiments/{id}/validate` | Validate a draft + return `total_runs` (required before launch; enforces the tier per-sweep cap) | free (metadata) |
+| `POST` | `/api/v1/oracle/experiments/{id}/launch` | Fan the validated parameter space out into backtests (async) | `oracle_experiment` |
 | `GET`  | `/api/v1/oracle/results` | Read results as they materialize. Pass `?experiment_id=<id>` to scope to a single sweep, or omit it for the cross-experiment view. | `oracle_results_read` (1 unit; x402 $0.01) |
 | `POST` | `/api/v1/oracle/simulate/run` | Simulate a single strategy run without persisting | `oracle_simulate` (1 unit; x402 $0.10) |
 | `POST` | `/api/v1/oracle/simulate/generate` | LLM-backed strategy candidate generation | `oracle_simulate` |
@@ -42,28 +47,52 @@ Each `POST /experiments` + subsequent `/launch` counts as ONE billable HTTP call
     ```
   </Step>
   <Step title="Create an experiment">
-    Body shape: a strategy template (entry / exit rules) plus a `params_sweep` block that enumerates the grid.
+    Body is the `ExperimentConfig`: a `datasets` array (whole dataset OBJECTS from `/datasets`, not filenames), `entry_signals` / `exit_signals` (each signal needs a `signal_type`; entry needs ≥1 filter), and a `params_sweep` on each signal defining the space (`values: [...]` or `{min, max, step}`). The binary SIEVE `pre_filter` skips configs predicted not to trade.
 
     ```bash
     curl -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/experiments \
       -H "Authorization: Bearer $MANGROVE_API_KEY" \
       -H "Content-Type: application/json" \
       -d '{
-        "name": "rsi-momentum-sweep",
-        "dataset_id": "btc-1h-2024",
-        "template": {
-          "entry": {"trigger": {"name": "rsi_oversold"}, "filter": {"name": "is_above_sma"}},
-          "exit":  {"take_profit_pct": 5, "stop_loss_pct": 2}
+        "name": "BTC 1h MACD momentum sweep",
+        "search_mode": "grid",
+        "kind": "single",
+        "datasets": [ { /* a whole object from GET /datasets */ } ],
+        "entry_signals": {
+          "triggers": [
+            {"name": "macd_bullish_cross", "signal_type": "TRIGGER",
+             "params": {"window_sign": 9},
+             "params_sweep": {"window_fast": {"values": [8, 12, 16]},
+                              "window_slow": {"values": [21, 26, 30]}}}
+          ],
+          "filters": [
+            {"name": "is_above_sma", "signal_type": "FILTER",
+             "params_sweep": {"window": {"values": [50, 100]}}}
+          ],
+          "min_filters": 1, "max_filters": 1
         },
-        "params_sweep": {
-          "entry.trigger.window":    {"min": 7,   "max": 21, "step": 7},
-          "entry.trigger.threshold": {"min": 25,  "max": 35, "step": 5},
-          "entry.filter.window":     {"min": 100, "max": 200, "step": 50}
-        }
+        "exit_signals": {
+          "triggers": [
+            {"name": "macd_bearish_cross", "signal_type": "TRIGGER",
+             "params": {"window_fast": 12, "window_slow": 26, "window_sign": 9}}
+          ],
+          "filters": []
+        },
+        "grid_signals": {"n_param_combos": 24},
+        "execution_config": {"base": {}, "sweep_axes": []},
+        "pre_filter": {"enabled": true, "confidence_threshold": 0.8}
       }'
     ```
 
-    Returns an experiment id and the cardinality of the grid (the engine refuses grids larger than 99 strategies).
+    Returns an `experiment_id` with `status: "draft"`. Sweep size is controlled by `grid_signals.n_param_combos` (grid) or `n_random` (random) — the engine samples up to that many configs from the space.
+  </Step>
+  <Step title="Validate">
+    ```bash
+    curl -X POST https://api.mangrovedeveloper.ai/api/v1/oracle/experiments/<id>/validate \
+      -H "Authorization: Bearer $MANGROVE_API_KEY"
+    ```
+
+    Returns `{ "valid": bool, "total_runs": int, "errors": [...], "warnings": [...] }`. **Required before launch.** This is where the tier per-sweep cap is enforced: if `total_runs` exceeds your tier's `max_backtests_per_sweep`, validate fails with HTTP 403 — shrink the size or upgrade. There is no fixed 99 limit.
   </Step>
   <Step title="Launch">
     ```bash
@@ -71,7 +100,7 @@ Each `POST /experiments` + subsequent `/launch` counts as ONE billable HTTP call
       -H "Authorization: Bearer $MANGROVE_API_KEY"
     ```
 
-    The engine starts evaluating the grid asynchronously.
+    The engine starts evaluating the space asynchronously (in the cloud). A 429 here means you've hit your tier's concurrent-sweep cap — wait for the running sweep to finish, then launch.
   </Step>
   <Step title="Poll for results">
     ```bash
@@ -85,13 +114,20 @@ Each `POST /experiments` + subsequent `/launch` counts as ONE billable HTTP call
 
 ## Costs
 
-Per the developer pricing page, every `POST /experiments` + `/launch` HTTP call counts as 1 unit against your API quota. x402 callers pay $0.25 per kickoff. The engine fans out to up to 99 individual backtests internally; you are not charged per fanout child.
+Per the developer pricing page, every `POST /experiments` + `/launch` HTTP call counts as 1 unit against your API quota. x402 callers pay $0.25 per kickoff. The engine fans out to many individual backtests internally; you are not charged per fanout child.
 
 `GET /results` is billed separately at 1 unit per call ($0.01 x402). Polling efficiently matters — prefer larger paged reads to short-interval polling.
 
+## Limits & caps
+
+Two tier-dependent caps govern sweeps (there is **no** fixed 99-strategy limit — that 99 is [SIEVE](/api-reference/sieve)'s per-call cap, a different feature):
+
+- **Per-sweep size** — `max_backtests_per_sweep` for your tier (e.g. Pro 5,000 / Startup 20,000 / Enterprise 100,000). Enforced at **validate** (HTTP 403 if `total_runs` exceeds it). Control your size with `grid_signals.n_param_combos` or `n_random`.
+- **Concurrent sweeps** — `concurrent_sweep_cap` (often 1 on lower tiers). Enforced at **launch** (HTTP 429). Wait for the in-flight sweep to finish, then launch the next.
+
 ## Related
 
-- [SIEVE classifier](/api-reference/sieve) — score up to 99 strategy candidates before sending them through a full sweep. Use SIEVE to prune the grid first; pay for backtest compute only on the candidates that survive.
+- [SIEVE classifier](/api-reference/sieve) — a **separate** workflow: cheaply score a *fixed* candidate shortlist (≤99 per call) and hand the survivors to a [bulk backtest](/api-reference/oracle-backtest). It does NOT gate or feed a sweep. (A sweep's *own* built-in binary SIEVE `pre_filter` is a different mechanism — it skips dead configs during the search.)
 - [Backtesting API](/api-reference/backtesting) — single-strategy synchronous and async backtests, useful when you already know the parameters you want to test.
 - [Deployed strategies](/api-reference/oracle-deployed) — live execution state of curated paper-trading strategies (the surface formerly implied by "leaderboard").
 - [`mangroveai` Python SDK](/sdks/mangroveai) — `client.oracle.create_experiment(...)`, `client.oracle.simulate_run(...)`, `client.oracle.list_results(...)`, and the full deployed/leaderboard surface are typed wrappers as of SDK v1.4.0.

--- a/docs/api-reference/oracle-backtest.mdx
+++ b/docs/api-reference/oracle-backtest.mdx
@@ -376,8 +376,8 @@ See [Pricing](/api-reference/overview#pricing) for tier monthly caps. Source of 
 
 ## Related
 
-- [Experiments](/api-reference/experiments) — multi-strategy parameter sweeps with managed lifecycle (`create` → `validate` → `launch` → poll results). Use experiments when the parameter grid is larger than a single bulk request can hold.
+- [Experiments](/api-reference/experiments) — parameter-space **sweeps** where the engine generates its own candidates (`create` → `validate` → `launch` → poll). Different from bulk: bulk backtests a list *you* supply; a sweep searches a space. Sweep size is tier-bounded, not capped at the bulk 99.
 - [SIEVE classifier](/api-reference/sieve) — score 1-99 candidate strategies in milliseconds before paying for backtests.
 - [Deployed strategies](/api-reference/oracle-deployed) — live execution state for curated paper-trading strategies, not for ad-hoc backtests.
-- [End-to-end workflow with SIEVE](/guides/sieve-end-to-end-workflow) — end-to-end demo: list-signals, SIEVE, sweep via experiments, adopt.
+- [End-to-end workflow with SIEVE](/guides/sieve-end-to-end-workflow) — end-to-end demo: list-signals, SIEVE screen, bulk-backtest the survivors, adopt.
 - [`mangroveai` Python SDK](/sdks/mangroveai) — typed wrappers for all `/backtest*` endpoints land in SDK v1.4.0; the historical risk-mgmt gap is now closed at the gateway (MangroveAI v3.10.12). The `/data/query` Python example below still uses raw HTTP pending SDK#16 / SDK#17.

--- a/docs/guides/oracle-sweep-quickstart.mdx
+++ b/docs/guides/oracle-sweep-quickstart.mdx
@@ -1,0 +1,83 @@
+---
+title: "Quickstart: run your first sweep on the Oracle engine"
+description: "From a fresh developer account to a ranked parameter sweep — set a key, describe a parameter space, and let the engine search it in the cloud."
+---
+
+# Quickstart: your first sweep
+
+A **sweep** searches a *parameter space*: you describe a strategy template plus the ranges to explore, and the Oracle engine **generates its own candidates**, backtests each in the cloud, and ranks the results. You don't hand it a list of strategies — you describe the space and it does the search.
+
+<Note>
+A sweep is **not** "screen a list, then run the survivors." Generating a fixed candidate list and screening it cheaply is a *different* workflow — [SIEVE](/api-reference/sieve) → [bulk backtest](/api-reference/oracle-backtest). This quickstart is the parameter **search**.
+</Note>
+
+## 1. Get a developer account + API key
+
+1. Create a developer account and grab an API key (`prod_…`) — see [Authentication](/authentication).
+2. Sweeps require an Oracle quota on your tier. Individual **Pro** ($29.99/mo) unlocks real sweep usage (20 launches/mo, up to 5,000 backtests per sweep). The free/beginner tiers get only a small teaser. Team (org) tiers raise the per-sweep size and concurrency.
+
+```bash
+export MANGROVE_API_KEY="prod_..."
+```
+
+## 2. Two ways to drive it
+
+### A) The `/sweep` skill (recommended)
+
+Clone the agent template and let the `/sweep` skill drive the whole lifecycle for you:
+
+```bash
+git clone https://github.com/MangroveTechnologies/mangrove-agent
+cd mangrove-agent   # add your MANGROVE_API_KEY to the server config
+```
+
+Then just describe the search in natural language:
+
+> "Sweep MACD fast 8→16 and slow 21→30 on BTC 1h, momentum signals, and rank them."
+
+The skill orients on the catalog, builds the config (with the binary SIEVE pre-filter on by default), validates it, reports the run count + cost, and — after you confirm — launches and ranks the results.
+
+### B) The HTML config builder
+
+The `/sweep` skill ships a lightweight `sweep-config.html` builder. The agent embeds the live signal + dataset catalog into it; you pick a dataset, choose signals (filterable by category — momentum / trend / volume / volatility / patterns), set the parameter ranges, and **Download config.json**. Hand that file back to the agent and it validates + launches (after confirming with you). The page makes no API calls itself — it only builds the JSON.
+
+## 3. The raw API lifecycle (what the skill does under the hood)
+
+```
+create ──▶ validate ──▶ launch ──▶ poll ──▶ results
+ draft      total_runs   async      status    ranked
+```
+
+1. **Orient** (free): `GET /api/v1/oracle/datasets`, `GET /api/v1/oracle/signals` (each signal carries a `category`), `GET /api/v1/oracle/exec-config/defaults`.
+2. **Create**: `POST /api/v1/oracle/experiments` with the `ExperimentConfig` — `datasets` holds whole dataset OBJECTS, each signal has a `signal_type`, entry needs ≥1 filter, and `params_sweep` defines the space. See [Experiments](/api-reference/experiments) for the full body.
+3. **Validate**: `POST /api/v1/oracle/experiments/{id}/validate` → `{ valid, total_runs, errors }`. **Required before launch.** Your tier's `max_backtests_per_sweep` is enforced here (403 if the size exceeds it) — there is **no fixed 99 limit** (that 99 is SIEVE's per-call cap, a different feature).
+4. **Launch**: `POST /api/v1/oracle/experiments/{id}/launch` (async, runs as a cloud job). A 429 means you've hit your tier's concurrent-sweep cap — wait, then launch.
+5. **Read**: `GET /api/v1/oracle/results?experiment_id=<id>` — paginated, ranked metrics per strategy.
+
+## 4. Control the sweep size
+
+You decide how many backtests run:
+
+- **grid** (`search_mode: "grid"`): `grid_signals.n_param_combos` caps how many combinations are drawn from the space (it does **not** run the full cross-product by default).
+- **random** (`search_mode: "random"`): `n_random` = number of Monte-Carlo samples.
+
+Pick the size deliberately — it's bounded above by your tier's `max_backtests_per_sweep`.
+
+## 5. Read the results
+
+Each result row carries ranked metrics. Two gotchas:
+
+- `irr_annualized`, `total_return`, `win_rate`, `max_drawdown` are **percents** (`35` = 35%), not fractions.
+- Sort by `sortino_ratio` (downside-aware), tie-break on `sharpe_ratio`. A row with `total_trades < 10` is *insufficient trades*, not a winner.
+- `benchmark_asset_return` / `benchmark_btc_return` let you check whether the top config actually beat buy-and-hold.
+
+Treat the top sweep result as a **candidate, not a verdict**: confirm it with a full single-strategy [backtest](/api-reference/oracle-backtest) on a properly sized window before paper/live.
+
+## Costs
+
+`create` + `launch` are 1 billable Oracle unit each (the fan-out children are not billed individually); each `GET /results` is 1 unit — page large, don't tight-poll.
+
+## Related
+- [Experiments API reference](/api-reference/experiments) — the full `ExperimentConfig` shape + caps.
+- [SIEVE classifier](/api-reference/sieve) and [screening a shortlist](/guides/using-sieve-prefilter) — the *other* workflow (screen a fixed list, then bulk-backtest).
+- [Oracle backtest](/api-reference/oracle-backtest) — single + bulk backtests for confirming a winner.

--- a/docs/guides/sieve-end-to-end-workflow.mdx
+++ b/docs/guides/sieve-end-to-end-workflow.mdx
@@ -1,11 +1,15 @@
 ---
 title: "End-to-end workflow with Mangrove SIEVE"
-description: "Combine SIEVE pre-filtering, bulk backtesting, and the strategy lifecycle to go from a signal mix to a running strategy in four phases."
+description: "Screen a fixed candidate shortlist with SIEVE, bulk-backtest the survivors, and register the winner — going from a signal mix to a running strategy in four phases."
 ---
 
 # End-to-end workflow with Mangrove SIEVE
 
-This guide walks the full chain from "I have a signal mix I want to explore" to "I have a strategy registered and running on MangroveAI."
+This guide walks the **shortlist-screening** chain: you build a fixed set of candidate strategies, cheaply screen them with SIEVE, bulk-backtest the survivors, and register the winner.
+
+<Note>
+**This is not a parameter sweep.** Here *you* generate a fixed candidate list and SIEVE screens it. If instead you want the **engine** to generate and search a parameter space for you, that's the [Experiments / sweep API](/api-reference/experiments) — a different tool. Screening a list ≠ searching a space.
+</Note>
 
 Four phases:
 
@@ -19,7 +23,7 @@ Four phases:
 Each phase corresponds to one or two SDK calls. The Python tabs use the `mangroveai` SDK 1.4.0+; the cURL tabs hit the underlying `/api/v1/*` surface directly.
 
 <Note>
-**Tier note.** Beginner accounts cap at 10 SIEVE calls / month, 2 sweep launches / month, and quotas on backtests. This walkthrough fits inside those caps if you keep candidates ≤99 (one SIEVE call) and one experiment of ≤99 backtests. The Pro tier unlocks larger sweeps if you want to widen the candidate pool.
+**Tier note.** This walkthrough uses two endpoints, each capped at **99 items per call**: `sieve_score` (the screen) and `backtest/bulk` (the backtest). Keep your candidate list ≤99 and it's one call of each. (That 99 is a per-call batch size for these two endpoints — it is unrelated to sweep-experiment sizing, which is governed by your tier's `max_backtests_per_sweep`.)
 </Note>
 
 ## Prerequisites
@@ -71,7 +75,7 @@ For deeper inspection of any signal's parameters see [Signals reference](/signal
 
 ## Phase 2 — Generate candidates + SIEVE filter
 
-Build N parameter combinations of the chosen signal mix, then score them in one round-trip through [SIEVE](/api-reference/sieve). The 4-class head tells you which combinations are most likely to win.
+Build N parameter combinations of the chosen signal mix (≤99), then score them in one round-trip through [SIEVE](/api-reference/sieve). Use the **binary head** to drop candidates that won't fire (`p_no_trades` high), then the **4-class head** to rank the survivors by `P(winning)`. Treat both as a cheap **screen that orders what's worth backtesting — not a verdict.** Only the backtest in Phase 3 decides whether a strategy is actually good.
 
 ```python Python
 import itertools
@@ -232,7 +236,7 @@ print(f"  trades={best['trade_count']}")
 
 If your winner has `trade_count == 0`, the surviving candidates didn't fire entries in this window — widen the parameter ranges in Phase 2 and re-rank. SIEVE's `p_no_trades` is the cheaper place to catch that.
 
-For the full request/response shape see [Oracle backtest reference](/api-reference/oracle-backtest). For larger sweeps with a managed lifecycle, see [Experiments](/api-reference/experiments).
+For the full request/response shape see [Oracle backtest reference](/api-reference/oracle-backtest). If instead of backtesting a fixed shortlist you want the engine to **search a parameter space** for you, that's the [Experiments / sweep API](/api-reference/experiments) — a different workflow, not a scaled-up version of this one.
 
 ## Phase 4 — Register the winner + run it
 
@@ -297,7 +301,7 @@ print(json.dumps(decision_log, indent=2))
 
 - [Filtering Strategies with Mangrove SIEVE](/guides/using-sieve-prefilter) — deeper dive on the SIEVE prefilter step in isolation
 - [Oracle backtest reference](/api-reference/oracle-backtest) — full request/response shapes for the single-strategy backtest endpoints + data corpus query
-- [Experiments](/api-reference/experiments) — the sweep lifecycle used in Phase 3
+- [Experiments](/api-reference/experiments) — the parameter-search sweep API (a separate workflow; Phase 3 here uses **bulk-backtest**, not a sweep)
 - [SIEVE API reference](/api-reference/sieve) — endpoint details for `sieve/score`
 - [Creating a strategy](/guides/creating-a-strategy) — strategy-object shape, status transitions, and the wallet/allocation gating for `live`
 - [`mangroveai` Python SDK](/sdks/mangroveai)

--- a/docs/guides/using-sieve-prefilter.mdx
+++ b/docs/guides/using-sieve-prefilter.mdx
@@ -12,7 +12,13 @@ SIEVE is a learned classifier trained on millions of historical Mangrove sweep r
 - **Binary** — `P(no_trades)` vs `P(trades)`. Filter out strategies that won't fire at all.
 - **4-class** — `losing` / `no_trades` / `wash` / `winning`. Rank what's left by expected outcome.
 
-This guide walks through using both heads to compress a 1,000-strategy search down to the ~50 worth a real backtest.
+Both heads are a **screen, not a verdict** — they cheaply order what's worth backtesting; only a real backtest decides whether a strategy is good.
+
+This guide walks through using both heads to compress a large fixed candidate list down to the ~50 worth a real backtest, then handing those to a [backtest](/api-reference/oracle-backtest).
+
+<Note>
+This is the **shortlist-screening** use of SIEVE (you supply the candidates). It is distinct from a parameter **sweep**, where the [Experiments engine](/api-reference/experiments) generates its own candidates and applies the *binary* head as an inline pre-filter. Don't feed a screened list into a sweep.
+</Note>
 
 ## Prerequisites
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -141,6 +141,7 @@
         "guides/creating-a-strategy",
         "guides/running-a-backtest",
         "guides/backtesting-guide",
+        "guides/oracle-sweep-quickstart",
         "guides/using-sieve-prefilter",
         "guides/sieve-end-to-end-workflow",
         "guides/using-the-ai-copilot",


### PR DESCRIPTION
## Summary
Corrects the SIEVE/sweep conflation across the docs and adds the missing Oracle-sweep quickstart.

**Root cause (verified in Oracle engine code):** the `99` cap is **SIEVE-only** (`MAX_ITEMS_PER_REQUEST`); sweep size is the tier's `max_backtests_per_sweep` (Pro 5,000), enforced at `validate`; the in-sweep SIEVE hook is the **binary** head; the **4-class** head is post-hoc/replay.

## Changes
- **`api-reference/experiments.mdx`** — replace the stale `dataset_id`/`template` payload with the real `ExperimentConfig`; add a **Validate** step + **Limits & caps** section; remove the 99-myth; fix the SIEVE 'Related' framing.
- **`guides/sieve-end-to-end-workflow.mdx`** — reframed as the **shortlist-screen** workflow (not a sweep); binary gate + 4-class rank labeled 'screen, not a verdict'; fix sweep mislabels.
- **`api-reference/oracle-backtest.mdx`** — distinguish bulk (supply a list) from sweep (engine searches a space).
- **`guides/using-sieve-prefilter.mdx`** — add screen-not-verdict + not-a-sweep note.
- **NEW `guides/oracle-sweep-quickstart.mdx`** — the missing 'run your first sweep' onboarding guide.
- **`mint.json`** — register the new guide (valid JSON verified).

## Verification
Concepts validated against a live prod sweep (numbers in the paired mangrove-agent PR). Mintlify nav resolves the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)