### PR TITLE
fix(kb): quickstart sample_ohlcv + native-bool contract + compute_frame accessor (combined)

### DIFF
--- a/PKG_README.md
+++ b/PKG_README.md
@@ -21,9 +21,9 @@ All indicators use a stateless classmethod API. Pass data and params, get result
 
 ```python
 from mangrove_kb.indicators import RSI, MACD, BollingerBands, EMA
-import pandas as pd
+from mangrove_kb import sample_ohlcv
 
-df = pd.read_csv("your_ohlcv_data.csv")
+df = sample_ohlcv()  # self-contained sample data; or pd.read_csv("your_ohlcv_data.csv")
 
 # RSI
 result = RSI.compute(data={"close": df["Close"]}, params={"window": 14})
@@ -81,9 +81,11 @@ if macd_bullish_cross(df, window_fast=12, window_slow=26, window_sign=9):
 Evaluate signals by name -- useful for strategy engines and configuration-driven systems:
 
 ```python
-from mangrove_kb.registry import RuleRegistry
+from mangrove_kb import RuleRegistry, sample_ohlcv
 # Import signal modules to register them
 from mangrove_kb.signals import momentum, trend, volume, volatility, patterns
+
+df = sample_ohlcv()  # self-contained sample data; or bring your own DataFrame
 
 # Evaluate by name
 rule = {"name": "rsi_oversold", "params": {"window": 14, "threshold": 30.0}}

--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ if hammer_trigger(df):
 Evaluate signals by name -- useful for strategy engines:
 
 ```python
-from mangrove_kb.registry import RuleRegistry
+from mangrove_kb import RuleRegistry, sample_ohlcv
 from mangrove_kb.signals import momentum, trend, volume, volatility, patterns
+
+df = sample_ohlcv()  # self-contained sample data; or bring your own DataFrame
 
 rule = {"name": "rsi_oversold", "params": {"window": 14, "threshold": 30.0}}
 is_oversold = RuleRegistry.evaluate(rule, df)

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -67,11 +67,12 @@ pip install mangrove-kb
 ```
 
 ```python
-import pandas as pd
-from mangrove_kb import RuleRegistry
+from mangrove_kb import RuleRegistry, sample_ohlcv
 from mangrove_kb.indicators import RSI
 
-df = pd.read_csv("ohlcv.csv")  # columns: Open, High, Low, Close, Volume
+# Self-contained sample data — no file or download needed.
+# Bring your own with: df = pd.read_csv("your_ohlcv.csv")  # columns: Open, High, Low, Close, Volume
+df = sample_ohlcv()
 
 # Compute an indicator
 rsi = RSI.compute({"close": df["Close"]}, {"window": 14})["rsi"]

--- a/docs/sdks/mangrove-kb.mdx
+++ b/docs/sdks/mangrove-kb.mdx
@@ -28,10 +28,11 @@ Browse the full signal list in the [Signal Catalog](/signals/catalog) and indica
 ## Hello world — evaluate a signal
 
 ```python
-import pandas as pd
-from mangrove_kb import RuleRegistry
+from mangrove_kb import RuleRegistry, sample_ohlcv
 
-df = pd.read_csv("ohlcv.csv")  # columns: Open, High, Low, Close, Volume
+# Self-contained sample data — no file or download needed.
+# Bring your own with: df = pd.read_csv("your_ohlcv.csv")  # columns: Open, High, Low, Close, Volume
+df = sample_ohlcv()
 
 fired = RuleRegistry.evaluate(
     {"name": "rsi_oversold", "params": {"window": 14, "threshold": 30}},

--- a/mangrove_kb/__init__.py
+++ b/mangrove_kb/__init__.py
@@ -25,5 +25,6 @@ except PackageNotFoundError:
     __version__ = "0.0.0.dev0"
 
 from mangrove_kb.registry import RuleRegistry
+from mangrove_kb.sample_data import sample_ohlcv
 from mangrove_kb import indicators
 from mangrove_kb import signals

--- a/mangrove_kb/indicators/indicator_interface.py
+++ b/mangrove_kb/indicators/indicator_interface.py
@@ -58,6 +58,39 @@ class IndicatorInterface:
         return cls._compute(data, params)
 
     @classmethod
+    def compute_frame(cls, data: dict[str, pd.Series], params: dict[str, any]) -> pd.DataFrame:
+        """
+        Compute the indicator and return its outputs as a single DataFrame.
+
+        Convenience wrapper over ``compute()``: assembles the
+        ``{output_name: pd.Series}`` result into one DataFrame whose columns
+        are the indicator's output names and whose index is the shared input
+        index. This is the uniform tabular surface for feature engineering --
+        because every indicator's output Series share the input index, frames
+        from different indicators outer-join cleanly into a feature matrix::
+
+            features = pd.concat(
+                [
+                    RSI.compute_frame(data, {"window": 14}),
+                    MACD.compute_frame(data, {"window_fast": 12, "window_slow": 26, "window_sign": 9}),
+                    OBV.compute_frame(data, {}),
+                ],
+                axis=1,
+            )
+
+        ``compute()`` (returning ``dict[str, pd.Series]``) remains the canonical
+        API; this method does not change it.
+
+        Args:
+            data: {'close': series, 'high': series, ...}
+            params: {'window': 14, ...}
+
+        Returns:
+            pd.DataFrame with one column per output name, indexed by the input index.
+        """
+        return pd.DataFrame(cls.compute(data=data, params=params))
+
+    @classmethod
     def _validate(cls, data: dict, params: dict):
         """Validate inputs."""
         missing_data = [f for f in cls._data if f not in data]

--- a/mangrove_kb/registry.py
+++ b/mangrove_kb/registry.py
@@ -1,11 +1,44 @@
+import functools
+
+import numpy as np
+import pandas as pd
+
+
+def _to_native(value):
+    """Coerce numpy return types to native Python / pandas containers.
+
+    Signal functions compute their result by comparing numpy/pandas scalars
+    (e.g. ``close.iloc[-1] > sma.iloc[-1]``), which yields a ``numpy.bool_``
+    rather than a native Python ``bool``. ``numpy.bool_`` is not
+    JSON-serializable, so passing a signal result straight into
+    ``json.dumps()`` or a webhook payload raises
+    ``TypeError: Object of type bool_ is not JSON serializable`` and silently
+    halts downstream automation.
+
+    Normalizing here -- at the single point every signal is registered through
+    -- guarantees the public return-type contract (native ``bool`` or a native
+    ``pd.Series``) for every signal, whether it is called directly or via
+    :meth:`RuleRegistry.evaluate`.
+    """
+    if isinstance(value, np.generic):  # numpy scalar (bool_, int64, float64, ...)
+        return value.item()
+    if isinstance(value, np.ndarray):  # array result -> native boolean container
+        return pd.Series(value)
+    return value
+
+
 class RuleRegistry:
     _registry = {}
 
     @classmethod
     def register(cls, name):
         def wrapper(fn):
-            cls._registry[name] = fn
-            return fn
+            @functools.wraps(fn)
+            def coerced(*args, **kwargs):
+                return _to_native(fn(*args, **kwargs))
+
+            cls._registry[name] = coerced
+            return coerced
 
         return wrapper
 

--- a/mangrove_kb/sample_data.py
+++ b/mangrove_kb/sample_data.py
@@ -22,7 +22,7 @@ def sample_ohlcv(
     trend: str = "down",
     start_price: float = 100.0,
     volatility: float = 0.02,
-    seed: int = 0,
+    seed: int = 10,
 ) -> pd.DataFrame:
     """Generate a deterministic synthetic OHLCV DataFrame for examples and tests.
 
@@ -39,7 +39,8 @@ def sample_ohlcv(
         volatility (float): Per-bar standard deviation of log-returns. Range: >=0.
             Default: 0.02.
         seed (int): Seed for the random generator so the data is reproducible.
-            Default: 0.
+            Default: 10 (a downtrend that makes the rsi_oversold quickstart
+            example actually fire).
 
     Returns:
         pd.DataFrame: ``rows`` rows indexed by a daily ``DatetimeIndex`` named

--- a/mangrove_kb/sample_data.py
+++ b/mangrove_kb/sample_data.py
@@ -1,0 +1,97 @@
+"""Sample OHLCV data generator.
+
+Provides a deterministic, dependency-free helper so every quickstart snippet
+runs out of the box -- no CSV file, no download, no network call. The generated
+DataFrame uses the same **capitalized** ``Open/High/Low/Close/Volume`` columns
+that the signals and indicators in this package expect.
+
+Example:
+    >>> from mangrove_kb import sample_ohlcv, RuleRegistry
+    >>> df = sample_ohlcv()
+    >>> RuleRegistry.evaluate({"name": "rsi_oversold", "params": {"window": 14}}, df)
+    True
+"""
+import numpy as np
+import pandas as pd
+
+__all__ = ["sample_ohlcv"]
+
+
+def sample_ohlcv(
+    rows: int = 200,
+    trend: str = "down",
+    start_price: float = 100.0,
+    volatility: float = 0.02,
+    seed: int = 0,
+) -> pd.DataFrame:
+    """Generate a deterministic synthetic OHLCV DataFrame for examples and tests.
+
+    The output is a geometric random walk with a mild directional drift, shaped
+    into realistic candles. It is fully self-contained -- no file, no download,
+    no network -- so quickstart snippets run immediately on a clean install.
+
+    Args:
+        rows (int): Number of bars (rows) to generate. Range: 2-100000. Default: 200.
+        trend (str): Directional drift, one of "down", "up", or "flat". The
+            default "down" lets oversold-style signals (e.g. ``rsi_oversold``)
+            actually fire, matching the common first example. Default: "down".
+        start_price (float): Close price of the first bar. Range: >0. Default: 100.0.
+        volatility (float): Per-bar standard deviation of log-returns. Range: >=0.
+            Default: 0.02.
+        seed (int): Seed for the random generator so the data is reproducible.
+            Default: 0.
+
+    Returns:
+        pd.DataFrame: ``rows`` rows indexed by a daily ``DatetimeIndex`` named
+        ``Timestamp``, with float columns ``Open``, ``High``, ``Low``,
+        ``Close``, ``Volume`` -- the capitalized OHLCV schema the signals and
+        indicators expect.
+
+    Raises:
+        ValueError: If ``rows`` < 2, ``start_price`` <= 0, ``volatility`` < 0, or
+            ``trend`` is not one of "down", "up", "flat".
+    """
+    if rows < 2:
+        raise ValueError(f"rows must be >= 2, got {rows}")
+    if start_price <= 0:
+        raise ValueError(f"start_price must be > 0, got {start_price}")
+    if volatility < 0:
+        raise ValueError(f"volatility must be >= 0, got {volatility}")
+
+    drift_by_trend = {"down": -0.004, "up": 0.004, "flat": 0.0}
+    if trend not in drift_by_trend:
+        raise ValueError(f"trend must be one of {sorted(drift_by_trend)}, got {trend!r}")
+    drift = drift_by_trend[trend]
+
+    rng = np.random.default_rng(seed)
+
+    # Close as a geometric random walk: log-returns are drift + gaussian noise.
+    log_returns = drift + volatility * rng.standard_normal(rows)
+    close = start_price * np.exp(np.cumsum(log_returns))
+
+    # Open at the prior bar's close (first bar opens at start_price).
+    open_ = np.empty(rows)
+    open_[0] = start_price
+    open_[1:] = close[:-1]
+
+    # High/Low straddle the open-close body with a positive intrabar wick.
+    body_high = np.maximum(open_, close)
+    body_low = np.minimum(open_, close)
+    wick = volatility * np.abs(rng.standard_normal(rows))
+    high = body_high * (1.0 + wick)
+    low = body_low * (1.0 - wick)
+
+    # Volume: positive, lognormally distributed around a realistic base.
+    volume = 1_000.0 * np.exp(0.3 * rng.standard_normal(rows))
+
+    index = pd.date_range("2024-01-01", periods=rows, freq="D", name="Timestamp")
+    return pd.DataFrame(
+        {
+            "Open": open_,
+            "High": high,
+            "Low": low,
+            "Close": close,
+            "Volume": volume,
+        },
+        index=index,
+    )

--- a/tests/test_indicator_frame.py
+++ b/tests/test_indicator_frame.py
@@ -1,0 +1,100 @@
+"""Tests for the uniform tabular accessor IndicatorInterface.compute_frame().
+
+Context: a contract-audit bug report claimed 14 indicators "violate the unified
+data pipeline contract" by returning raw dicts instead of pandas tabular
+objects. In fact ALL indicators return ``dict[str, pd.Series]`` -- that is the
+documented contract (the 14 flagged were simply the no-param indicators, the
+only ones the reporter's harness could execute with empty params). These tests
+pin down that uniform contract and exercise ``compute_frame()``, the additive,
+non-breaking tabular surface for feature stacking.
+"""
+import numpy as np
+import pandas as pd
+
+import mangrove_kb.indicators as ind
+from mangrove_kb.indicators.indicator_interface import IndicatorInterface
+
+# The 14 no-param indicators the audit harness flagged.
+NO_PARAM_INDICATORS = [
+    "ADI", "BOP", "CumulativeReturn", "DailyLogReturn", "DailyReturn",
+    "Engulfing", "Harami", "HeikinAshi", "InsideBar", "OBV", "OutsideBar",
+    "ThreeInsideDown", "ThreeInsideUp", "TrueRange",
+]
+
+
+def _ohlcv(n=120):
+    np.random.seed(0)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    close = pd.Series(100 + np.cumsum(np.random.randn(n)), index=idx)
+    high = close + np.abs(np.random.randn(n))
+    low = close - np.abs(np.random.randn(n))
+    open_ = close.shift(1).bfill()
+    volume = pd.Series(np.random.randint(1000, 5000, n).astype(float), index=idx)
+    return idx, {"open": open_, "high": high, "low": low, "close": close, "volume": volume}
+
+
+def test_all_no_param_indicators_share_dict_contract():
+    """compute() returns dict[str, pd.Series] for every flagged indicator."""
+    idx, full = _ohlcv()
+    for name in NO_PARAM_INDICATORS:
+        cls = getattr(ind, name)
+        data = {k: full[k] for k in cls._data}
+        result = cls.compute(data=data, params={})
+        assert isinstance(result, dict), f"{name} did not return a dict"
+        for key, series in result.items():
+            assert isinstance(series, pd.Series), f"{name}[{key}] is not a Series"
+            assert series.index.equals(idx), f"{name}[{key}] lost the input index"
+
+
+def test_compute_frame_returns_dataframe_with_output_columns():
+    """compute_frame() yields a DataFrame whose columns are the output names."""
+    idx, full = _ohlcv()
+    for name in NO_PARAM_INDICATORS:
+        cls = getattr(ind, name)
+        data = {k: full[k] for k in cls._data}
+        frame = cls.compute_frame(data=data, params={})
+        assert isinstance(frame, pd.DataFrame), f"{name}.compute_frame() is not a DataFrame"
+        assert list(frame.columns) == list(cls._outputs), f"{name} columns != _outputs"
+        assert frame.index.equals(idx), f"{name} frame lost the input index"
+
+
+def test_compute_frame_works_for_param_indicators():
+    """The accessor is uniform: param-taking indicators also yield DataFrames."""
+    idx, full = _ohlcv()
+    frame = ind.RSI.compute_frame(data={"close": full["close"]}, params={"window": 14})
+    assert isinstance(frame, pd.DataFrame)
+    assert list(frame.columns) == ["rsi"]
+    macd = ind.MACD.compute_frame(
+        data={"close": full["close"]},
+        params={"window_fast": 12, "window_slow": 26, "window_sign": 9},
+    )
+    assert list(macd.columns) == ["macd", "signal", "histogram"]
+    assert macd.index.equals(idx)
+
+
+def test_frames_outer_join_into_feature_matrix():
+    """The reporter's use case: stack many indicators into one matrix."""
+    idx, full = _ohlcv()
+    features = pd.concat(
+        [
+            ind.RSI.compute_frame({"close": full["close"]}, {"window": 14}),
+            ind.OBV.compute_frame({"close": full["close"], "volume": full["volume"]}, {}),
+            ind.TrueRange.compute_frame(
+                {"high": full["high"], "low": full["low"], "close": full["close"]}, {}
+            ),
+            ind.MACD.compute_frame(
+                {"close": full["close"]},
+                {"window_fast": 12, "window_slow": 26, "window_sign": 9},
+            ),
+        ],
+        axis=1,
+    )
+    assert isinstance(features, pd.DataFrame)
+    # No row explosion: concat aligned on the shared index, one row per bar.
+    assert len(features) == len(idx)
+    assert features.index.equals(idx)
+    assert set(["rsi", "obv", "true_range", "macd", "signal", "histogram"]).issubset(features.columns)
+
+
+def test_compute_frame_available_on_base_interface():
+    assert hasattr(IndicatorInterface, "compute_frame")

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -1,0 +1,107 @@
+"""
+Tests for the sample_ohlcv() mock-data helper.
+
+Reproduces the reported bug: the quickstart snippets referenced a file
+(`ohlcv.csv`) that is not shipped, so they failed on a clean install with
+FileNotFoundError. sample_ohlcv() gives every snippet self-contained data that
+runs out of the box, with the capitalized OHLCV columns the signals expect.
+
+Usage:
+    pytest tests/test_sample_data.py -v
+"""
+
+import pandas as pd
+import pytest
+
+from mangrove_kb import RuleRegistry, sample_ohlcv
+
+
+class TestShape:
+    EXPECTED_COLUMNS = ["Open", "High", "Low", "Close", "Volume"]
+
+    def test_default_columns_are_capitalized_ohlcv(self):
+        df = sample_ohlcv()
+        assert list(df.columns) == self.EXPECTED_COLUMNS
+
+    def test_default_row_count(self):
+        assert len(sample_ohlcv()) == 200
+
+    def test_custom_row_count(self):
+        assert len(sample_ohlcv(rows=50)) == 50
+
+    def test_datetime_index(self):
+        df = sample_ohlcv()
+        assert isinstance(df.index, pd.DatetimeIndex)
+        assert df.index.name == "Timestamp"
+
+    def test_values_are_float_and_finite(self):
+        df = sample_ohlcv()
+        assert df.to_numpy().dtype.kind == "f"
+        assert df.notna().all().all()
+
+
+class TestCandleInvariants:
+    def test_high_is_the_max_low_is_the_min(self):
+        df = sample_ohlcv(rows=500)
+        body_high = df[["Open", "Close"]].max(axis=1)
+        body_low = df[["Open", "Close"]].min(axis=1)
+        assert (df["High"] >= body_high - 1e-9).all()
+        assert (df["Low"] <= body_low + 1e-9).all()
+        assert (df["High"] >= df["Low"]).all()
+
+    def test_prices_and_volume_are_positive(self):
+        df = sample_ohlcv(rows=500)
+        assert (df[["Open", "High", "Low", "Close"]] > 0).all().all()
+        assert (df["Volume"] > 0).all()
+
+    def test_first_bar_opens_at_start_price(self):
+        df = sample_ohlcv(start_price=250.0)
+        assert df["Open"].iloc[0] == pytest.approx(250.0)
+
+
+class TestDeterminism:
+    def test_same_seed_same_data(self):
+        pd.testing.assert_frame_equal(sample_ohlcv(seed=7), sample_ohlcv(seed=7))
+
+    def test_different_seed_different_data(self):
+        assert not sample_ohlcv(seed=1)["Close"].equals(sample_ohlcv(seed=2)["Close"])
+
+
+class TestTrend:
+    def test_down_trend_ends_lower(self):
+        df = sample_ohlcv(rows=400, trend="down", seed=0)
+        assert df["Close"].iloc[-1] < df["Close"].iloc[0]
+
+    def test_up_trend_ends_higher(self):
+        df = sample_ohlcv(rows=400, trend="up", seed=0)
+        assert df["Close"].iloc[-1] > df["Close"].iloc[0]
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"rows": 1},
+            {"start_price": 0},
+            {"start_price": -5},
+            {"volatility": -0.1},
+            {"trend": "sideways"},
+        ],
+    )
+    def test_bad_args_raise_value_error(self, kwargs):
+        with pytest.raises(ValueError):
+            sample_ohlcv(**kwargs)
+
+
+class TestQuickstartRunsOutOfTheBox:
+    """The exact bug: the documented snippet must run with no CSV file."""
+
+    def test_rule_registry_evaluate_runs_on_sample_data(self):
+        df = sample_ohlcv()
+        fired = RuleRegistry.evaluate(
+            {"name": "rsi_oversold", "params": {"window": 14, "threshold": 30}},
+            df,
+        )
+        # Decoupled from the numpy.bool_-leak issue (#66): just assert the
+        # documented snippet executes and returns a boolean-like result.
+        assert bool(fired) in (True, False)

--- a/tests/test_signal_return_types.py
+++ b/tests/test_signal_return_types.py
@@ -1,0 +1,135 @@
+"""
+Return-type contract tests for the signal registry.
+
+Signal functions compute their result by comparing numpy/pandas scalars
+(e.g. ``close.iloc[-1] > sma.iloc[-1]``), which yields a ``numpy.bool_`` rather
+than a native Python ``bool``. ``numpy.bool_`` is not JSON-serializable, so a
+signal result passed straight into ``json.dumps()`` or a webhook payload raises
+``TypeError: Object of type bool_ is not JSON serializable`` and silently halts
+downstream automation.
+
+These tests assert the public contract: every registered signal returns a
+native Python ``bool`` (or a ``pd.Series``) that is JSON-serializable, both when
+called directly and via :meth:`RuleRegistry.evaluate`. Regression guard for the
+numpy primitive-leakage bug.
+
+Usage:
+    pytest tests/test_signal_return_types.py -v
+"""
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import mangrove_kb.signals  # noqa: F401  -- triggers signal registration
+from mangrove_kb.registry import RuleRegistry, _to_native
+
+
+# --------------------------------------------------------------------------- #
+# Realistic OHLCV + alt-data frame                                            #
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def df() -> pd.DataFrame:
+    n = 300
+    idx = pd.date_range("2024-01-01", periods=n, freq="h")
+    # A deterministic but non-trivial price path so signals reach their
+    # comparison return paths (not just the early "insufficient data" guard).
+    drift = np.linspace(100.0, 160.0, n)
+    wiggle = 5.0 * np.sin(np.linspace(0.0, 12.0, n))
+    close = drift + wiggle
+    frame = pd.DataFrame(
+        {
+            "Open": close - 0.5,
+            "High": close + 1.0,
+            "Low": close - 1.0,
+            "Close": close,
+            "Volume": np.linspace(1_000.0, 2_000.0, n),
+        },
+        index=idx,
+    )
+    # On-chain signals consume alternative-data columns time-aligned to bars.
+    for col in (
+        "SmartMoneyNetflow",
+        "SmartMoneyHoldings",
+        "ExchangeNetflow",
+        "WhaleNetInflow",
+        "HolderConcentration",
+    ):
+        frame[col] = wiggle
+    return frame
+
+
+# Signals explicitly called out in the bug report, with the args each needs to
+# reach its comparison return path (is_above_sma has no default window).
+REPORTED = [
+    ("rsi_cross_up", {"window": 14, "threshold": 50.0}),
+    ("rsi_cross_down", {"window": 14, "threshold": 50.0}),
+    ("is_above_sma", {"window": 50}),
+    ("supertrend_long", {"window": 10, "multiplier": 3.0}),
+    ("supertrend_short", {"window": 10, "multiplier": 3.0}),
+]
+
+
+def _native_type(value) -> bool:
+    return isinstance(value, (bool, pd.Series))
+
+
+class TestToNativeHelper:
+    def test_numpy_bool_becomes_native_bool(self):
+        coerced = _to_native(np.bool_(True))
+        assert coerced is True
+        assert type(coerced) is bool
+
+    def test_native_bool_passes_through(self):
+        assert _to_native(True) is True
+        assert _to_native(False) is False
+
+    def test_numpy_array_becomes_series(self):
+        out = _to_native(np.array([True, False]))
+        assert isinstance(out, pd.Series)
+
+    def test_series_passes_through(self):
+        s = pd.Series([True, False])
+        assert _to_native(s) is s
+
+
+class TestReportedSignals:
+    """The five signals named in the bug report must honor the contract."""
+
+    @pytest.mark.parametrize("name,kwargs", REPORTED)
+    def test_returns_native_and_json_serializable(self, name, kwargs, df):
+        value = RuleRegistry._registry[name](df, **kwargs)
+        assert _native_type(value), f"{name} returned {type(value)!r}"
+        assert not isinstance(value, np.generic), f"{name} leaked a numpy scalar"
+        # The exact downstream failure mode from the report.
+        json.dumps(value if not isinstance(value, pd.Series) else value.tolist())
+
+
+class TestEverySignalContract:
+    """No registered signal may leak a numpy primitive on realistic data."""
+
+    def test_no_numpy_leakage_across_registry(self, df):
+        offenders = []
+        for name, fn in RuleRegistry._registry.items():
+            try:
+                value = fn(df)
+            except TypeError:
+                # Signals with required positional args (e.g. window_fast)
+                # can't be called with df alone; their return path is covered
+                # by the parametrized/evaluate tests instead.
+                continue
+            if isinstance(value, np.generic) or not _native_type(value):
+                offenders.append((name, type(value).__name__))
+        assert not offenders, f"signals leaking non-native return types: {offenders}"
+
+
+class TestEvaluatePath:
+    """The same contract must hold through RuleRegistry.evaluate()."""
+
+    def test_evaluate_returns_native_bool(self, df):
+        rule = {"name": "rsi_cross_down", "params": {"window": 14, "threshold": 50.0}}
+        value = RuleRegistry.evaluate(rule, df)
+        assert type(value) is bool
+        json.dumps(value)


### PR DESCRIPTION
Combined KB PR — collapses #71 + #67 + #69 (disjoint files) into one merge. Rebuilt on current main and all three test suites re-run green (34 passed) after the recent in-flight KB merges.

## #71 — quickstart runs out of the box (closes #70)
`sample_ohlcv()` helper so KB snippets run with no CSV/download (Cold Start FileNotFoundError). Default `seed=10` so the documented `rsi_oversold` example genuinely fires.

## #67 — native bool / Series contract (closes #66)
Coerce signal returns at the single registration point so all 233 signals return native `bool`/`pd.Series` instead of `numpy.bool_` (which `json.dumps()` can't serialize). `@functools.wraps` preserves `__module__` (category derivation intact).

## #69 — uniform tabular accessor (closes #68)
`IndicatorInterface.compute_frame()` returns a DataFrame for feature stacking. (The #68 report's "14 indicators return dict" was a **false positive** — all return `dict[str, pd.Series]`, the documented contract; this adds the additive tabular surface they actually wanted. `compute()` unchanged.)

## Verification (re-run on current main)
- `tests/test_sample_data.py` + `test_signal_return_types.py` + `test_indicator_frame.py`: **34 passed**.
- Live: `sample_ohlcv()` -> (200,5), `rsi_oversold` fires True; `is_above_sma` -> native bool + JSON-ok; `RSI.compute_frame` -> DataFrame.

Closes #70, #66, #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
