### PR TITLE
docs: API key scopes, v2 engine fields, cooldown migration, data window, strategy visibility

### DIFF
--- a/docs/api-reference/backtesting.mdx
+++ b/docs/api-reference/backtesting.mdx
@@ -232,7 +232,7 @@ Pass `cooldown_config` as a top-level key in the backtest request body to contro
 Max hold time is controlled by `execution_config.max_hold_bars`, not by `cooldown_config`.
 
 <Warning>
-**Deprecated parameters:** `cooldown_bars`, `daily_momentum_limit`, and `weekly_momentum_limit` are deprecated flat keys accepted for backward compatibility during the 90-day grace period. Migrate to `cooldown_config` before the next major version. The legacy keys are not shown in the examples above.
+**Deprecated parameters:** `cooldown_bars`, `daily_momentum_limit`, and `weekly_momentum_limit` are deprecated flat keys, kept for backward compatibility. They are **optional** -- omit them and they default from `trading_defaults.json` (`24`, `3`, `3`). You no longer need to supply them to call the backtest endpoints, so the examples above leave them out. Continue migrating any explicit cooldown tuning to `cooldown_config` before the next major version.
 </Warning>
 
 See the [Risk Management guide](/guides/risk-management) for full cooldown tuning details.

--- a/docs/authentication.mdx
+++ b/docs/authentication.mdx
@@ -112,7 +112,7 @@ curl -X POST https://api.mangrovedeveloper.ai/api/v1/auth/api-keys \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Production Server Key",
-    "scopes": ["read:strategies", "write:backtests"],
+    "scopes": ["strategy:read", "strategy:create", "backtest:create"],
     "expires_days": 365
   }'
 ```
@@ -123,7 +123,7 @@ response = requests.post(
     headers={"Authorization": f"Bearer {access_token}"},
     json={
         "name": "Production Server Key",
-        "scopes": ["read:strategies", "write:backtests"],
+        "scopes": ["strategy:read", "strategy:create", "backtest:create"],
         "expires_days": 365
     }
 )
@@ -210,6 +210,53 @@ async function refreshAccessToken(refreshToken) {
 | Authenticated User | Valid JWT or API key | Own data (strategies, backtests, conversations) within your tier limits |
 | Unauthenticated | None | Health checks, Swagger docs, the x402-gated wallet-paid surface (no signup) |
 
+## API Key Scopes
+
+Every authenticated endpoint requires a specific scope. When you mint a key with
+a non-empty `scopes` array, each request is checked against that list and a
+missing scope returns **403 `INSUFFICIENT_PERMISSIONS`** with the exact scope it
+needed (for example, `API key does not have scope: strategy:update_status`).
+
+Two rules govern what a key can actually do:
+
+- **Empty `scopes: []` means full role-based access** -- the key inherits every
+  scope its organization role permits. Pass an explicit list only to restrict a
+  key below its role.
+- **Scopes are baked at mint time and your role gates them.** A `viewer` role
+  only ever gets the read scopes below, regardless of what you request; to write
+  you need a `member` (or higher) key. Changing a role later does not re-scope an
+  already-minted key -- revoke and re-mint.
+
+Scope strings use the `resource:action` form (note: `strategy:read`, **not**
+`read:strategies`). Required scope by endpoint:
+
+| Endpoint | Method | Required scope |
+|----------|--------|----------------|
+| `/api/v1/strategies` | `POST` | `strategy:create` |
+| `/api/v1/strategies`, `/api/v1/strategies/{id}` | `GET` | `strategy:read` |
+| `/api/v1/strategies/{id}` (update, incl. `execution_config`) | `PUT` | `strategy:update_status` |
+| `/api/v1/strategies/{id}/status` | `PATCH` | `strategy:update_status` |
+| `/api/v1/strategies/{id}/execution-state` | `PATCH` | `strategy:update_status` |
+| `/api/v1/strategies/{id}` | `DELETE` | `strategy:delete` |
+| `/api/v1/execution/evaluate/{id}`, `/evaluate`, `/evaluate/bulk` | `POST` | `strategy:read` |
+| `/api/v1/execution/portfolio` | `GET` | `strategy:read` |
+| `/api/v1/execution/accounts`, `/positions`, `/trades` | `GET` | `position:read` |
+| `/api/v1/execution/accounts` | `POST` | `position:create` |
+| `/api/v1/backtesting/backtest`, `/backtest/bulk` | `POST` | `backtest:create` |
+| `/api/v1/backtesting/backtest/{id}` | `GET` | `backtest:read` |
+| `/api/v1/signals/...` | `GET` | `signal:read` |
+| `/api/v1/signals/evaluate` | `POST` | `signal:evaluate` |
+| `/api/v1/oracle/backtest/...` | `POST` | `oracle:backtest` |
+| `/api/v1/oracle/experiments/...` | `POST` | `oracle:sweep` |
+| `/api/v1/oracle/data/query` | `POST` | `data:query` |
+
+<Note>
+Updating a strategy's `execution_config` (a `PUT /strategies/{id}`) requires the
+`strategy:update_status` scope -- the same scope that guards status changes. A
+read-only (`viewer`) key cannot perform it. If you only need to evaluate a saved
+strategy, `strategy:read` is sufficient.
+</Note>
+
 ## Error Responses
 
 **401 Unauthorized** -- Token missing, invalid, or expired. The response carries
@@ -228,12 +275,16 @@ self-explanatory:
 A request sent with no credentials returns the same shape with
 `"message": "Missing or invalid authentication token"`.
 
-**403 Forbidden** -- Insufficient permissions:
+**403 Forbidden** -- Insufficient permissions. The `code` is
+`INSUFFICIENT_PERMISSIONS` and the `message` names the exact scope (or role
+permission) that was missing, so you know which scope to add when re-minting the
+key (see [API Key Scopes](#api-key-scopes)):
 
 ```json
 {
-  "error": "Forbidden",
-  "message": "Insufficient permissions for this operation"
+  "error": "authorization_error",
+  "message": "API key does not have scope: strategy:update_status",
+  "code": "INSUFFICIENT_PERMISSIONS"
 }
 ```
 

--- a/docs/guides/creating-a-strategy.mdx
+++ b/docs/guides/creating-a-strategy.mdx
@@ -402,8 +402,30 @@ A successful response returns the full strategy object including auto-populated 
 ```
 
 <Note>
-You did not provide `execution_config` or `execution_state` in the request. The API automatically populates both with defaults from `trading_defaults.json`. You can override any field by including it in your request. See the [Risk Management guide](/guides/risk-management) for details on every field.
+You did not provide `execution_config` or `execution_state` in the request. The API automatically populates both with defaults from `trading_defaults.json`. You can override any field by including it in your request -- a partial `execution_config` you send is **merged over** the defaults, so omitting a field keeps its default rather than dropping it. See the [Risk Management guide](/guides/risk-management) for details on every field.
 </Note>
+
+### Sizing version (`position_size_calc`)
+
+Every strategy is created with a `position_size_calc` value -- `"v2"` by default
+(the canonical value from `trading_defaults.json`). It is **pinned at creation
+and immutable** thereafter. The v2 position-sizing engine reads a set of
+`execution_config` fields with no built-in fallback:
+
+```
+atr_short_weight, atr_long_weight, min_balance_threshold, min_trade_amount,
+max_open_positions, max_trades_per_day, volatility_window, target_volatility,
+volatility_mode, enable_volatility_adjustment, max_hold_bars,
+exit_on_loss_after_bars, exit_on_profit_after_bars, profit_threshold_pct
+```
+
+You do not need to set these yourself: because a provided `execution_config` is
+merged over the canon defaults (and an omitted one is filled entirely from
+canon), every created strategy carries the full v2 field set, and
+`POST /api/v1/execution/evaluate/{id}` works out of the box. To pin a strategy to
+the older v1 sizing math instead, pass `"position_size_calc": "v1"` in the create
+request. See the [Risk Management guide](/guides/risk-management) for what each
+field does.
 
 ## Step 5: Verify the strategy
 
@@ -451,6 +473,16 @@ You should see:
 - **Status**: `inactive` (the default for new strategies)
 - **Entry signals**: `macd_bullish_cross` (TRIGGER) + `is_above_sma` (FILTER)
 - **Exit signals**: `macd_bearish_cross` (TRIGGER)
+
+<Note>
+**Strategy visibility is scoped to your developer account.** `GET /api/v1/strategies`
+returns only the strategies created through the developer API under the same
+authenticated `user_id` and organization. A strategy created under a different
+account or organization -- or through a separate Mangrove product surface -- will
+not appear in your list and `total` may read `0`. To manage a strategy through
+this API (list it, evaluate it, back-test it by `strategy_id`), create it through
+this API.
+</Note>
 
 ## Common validation errors
 

--- a/docs/guides/running-a-backtest.mdx
+++ b/docs/guides/running-a-backtest.mdx
@@ -330,6 +330,17 @@ To use an explicit date range instead of lookback, replace `lookback_months` wit
 You must provide at least one date parameter. The API will reject requests with no date range specified. Dates use ISO format: `YYYY-MM-DD`.
 </Warning>
 
+<Note>
+**Data availability is the effective floor on the window.** The requested range
+is clipped to what the upstream market-data provider (CoinAPI) actually has for
+the asset and interval. If the provider only holds, say, the last few months for
+a symbol, then `lookback_months: 12` and an equivalent `start_date` resolve to
+the **same** backtest -- identical trade count and metrics -- because both are
+bounded by the available history, not by the parameter you sent. Treat the date
+parameters as an upper bound on the window, not a guarantee of its length, and
+check the returned date range / bar count to see what was actually used.
+</Note>
+
 ## Step 3: Review the results
 
 A successful backtest returns performance metrics and a trade count:


### PR DESCRIPTION
Docs companion to MangroveTechnologies/MangroveAI#677. Tracking issue: MangroveTechnologies/MangroveAI#676.

Reported by developer-program tester lukecourts_80412 (Discord #testing-log). Closes the documentation gaps in the multi-part report.

## Changes

- **`docs/authentication.mdx`** -- New **API Key Scopes** section with a per-endpoint scope table using the *real* scope strings (`strategy:read`, `strategy:update_status`, `backtest:create`, ... -- the docs previously showed an incorrect `read:strategies` form, also fixed in the mint example). Documents the empty-`scopes`-means-full-role-access contract, that scopes are role-gated and baked at mint time, and corrects the 403 example to the real `INSUFFICIENT_PERMISSIONS` shape. Explicitly calls out that updating `execution_config` via `PUT /strategies/{id}` needs `strategy:update_status` (the tester's report item 2).
- **`docs/guides/creating-a-strategy.mdx`** -- Documents `position_size_calc` (defaults `'v2'`, pinned at creation) and the v2 engine field set, and that a partial `execution_config` is merged over canon (matches MangroveAI#677). Adds a strategy-visibility note (`GET /strategies` is scoped to your `user_id + org_id`) for report item 5.
- **`docs/api-reference/backtesting.mdx`** -- The deprecated flat cooldown keys are now optional and default from canon (matches MangroveAI#677).
- **`docs/guides/running-a-backtest.mdx`** -- Notes that CoinAPI data availability is the effective floor on the backtest window (report item 4), so `lookback_months` and an equivalent `start_date` can resolve to the same window.

## Verification
- `mintlify broken-links` on `docs/`: **no broken links** (incl. the new `#api-key-scopes` anchor). The OpenAPI-schema warning is pre-existing and unrelated.
- All scope strings cross-checked against `MangroveAI/utils/auth/permissions.py` and the `@require_permission(...)` decorators on the strategies / managers / backtesting routes.

## Product decision flagged (not in this PR)
Whether app-created strategies should be queryable via the dev portal API (report item 5) is a Mangrove team decision -- see MangroveAI#676. This PR only adds a conservative, verifiable visibility note.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
