### PR TITLE
docs(oracle): launch 504-but-succeeded + poll contract (MangroveOracle#296)

### DIFF
--- a/docs/api-reference/experiments.mdx
+++ b/docs/api-reference/experiments.mdx
@@ -101,6 +101,10 @@ Each `POST /experiments` + subsequent `/launch` counts as ONE billable HTTP call
     ```
 
     The engine starts evaluating the space asynchronously (in the cloud). A 429 here means you've hit your tier's concurrent-sweep cap — wait for the running sweep to finish, then launch.
+
+    <Warning>
+      Launch is **non-idempotent** and can return a **504 gateway timeout even though the launch succeeded** server-side. Do **not** re-send the launch on a 504 (a retry can hit the single-flight 409 or the concurrent-cap 429). Instead, poll `GET /api/v1/oracle/experiments/{id}` and treat any status past `validated` (e.g. `preparing`/`running`) as success. The Python SDK's `oracle.launch_experiment_and_wait()` handles this for you; raw HTTP clients should not auto-retry the launch `POST`.
+    </Warning>
   </Step>
   <Step title="Poll for results">
     ```bash

--- a/docs/guides/oracle-sweep-quickstart.mdx
+++ b/docs/guides/oracle-sweep-quickstart.mdx
@@ -51,7 +51,7 @@ create ──▶ validate ──▶ launch ──▶ poll ──▶ results
 1. **Orient** (free): `GET /api/v1/oracle/datasets`, `GET /api/v1/oracle/signals` (each signal carries a `category`), `GET /api/v1/oracle/exec-config/defaults`.
 2. **Create**: `POST /api/v1/oracle/experiments` with the `ExperimentConfig` — `datasets` holds whole dataset OBJECTS, each signal has a `signal_type`, entry needs ≥1 filter, and `params_sweep` defines the space. See [Experiments](/api-reference/experiments) for the full body.
 3. **Validate**: `POST /api/v1/oracle/experiments/{id}/validate` → `{ valid, total_runs, errors }`. **Required before launch.** Your tier's `max_backtests_per_sweep` is enforced here (403 if the size exceeds it) — there is **no fixed 99 limit** (that 99 is SIEVE's per-call cap, a different feature).
-4. **Launch**: `POST /api/v1/oracle/experiments/{id}/launch` (async, runs as a cloud job). A 429 means you've hit your tier's concurrent-sweep cap — wait, then launch.
+4. **Launch**: `POST /api/v1/oracle/experiments/{id}/launch` (async, runs as a cloud job). A 429 means you've hit your tier's concurrent-sweep cap — wait, then launch. Launch is non-idempotent and may return a **504 gateway timeout even though it succeeded** server-side — do **not** re-launch on a 504; poll `GET /api/v1/oracle/experiments/{id}` and treat any status past `validated` as success. (The SDK's `launch_experiment_and_wait()` does this for you.)
 5. **Read**: `GET /api/v1/oracle/results?experiment_id=<id>` — paginated, ranked metrics per strategy.
 
 ## 4. Control the sweep size


### PR DESCRIPTION
WS5 of the MangroveOracle #296 remediation. Documents that Oracle sweep launch is non-idempotent and can return a **504 even though it succeeded** server-side — don't re-launch; poll `GET /experiments/{id}` and treat any status past `validated` as success (SDK `launch_experiment_and_wait` handles it).

- `docs/guides/oracle-sweep-quickstart.mdx` — launch step note.
- `docs/api-reference/experiments.mdx` — `<Warning>` callout in the Launch step.

Completes the #296 client-resilience set (MangroveOracle #302, MangroveAI #675, MangroveAI-SDK #28, mangrove-agent #101).

🤖 Generated with [Claude Code](https://claude.com/claude-code)