### PR TITLE
docs: correct stale cloud-dev refs → single mangroveai-prod environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ us-central1-docker.pkg.dev/mangroveai-platform/mangrove-ai-repo/mangrove-ai-kb
 ```
 Tags: `latest` + commit SHA.
 
-MangroveAI controls Cloud Run deployment separately (via its own `deploy-kb-dev` / `deploy-kb-prod` workflows).
+MangroveAI controls Cloud Run deployment separately (via its own `deploy-kb-prod` workflow). There is no cloud dev environment — dev was shut down (#271, 2026-06-15); everything runs in `mangroveai-prod`.
 
 ### CI
 On push/PR to main, the `ci` workflow runs pytest across Python 3.10, 3.11, 3.12.
@@ -150,8 +150,7 @@ KB server image is built and pushed to Artifact Registry by this repo. Cloud Run
 | Environment | URL | Managed By |
 |------------|-----|------------|
 | Local | http://localhost:8081 | docker-compose (this repo or MangroveAI) |
-| Dev | https://devkb.mangrove.trade | MangroveAI deploy-kb-dev workflow |
-| Prod | https://kb.mangrovedeveloper.ai | MangroveAI deploy-kb-prod workflow |
+| Prod | https://kb.mangrovedeveloper.ai | MangroveAI deploy-kb-prod workflow (`mangroveai-prod`) |
 
 Terraform module: `MangroveAI/infra/terraform/modules/app-mangroveai-kb/`
 

--- a/findings/docs-and-admin-plan.md
+++ b/findings/docs-and-admin-plan.md
@@ -1,5 +1,7 @@
 # Planning Document: Mintlify Public Docs + MangroveAdmin Extraction
 
+> ⚠️ **Historical — superseded by #271 (2026-06-15).** No cloud dev environment exists; everything runs in **`mangroveai-prod`** (deploy via `deploy-kb-prod`). Any `mangroveai-dev` / `*-dev` deploy reference below is historical.
+
 **Date:** 2026-02-22
 **Status:** Planning only -- no implementation
 **Author:** Claude (Opus 4.6)


### PR DESCRIPTION
## Why
No cloud dev environment exists — dev was shut down (#271, 2026-06-15). KB deploys to **`mangroveai-prod`** via MangroveAI's `deploy-kb-prod` workflow. Part of the portfolio-wide propagation of the single-environment fact (skills: mangrove-workspace#51; Oracle: MangroveOracle#311).

## Changes
- **CLAUDE.md**: drop the `deploy-kb-dev` workflow reference; remove the `Dev | https://devkb.mangrove.trade | deploy-kb-dev` row from the deployment table (no dev env); add a one-line single-environment note.
- **findings/docs-and-admin-plan.md**: historical-superseded banner (dated planning doc).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)