### PR TITLE
feat(signals): DeFiLlama Pro signal families (5 families, 10 signals)

### DIFF
--- a/docs/signals/catalog.mdx
+++ b/docs/signals/catalog.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Signal Catalog"
-description: "Index of all 233 trading signals across 6 categories."
+description: "Index of all 243 trading signals across 7 categories."
 ---
 
 # Signal Catalog
 
-Complete reference for all **233** trading signals 
-(112 TRIGGER, 121 FILTER) organized by category.
+Complete reference for all **243** trading signals 
+(117 TRIGGER, 126 FILTER) organized by category.
 
 See [Signals Overview](/signals/overview) for an introduction to how signals work.
 
@@ -20,6 +20,7 @@ See [Signals Overview](/signals/overview) for an introduction to how signals wor
 | Volatility | 20 | [/signals/catalog/volatility](/signals/catalog/volatility) |
 | Patterns | 40 | [/signals/catalog/patterns](/signals/catalog/patterns) |
 | On-Chain | 10 | [/signals/catalog/on-chain](/signals/catalog/on-chain) |
+| DeFi Pro | 10 | [/signals/catalog/defi-pro](/signals/catalog/defi-pro) |
 
 ## All signals
 
@@ -258,7 +259,17 @@ See [Signals Overview](/signals/overview) for an introduction to how signals wor
 | [`smart_money_net_positive`](/signals/catalog/on-chain) | FILTER | On-Chain | SmartMoneyNetflow |
 | [`whale_accumulation_trigger`](/signals/catalog/on-chain) | TRIGGER | On-Chain | WhaleNetInflow |
 | [`whale_net_accumulation`](/signals/catalog/on-chain) | FILTER | On-Chain | WhaleNetInflow |
+| [`etf_inflow_spike`](/signals/catalog/defi-pro) | TRIGGER | DeFi Pro | EtfNetFlow |
+| [`etf_inflow_streak`](/signals/catalog/defi-pro) | FILTER | DeFi Pro | EtfNetFlow |
+| [`funding_flip_positive`](/signals/catalog/defi-pro) | TRIGGER | DeFi Pro | PerpFundingRate |
+| [`funding_negative_regime`](/signals/catalog/defi-pro) | FILTER | DeFi Pro | PerpFundingRate |
+| [`lending_spread_low`](/signals/catalog/defi-pro) | FILTER | DeFi Pro | LendingRateSpread |
+| [`lending_spread_widening`](/signals/catalog/defi-pro) | TRIGGER | DeFi Pro | LendingRateSpread |
+| [`token_unlock_cliff_ahead`](/signals/catalog/defi-pro) | TRIGGER | DeFi Pro | TokenUnlockPressure |
+| [`token_unlock_pressure_low`](/signals/catalog/defi-pro) | FILTER | DeFi Pro | TokenUnlockPressure |
+| [`treasury_accumulation_trigger`](/signals/catalog/defi-pro) | TRIGGER | DeFi Pro | TreasuryUsd |
+| [`treasury_growing`](/signals/catalog/defi-pro) | FILTER | DeFi Pro | TreasuryUsd |
 
 ---
 
-_Generated from docstring metadata. 233 signals total (112 TRIGGER, 121 FILTER)._
+_Generated from docstring metadata. 243 signals total (117 TRIGGER, 126 FILTER)._

--- a/docs/signals/catalog/defi-pro.mdx
+++ b/docs/signals/catalog/defi-pro.mdx
@@ -1,0 +1,447 @@
+---
+title: "DeFi Pro Signals"
+description: "10 defi-pro trading signals with parameters, descriptions, and examples."
+---
+
+# DeFi Pro Signals
+
+_10 signals in this category._
+
+See the full [Signal Catalog](/signals/catalog) for the cross-category index, or the [Signals Overview](/signals/overview) for an introduction.
+
+Click a signal to expand parameters and examples.
+
+<AccordionGroup>
+
+<Accordion title="etf_inflow_spike" description="TRIGGER - requires EtfNetFlow">
+
+Detect an unusually large net ETF inflow on the latest bar.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 5 -- 200 | `20` | Prior bars forming the rolling baseline (latest excluded) |
+| `z_threshold` | `float` | 0.5 -- 5.0 | `2.0` | Std-devs above the baseline mean to fire |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "etf_inflow_spike",
+    "parameters": {
+        "window": 20,
+        "z_threshold": 2.0
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "etf_inflow_spike",
+  "parameters": {
+    "window": 20,
+    "z_threshold": 2.0
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="etf_inflow_streak" description="FILTER - requires EtfNetFlow">
+
+Confirm sustained net ETF inflows.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 2 -- 60 | `5` | Number of consecutive latest bars that must be positive |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "etf_inflow_streak",
+    "parameters": {
+        "window": 5
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "etf_inflow_streak",
+  "parameters": {
+    "window": 5
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="funding_flip_positive" description="TRIGGER - requires PerpFundingRate">
+
+Detect funding crossing from non-positive to positive on the latest bar.
+
+_No configurable parameters._
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "funding_flip_positive",
+    "parameters": {}
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "funding_flip_positive",
+  "parameters": {}
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="funding_negative_regime" description="FILTER - requires PerpFundingRate">
+
+Check for a persistently negative funding regime (shorts pay longs).
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 3 -- 200 | `14` | Number of recent bars to average |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "funding_negative_regime",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "funding_negative_regime",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="lending_spread_low" description="FILTER - requires LendingRateSpread">
+
+Confirm a calm lending market (narrow borrow-supply spread).
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `threshold` | `float` | 0.001 -- 0.5 | `0.02` | Maximum spread to consider calm |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "lending_spread_low",
+    "parameters": {
+        "threshold": 0.02
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "lending_spread_low",
+  "parameters": {
+    "threshold": 0.02
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="lending_spread_widening" description="TRIGGER - requires LendingRateSpread">
+
+Detect the borrow-supply spread crossing above its moving average.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 3 -- 200 | `20` | Moving-average window |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "lending_spread_widening",
+    "parameters": {
+        "window": 20
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "lending_spread_widening",
+  "parameters": {
+    "window": 20
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="token_unlock_cliff_ahead" description="TRIGGER - requires TokenUnlockPressure">
+
+Detect a large upcoming unlock cliff (supply-shock warning).
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 5 -- 200 | `30` | Prior bars forming the rolling baseline (latest excluded) |
+| `z_threshold` | `float` | 0.5 -- 5.0 | `2.0` | Std-devs above the baseline mean the latest pressure must reach to fire |
+| `min_pressure` | `float` | 0.005 -- 0.5 | `0.03` | Floor the latest pressure must also clear, so noise around a tiny baseline does not fire |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "token_unlock_cliff_ahead",
+    "parameters": {
+        "window": 30,
+        "z_threshold": 2.0,
+        "min_pressure": 0.03
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "token_unlock_cliff_ahead",
+  "parameters": {
+    "window": 30,
+    "z_threshold": 2.0,
+    "min_pressure": 0.03
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="token_unlock_pressure_low" description="FILTER - requires TokenUnlockPressure">
+
+Confirm there is little near-term unlock dilution ahead.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `threshold` | `float` | 0.005 -- 0.25 | `0.02` | Maximum acceptable unlock pressure (a value of 0.02 means 2% of circulating supply) |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "token_unlock_pressure_low",
+    "parameters": {
+        "threshold": 0.02
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "token_unlock_pressure_low",
+  "parameters": {
+    "threshold": 0.02
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="treasury_accumulation_trigger" description="TRIGGER - requires TreasuryUsd">
+
+Detect treasury value crossing above its moving average.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 3 -- 200 | `20` | Moving-average window |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "treasury_accumulation_trigger",
+    "parameters": {
+        "window": 20
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "treasury_accumulation_trigger",
+  "parameters": {
+    "window": 20
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+<Accordion title="treasury_growing" description="FILTER - requires TreasuryUsd">
+
+Check whether the protocol treasury is growing over the window.
+
+**Parameters**
+
+| Name | Type | Range | Default | Description |
+|------|------|-------|---------|-------------|
+| `window` | `int` | 3 -- 200 | `14` | Lookback for the comparison |
+
+**Example**
+
+<CodeGroup>
+
+```python Python
+from mangrove_kb import RuleRegistry
+
+rule = {
+    "name": "treasury_growing",
+    "parameters": {
+        "window": 14
+    }
+}
+result = RuleRegistry.evaluate(rule, df)
+print(result)  # True or False
+```
+
+```bash cURL
+curl -X POST https://api.mangrovedeveloper.ai/api/v1/execution/evaluate \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "name": "treasury_growing",
+  "parameters": {
+    "window": 14
+  }
+}'
+```
+
+</CodeGroup>
+
+</Accordion>
+
+</AccordionGroup>

--- a/kb_server/services/signal_service.py
+++ b/kb_server/services/signal_service.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from mangrove_kb.registry import RuleRegistry
 from mangrove_kb.docstring_parser import parse_all_signals
-from mangrove_kb.signals import momentum, trend, volume, volatility, patterns, onchain
+from mangrove_kb.signals import momentum, trend, volume, volatility, patterns, onchain, defi_pro
 
 _MODULE_CATEGORY = {
     "momentum": "Momentum",
@@ -17,9 +17,10 @@ _MODULE_CATEGORY = {
     "volatility": "Volatility",
     "patterns": "Patterns",
     "onchain": "On-Chain",
+    "defi_pro": "DeFi Pro",
 }
 
-_SIGNAL_MODULES = [momentum, trend, volume, volatility, patterns, onchain]
+_SIGNAL_MODULES = [momentum, trend, volume, volatility, patterns, onchain, defi_pro]
 
 
 class SignalService:

--- a/mangrove_kb/signals/__init__.py
+++ b/mangrove_kb/signals/__init__.py
@@ -11,6 +11,8 @@ Signal Categories:
     - volatility: Bollinger Bands, ATR, Keltner Channel, Donchian, etc.
     - patterns: Doji, Hammer, Engulfing, MorningStar, InsideBar, NR7, etc.
     - onchain: smart-money flows, exchange flows, whale activity, holder concentration
+    - defi_pro: token-unlock pressure, perp funding regime, ETF-flow momentum,
+      treasury accumulation, lending-rate spread (DeFiLlama Pro)
 """
 
 # Import all signal modules to trigger registration with RuleRegistry
@@ -20,3 +22,4 @@ from mangrove_kb.signals import volume
 from mangrove_kb.signals import volatility
 from mangrove_kb.signals import patterns
 from mangrove_kb.signals import onchain
+from mangrove_kb.signals import defi_pro

--- a/mangrove_kb/signals/defi_pro.py
+++ b/mangrove_kb/signals/defi_pro.py
@@ -1,0 +1,319 @@
+"""DeFiLlama Pro signal families.
+
+These signals consume DeFiLlama Pro alternative-data columns (sourced via the
+paid DeFiLlama API tier and surfaced through MangroveAI's /defi/* Pro routes)
+alongside OHLCV. As with the on-chain signals, the CALLER is responsible for
+populating the named column on the DataFrame (in MangroveAI this is done by the
+eval-time fetcher); when a required column is absent or empty every signal
+fails closed (returns False), exactly like the OHLCV signals.
+
+Five families, each keyed to one Pro column:
+    - token-unlock pressure   -> TokenUnlockPressure  (upcoming unlock supply as
+                                 a fraction of circulating supply; higher = more
+                                 dilution / sell-pressure ahead)
+    - funding-rate regime     -> PerpFundingRate       (aggregated perp funding;
+                                 positive = longs pay shorts)
+    - ETF-flow momentum       -> EtfNetFlow            (net ETF flow, USD;
+                                 positive = inflow)
+    - treasury accumulation   -> TreasuryUsd           (protocol treasury value, USD)
+    - lending-rate spread     -> LendingRateSpread      (borrow minus supply rate;
+                                 widening = rising leverage demand)
+"""
+import logging
+
+import pandas as pd
+
+from mangrove_kb.registry import RuleRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _clean_series(df: pd.DataFrame, column: str) -> "pd.Series | None":
+    """Return the named column as a float Series with NaNs dropped, or None.
+
+    Mirrors signals/onchain.py so callers fail closed (return False) when the
+    Pro column was not populated.
+    """
+    if column not in df.columns:
+        return None
+    series = pd.to_numeric(df[column], errors="coerce").dropna()
+    if series.empty:
+        return None
+    return series
+
+
+# =============================================================================
+# Token-unlock pressure (DeFiLlama emissions/unlocks)
+# =============================================================================
+
+@RuleRegistry.register("token_unlock_pressure_low")
+def token_unlock_pressure_low(df: pd.DataFrame, threshold: float = 0.02) -> bool:
+    """
+    Confirm there is little near-term unlock dilution ahead.
+
+    Type: FILTER
+    Requires: TokenUnlockPressure
+
+    Args:
+        df (pd.DataFrame): DataFrame with a TokenUnlockPressure column (upcoming
+            unlock supply as a fraction of circulating supply, e.g. 0.05 = 5%).
+        threshold (float): Maximum acceptable unlock pressure (a value of 0.02
+            means 2% of circulating supply). Range: 0.005-0.25. Default: 0.02.
+
+    Returns:
+        bool: True if the latest unlock pressure is at or below ``threshold``
+            (i.e. safe from a large imminent supply unlock).
+    """
+    series = _clean_series(df, "TokenUnlockPressure")
+    if series is None:
+        return False
+    return float(series.iloc[-1]) <= threshold
+
+
+@RuleRegistry.register("token_unlock_cliff_ahead")
+def token_unlock_cliff_ahead(
+    df: pd.DataFrame, window: int = 30, z_threshold: float = 2.0, min_pressure: float = 0.03
+) -> bool:
+    """
+    Detect a large upcoming unlock cliff (supply-shock warning).
+
+    Type: TRIGGER
+    Requires: TokenUnlockPressure
+
+    Args:
+        df (pd.DataFrame): DataFrame with a TokenUnlockPressure column.
+        window (int): Prior bars forming the rolling baseline (latest excluded).
+            Range: 5-200. Default: 30.
+        z_threshold (float): Std-devs above the baseline mean the latest pressure
+            must reach to fire. Range: 0.5-5.0. Default: 2.0.
+        min_pressure (float): Floor the latest pressure must also clear, so noise
+            around a tiny baseline does not fire. Range: 0.005-0.5. Default: 0.03.
+
+    Returns:
+        bool: True if the latest unlock pressure both exceeds ``min_pressure``
+            and is at least ``z_threshold`` std-devs above the prior window.
+    """
+    series = _clean_series(df, "TokenUnlockPressure")
+    if series is None or len(series) < window + 1:
+        return False
+
+    baseline = series.iloc[-(window + 1):-1]
+    last = float(series.iloc[-1])
+    std = float(baseline.std())
+    if std == 0 or pd.isna(std):
+        return last >= min_pressure
+    z = (last - float(baseline.mean())) / std
+    return last >= min_pressure and z >= z_threshold
+
+
+# =============================================================================
+# Perp funding-rate regime (DeFiLlama perps)
+# =============================================================================
+
+@RuleRegistry.register("funding_negative_regime")
+def funding_negative_regime(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check for a persistently negative funding regime (shorts pay longs).
+
+    Type: FILTER
+    Requires: PerpFundingRate
+
+    Args:
+        df (pd.DataFrame): DataFrame with a PerpFundingRate column.
+        window (int): Number of recent bars to average. Range: 3-200. Default: 14.
+
+    Returns:
+        bool: True if the mean funding rate over the last ``window`` bars is
+            negative (a contrarian-bullish crowd-positioning condition).
+    """
+    series = _clean_series(df, "PerpFundingRate")
+    if series is None or len(series) < window:
+        return False
+    return float(series.iloc[-window:].mean()) < 0
+
+
+@RuleRegistry.register("funding_flip_positive")
+def funding_flip_positive(df: pd.DataFrame) -> bool:
+    """
+    Detect funding crossing from non-positive to positive on the latest bar.
+
+    Type: TRIGGER
+    Requires: PerpFundingRate
+
+    Args:
+        df (pd.DataFrame): DataFrame with a PerpFundingRate column.
+
+    Returns:
+        bool: True if funding was <= 0 on the prior bar and > 0 on the latest
+            (leverage demand flipping long).
+    """
+    series = _clean_series(df, "PerpFundingRate")
+    if series is None or len(series) < 2:
+        return False
+    return float(series.iloc[-2]) <= 0 < float(series.iloc[-1])
+
+
+# =============================================================================
+# ETF-flow momentum (DeFiLlama ETF flows)
+# =============================================================================
+
+@RuleRegistry.register("etf_inflow_streak")
+def etf_inflow_streak(df: pd.DataFrame, window: int = 5) -> bool:
+    """
+    Confirm sustained net ETF inflows.
+
+    Type: FILTER
+    Requires: EtfNetFlow
+
+    Args:
+        df (pd.DataFrame): DataFrame with an EtfNetFlow column (net flow, USD).
+        window (int): Number of consecutive latest bars that must be positive.
+            Range: 2-60. Default: 5.
+
+    Returns:
+        bool: True if net ETF flow is strictly positive on each of the last
+            ``window`` bars.
+    """
+    series = _clean_series(df, "EtfNetFlow")
+    if series is None or len(series) < window:
+        return False
+    return bool((series.iloc[-window:] > 0).all())
+
+
+@RuleRegistry.register("etf_inflow_spike")
+def etf_inflow_spike(df: pd.DataFrame, window: int = 20, z_threshold: float = 2.0) -> bool:
+    """
+    Detect an unusually large net ETF inflow on the latest bar.
+
+    Type: TRIGGER
+    Requires: EtfNetFlow
+
+    Args:
+        df (pd.DataFrame): DataFrame with an EtfNetFlow column.
+        window (int): Prior bars forming the rolling baseline (latest excluded).
+            Range: 5-200. Default: 20.
+        z_threshold (float): Std-devs above the baseline mean to fire.
+            Range: 0.5-5.0. Default: 2.0.
+
+    Returns:
+        bool: True if the latest net flow is positive and at least
+            ``z_threshold`` std-devs above the preceding window.
+    """
+    series = _clean_series(df, "EtfNetFlow")
+    if series is None or len(series) < window + 1:
+        return False
+    baseline = series.iloc[-(window + 1):-1]
+    last = float(series.iloc[-1])
+    std = float(baseline.std())
+    if std == 0 or pd.isna(std):
+        return False
+    z = (last - float(baseline.mean())) / std
+    return last > 0 and z >= z_threshold
+
+
+# =============================================================================
+# Treasury accumulation (DeFiLlama treasuries)
+# =============================================================================
+
+@RuleRegistry.register("treasury_growing")
+def treasury_growing(df: pd.DataFrame, window: int = 14) -> bool:
+    """
+    Check whether the protocol treasury is growing over the window.
+
+    Type: FILTER
+    Requires: TreasuryUsd
+
+    Args:
+        df (pd.DataFrame): DataFrame with a TreasuryUsd column (treasury value, USD).
+        window (int): Lookback for the comparison. Range: 3-200. Default: 14.
+
+    Returns:
+        bool: True if the latest treasury value is greater than it was
+            ``window`` bars ago (sustainable runway / revenue retention).
+    """
+    series = _clean_series(df, "TreasuryUsd")
+    if series is None or len(series) < window + 1:
+        return False
+    return float(series.iloc[-1]) > float(series.iloc[-(window + 1)])
+
+
+@RuleRegistry.register("treasury_accumulation_trigger")
+def treasury_accumulation_trigger(df: pd.DataFrame, window: int = 20) -> bool:
+    """
+    Detect treasury value crossing above its moving average.
+
+    Type: TRIGGER
+    Requires: TreasuryUsd
+
+    Args:
+        df (pd.DataFrame): DataFrame with a TreasuryUsd column.
+        window (int): Moving-average window. Range: 3-200. Default: 20.
+
+    Returns:
+        bool: True if treasury was at/below its MA on the prior bar and above it
+            on the latest bar.
+    """
+    series = _clean_series(df, "TreasuryUsd")
+    if series is None or len(series) < window + 1:
+        return False
+    ma = series.rolling(window=window).mean()
+    prev, last = series.iloc[-2], series.iloc[-1]
+    prev_ma, last_ma = ma.iloc[-2], ma.iloc[-1]
+    if pd.isna(prev_ma) or pd.isna(last_ma):
+        return False
+    return prev <= prev_ma and last > last_ma
+
+
+# =============================================================================
+# Lending-rate spread (DeFiLlama lending/borrow rates)
+# =============================================================================
+
+@RuleRegistry.register("lending_spread_low")
+def lending_spread_low(df: pd.DataFrame, threshold: float = 0.02) -> bool:
+    """
+    Confirm a calm lending market (narrow borrow-supply spread).
+
+    Type: FILTER
+    Requires: LendingRateSpread
+
+    Args:
+        df (pd.DataFrame): DataFrame with a LendingRateSpread column (borrow rate
+            minus supply rate, as a decimal, e.g. 0.03 = 3%).
+        threshold (float): Maximum spread to consider calm. Range: 0.001-0.5.
+            Default: 0.02.
+
+    Returns:
+        bool: True if the latest spread is at or below ``threshold`` (low
+            leverage demand / no funding stress).
+    """
+    series = _clean_series(df, "LendingRateSpread")
+    if series is None:
+        return False
+    return float(series.iloc[-1]) <= threshold
+
+
+@RuleRegistry.register("lending_spread_widening")
+def lending_spread_widening(df: pd.DataFrame, window: int = 20) -> bool:
+    """
+    Detect the borrow-supply spread crossing above its moving average.
+
+    Type: TRIGGER
+    Requires: LendingRateSpread
+
+    Args:
+        df (pd.DataFrame): DataFrame with a LendingRateSpread column.
+        window (int): Moving-average window. Range: 3-200. Default: 20.
+
+    Returns:
+        bool: True if the spread was at/below its MA on the prior bar and above
+            it on the latest bar (rising leverage demand).
+    """
+    series = _clean_series(df, "LendingRateSpread")
+    if series is None or len(series) < window + 1:
+        return False
+    ma = series.rolling(window=window).mean()
+    prev, last = series.iloc[-2], series.iloc[-1]
+    prev_ma, last_ma = ma.iloc[-2], ma.iloc[-1]
+    if pd.isna(prev_ma) or pd.isna(last_ma):
+        return False
+    return prev <= prev_ma and last > last_ma

--- a/scripts/generate-signal-catalog.py
+++ b/scripts/generate-signal-catalog.py
@@ -27,7 +27,7 @@ sys.path.insert(0, PROJECT_ROOT)
 import mangrove_kb  # noqa: E402
 from mangrove_kb.registry import RuleRegistry  # noqa: E402
 from mangrove_kb.docstring_parser import parse_all_signals  # noqa: E402
-from mangrove_kb.signals import momentum, trend, volume, volatility, patterns, onchain  # noqa: E402
+from mangrove_kb.signals import momentum, trend, volume, volatility, patterns, onchain, defi_pro  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Category classification
@@ -40,6 +40,7 @@ MODULE_CATEGORY = {
     "volatility": "Volatility",
     "patterns": "Patterns",
     "onchain": "On-Chain",
+    "defi_pro": "DeFi Pro",
 }
 
 
@@ -155,7 +156,7 @@ def generate_catalog():
     """Generate the docs/signals/catalog.mdx file."""
 
     # Parse all signals
-    signal_modules = [momentum, trend, volume, volatility, patterns, onchain]
+    signal_modules = [momentum, trend, volume, volatility, patterns, onchain, defi_pro]
     all_signals = parse_all_signals(signal_modules)
 
     # Attach category info
@@ -171,7 +172,7 @@ def generate_catalog():
         })
 
     # Sort by category then name
-    category_order = ["Momentum", "Trend", "Volume", "Volatility", "Patterns", "On-Chain", "Other"]
+    category_order = ["Momentum", "Trend", "Volume", "Volatility", "Patterns", "On-Chain", "DeFi Pro", "Other"]
     enriched.sort(key=lambda s: (category_order.index(s["category"]) if s["category"] in category_order else 99, s["name"]))
 
     # Group by category
@@ -268,7 +269,7 @@ def generate_catalog():
     index_lines.append("| Category | Count | Page |")
     index_lines.append("|---|---|---|")
     for cat, sigs in grouped.items():
-        slug = cat.lower()
+        slug = cat.lower().replace(" ", "-")
         index_lines.append(f"| {cat} | {len(sigs)} | [/signals/catalog/{slug}](/signals/catalog/{slug}) |")
     index_lines.append("")
     index_lines.append("## All signals")
@@ -278,7 +279,7 @@ def generate_catalog():
     for sig in enriched:
         requires_str = ", ".join(sig.get("requires", [])) if sig.get("requires") else "None"
         sig_type = sig.get("type", "")
-        slug = sig["category"].lower()
+        slug = sig["category"].lower().replace(" ", "-")
         index_lines.append(
             f"| [`{sig['name']}`](/signals/catalog/{slug}) "
             f"| {sig_type} | {sig['category']} | {requires_str} |"
@@ -302,11 +303,11 @@ def generate_catalog():
     os.makedirs(category_dir, exist_ok=True)
 
     for cat, sigs in grouped.items():
-        slug = cat.lower()
+        slug = cat.lower().replace(" ", "-")
         cat_lines = []
         cat_lines.append("---")
         cat_lines.append(f'title: "{cat} Signals"')
-        cat_lines.append(f'description: "{len(sigs)} {cat.lower()} trading signals with parameters, descriptions, and examples."')
+        cat_lines.append(f'description: "{len(sigs)} {cat.lower().replace(" ", "-")} trading signals with parameters, descriptions, and examples."')
         cat_lines.append("---")
         cat_lines.append("")
         cat_lines.append(f"# {cat} Signals")

--- a/tests/test_api_signals.py
+++ b/tests/test_api_signals.py
@@ -12,7 +12,7 @@ class TestSignalEndpoints:
         resp = client.get("/api/signals")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["total"] == 233
+        assert data["total"] == 243
 
     def test_list_signals_filter_category(self):
         resp = client.get("/api/signals?category=Momentum")
@@ -22,7 +22,7 @@ class TestSignalEndpoints:
     def test_list_signals_filter_type(self):
         resp = client.get("/api/signals?signal_type=TRIGGER")
         assert resp.status_code == 200
-        assert resp.json()["total"] == 112
+        assert resp.json()["total"] == 117
 
     def test_get_signal(self):
         resp = client.get("/api/signals/rsi_oversold")

--- a/tests/test_defi_pro_signals.py
+++ b/tests/test_defi_pro_signals.py
@@ -1,0 +1,121 @@
+"""
+Validation + behavioral tests for the DeFiLlama Pro signal families.
+
+Mirrors tests/test_onchain_signals.py: structural checks via the docstring
+parser (Type/Requires tags, registration) plus synthetic-data exercises that
+confirm each signal fires under its intended condition and fails closed when
+its Pro column is absent.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from mangrove_kb.registry import RuleRegistry
+from mangrove_kb.signals import defi_pro as defi_pro_signals
+from mangrove_kb.docstring_parser import parse_all_signals
+
+
+@pytest.fixture(scope="session")
+def parsed() -> dict:
+    return parse_all_signals([defi_pro_signals])
+
+
+# --------------------------------------------------------------------------- #
+# Coverage                                                                    #
+# --------------------------------------------------------------------------- #
+class TestDefiProCoverage:
+    EXPECTED_TRIGGER_COUNT = 5  # cliff_ahead, funding_flip, etf_spike, treasury_trigger, spread_widening
+    EXPECTED_FILTER_COUNT = 5   # unlock_low, funding_negative, etf_streak, treasury_growing, spread_low
+    EXPECTED_TOTAL = 10
+
+    def test_total_count(self, parsed):
+        assert len(parsed) == self.EXPECTED_TOTAL, sorted(parsed)
+
+    def test_trigger_count(self, parsed):
+        triggers = [k for k, v in parsed.items() if v["type"] == "TRIGGER"]
+        assert len(triggers) == self.EXPECTED_TRIGGER_COUNT, sorted(triggers)
+
+    def test_filter_count(self, parsed):
+        filters = [k for k, v in parsed.items() if v["type"] == "FILTER"]
+        assert len(filters) == self.EXPECTED_FILTER_COUNT, sorted(filters)
+
+    def test_all_registered(self, parsed):
+        for name in parsed:
+            assert name in RuleRegistry._registry, name
+
+
+# --------------------------------------------------------------------------- #
+# Structural validation -- every signal requires exactly one known Pro column #
+# --------------------------------------------------------------------------- #
+class TestDefiProMetadata:
+    VALID_COLUMNS = {
+        "TokenUnlockPressure",
+        "PerpFundingRate",
+        "EtfNetFlow",
+        "TreasuryUsd",
+        "LendingRateSpread",
+    }
+
+    def test_requires_known_columns(self, parsed):
+        for name, meta in parsed.items():
+            cols = set(meta["requires"])
+            assert cols, f"{name} declares no Requires column"
+            assert cols <= self.VALID_COLUMNS, f"{name} requires unknown column(s): {cols - self.VALID_COLUMNS}"
+
+
+# --------------------------------------------------------------------------- #
+# Behavioral -- fires under intended condition, stays quiet / fails closed     #
+# --------------------------------------------------------------------------- #
+class TestDefiProBehavior:
+    def test_fail_closed_when_column_absent(self):
+        # An OHLCV-only frame (no Pro columns) must make every signal return False.
+        df = pd.DataFrame({"Close": np.linspace(100, 110, 40)})
+        for name in (
+            "token_unlock_pressure_low", "token_unlock_cliff_ahead",
+            "funding_negative_regime", "funding_flip_positive",
+            "etf_inflow_streak", "etf_inflow_spike",
+            "treasury_growing", "treasury_accumulation_trigger",
+            "lending_spread_low", "lending_spread_widening",
+        ):
+            assert RuleRegistry._registry[name](df) is False, name
+
+    def test_token_unlock_pressure_low(self):
+        assert defi_pro_signals.token_unlock_pressure_low(pd.DataFrame({"TokenUnlockPressure": [0.01]})) is True
+        assert defi_pro_signals.token_unlock_pressure_low(pd.DataFrame({"TokenUnlockPressure": [0.10]})) is False
+
+    def test_token_unlock_cliff_ahead(self):
+        vals = [0.005] * 30 + [0.20]  # flat baseline, then a big cliff
+        assert defi_pro_signals.token_unlock_cliff_ahead(pd.DataFrame({"TokenUnlockPressure": vals})) is True
+
+    def test_funding_negative_regime(self):
+        assert defi_pro_signals.funding_negative_regime(pd.DataFrame({"PerpFundingRate": [-0.01] * 14})) is True
+        assert defi_pro_signals.funding_negative_regime(pd.DataFrame({"PerpFundingRate": [0.01] * 14})) is False
+
+    def test_funding_flip_positive(self):
+        assert defi_pro_signals.funding_flip_positive(pd.DataFrame({"PerpFundingRate": [-0.002, 0.003]})) is True
+        assert defi_pro_signals.funding_flip_positive(pd.DataFrame({"PerpFundingRate": [0.001, 0.003]})) is False
+
+    def test_etf_inflow_streak(self):
+        assert defi_pro_signals.etf_inflow_streak(pd.DataFrame({"EtfNetFlow": [1e6] * 5})) is True
+        assert defi_pro_signals.etf_inflow_streak(pd.DataFrame({"EtfNetFlow": [1e6, 1e6, -1e6, 1e6, 1e6]})) is False
+
+    def test_etf_inflow_spike(self):
+        # Baseline needs variance (std>0) for a z-score, like smart_money_inflow_spike.
+        vals = list(np.linspace(1.0e5, 1.2e5, 20)) + [5.0e6]
+        assert defi_pro_signals.etf_inflow_spike(pd.DataFrame({"EtfNetFlow": vals})) is True
+
+    def test_treasury_growing(self):
+        assert defi_pro_signals.treasury_growing(pd.DataFrame({"TreasuryUsd": np.linspace(1e8, 2e8, 20)})) is True
+        assert defi_pro_signals.treasury_growing(pd.DataFrame({"TreasuryUsd": np.linspace(2e8, 1e8, 20)})) is False
+
+    def test_treasury_accumulation_trigger(self):
+        vals = [1.0e8] * 20 + [1.5e8]  # below flat MA, then jumps above
+        assert defi_pro_signals.treasury_accumulation_trigger(pd.DataFrame({"TreasuryUsd": vals})) is True
+
+    def test_lending_spread_low(self):
+        assert defi_pro_signals.lending_spread_low(pd.DataFrame({"LendingRateSpread": [0.01]})) is True
+        assert defi_pro_signals.lending_spread_low(pd.DataFrame({"LendingRateSpread": [0.08]})) is False
+
+    def test_lending_spread_widening(self):
+        vals = [0.02] * 20 + [0.06]
+        assert defi_pro_signals.lending_spread_widening(pd.DataFrame({"LendingRateSpread": vals})) is True

--- a/tests/test_signal_service.py
+++ b/tests/test_signal_service.py
@@ -8,7 +8,7 @@ class TestSignalServiceMetadata:
 
     def test_list_signals_returns_all(self):
         signals = self.service.list_signals()
-        assert len(signals) == 233
+        assert len(signals) == 243
 
     def test_list_signals_filter_by_category(self):
         momentum = self.service.list_signals(category="Momentum")
@@ -16,7 +16,7 @@ class TestSignalServiceMetadata:
 
     def test_list_signals_filter_by_type(self):
         triggers = self.service.list_signals(signal_type="TRIGGER")
-        assert len(triggers) == 112
+        assert len(triggers) == 117
 
     def test_get_signal_exists(self):
         signal = self.service.get_signal("rsi_oversold")


### PR DESCRIPTION
## Phase 5 (KB) of the DeFiLlama Pro program

Adds 10 signals across 5 families that consume the DeFiLlama **Pro** alt-data columns now surfaced by MangroveAI's `/defi/*` Pro routes (cap PR #697, Roots caching #60). Mirrors the existing on-chain signal pattern exactly: `@RuleRegistry.register`, fail-closed when the column is absent, `Type:`/`Requires:` docstring tags.

| Requires column | FILTER | TRIGGER |
|---|---|---|
| `TokenUnlockPressure` | `token_unlock_pressure_low` | `token_unlock_cliff_ahead` |
| `PerpFundingRate` | `funding_negative_regime` | `funding_flip_positive` |
| `EtfNetFlow` | `etf_inflow_streak` | `etf_inflow_spike` |
| `TreasuryUsd` | `treasury_growing` | `treasury_accumulation_trigger` |
| `LendingRateSpread` | `lending_spread_low` | `lending_spread_widening` |

### Wiring
- Registered in `signals/__init__.py`.
- Added to `signal_service._SIGNAL_MODULES` + `_MODULE_CATEGORY` ("DeFi Pro") so the signal **API/MCP** list and serve them.
- Added to the catalog generator (module list + category) and **fixed its slug derivation** to hyphenate spaces — category page filenames were `cat.lower()` only, so a multi-word category produced a filename with a space (`defi pro.mdx`). Now `defi-pro.mdx`; On-Chain etc. unaffected.
- Regenerated `docs/signals/catalog.mdx` + `catalog/defi-pro.mdx`.

### Tests
`tests/test_defi_pro_signals.py` — 16 tests: coverage (5 TRIGGER / 5 FILTER, all registered), `Requires` validates to the 5 known columns, and behavioral (each fires under its intended condition + fails closed when the column is absent). **Full signal suite: 61 passed / 0 failed** — no global count regressions.

### Consumer note (Phase 5b, separate MangroveAI PR)
These signals read **caller-populated** columns. To make them fire in backtests/eval, the MangroveAI eval-time fetcher must populate `TokenUnlockPressure` / `PerpFundingRate` / `EtfNetFlow` / `TreasuryUsd` / `LendingRateSpread` (via the `on_chain_fetcher` pattern, pulling from the `/defi/*` Pro routes). Until then the signals are registered, documented, and API/MCP-discoverable, and fail closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)