### PR TITLE
build(docs): scaffold + document docs-search provisioning (search dead for all users) [DRAFT]

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -91,6 +91,31 @@ ENV NODE_PATH=/app/node_modules
 ENV NODE_ENV=production
 ENV HOSTNAME=0.0.0.0
 
+# --- Documentation search provisioning (see issue #85) -----------------------
+# Mintlify's search/assistant is a HOSTED feature backed by Mintlify's cloud
+# (a Trieve vector DB plus the site's content indexed into it). It is NOT part
+# of this self-hosted client bundle, so search is non-functional here until a
+# backend is provisioned. The downloaded client's search routes forward to:
+#
+#   * public search box           -> /_mintlify/api-public/search/<subdomain>
+#         forwards to ${API_ENDPOINT:-http://localhost:5000}/api/end-user-public/<subdomain>/search
+#   * "Ask a question" assistant  -> /_mintlify/api/search
+#         forwards to ${NEXT_PUBLIC_AI_MESSAGE_HOST}/api/end-user/search
+#         (authorized with the public assistant key NEXT_PUBLIC_TRIEVE_API_KEY,
+#          a Mintlify `mint_dsc_...` token)
+#
+# All are read at RUNTIME by the standalone server, so the real values belong in
+# deploy config (Cloud Run env/secret in MangroveAI), NOT baked here. These
+# declarations document the contract and give deploy an explicit override
+# surface. The defaults are no-ops: empty API_ENDPOINT falls back to the built-in
+# localhost default, and Mintlify's env schema treats the empty NEXT_PUBLIC_*
+# values as undefined -- so they preserve today's behavior exactly (no
+# regression). They do NOT by themselves enable search: that also requires the
+# docs content to be indexed into the chosen backend. See issue #85 for options.
+ENV API_ENDPOINT=""
+ENV NEXT_PUBLIC_AI_MESSAGE_HOST=""
+ENV NEXT_PUBLIC_TRIEVE_API_KEY=""
+
 EXPOSE 3000
 
 # Start nginx (background) then Next.js standalone server on port 3001

--- a/findings/docs-search-provisioning.md
+++ b/findings/docs-search-provisioning.md
@@ -1,0 +1,86 @@
+# Docs-site search — why it's dead, and how to turn it on
+
+**Status:** broken in production for everyone, signed in or not (tracked in issue #85).
+The search box at `docs.mangrovedeveloper.ai` renders but returns no results — it has no
+search backend. This is an **architecture / provisioning** gap, not a content bug.
+
+## Root cause
+
+The docs site is **self-hosted**, not deployed on Mintlify's platform. `Dockerfile.docs`
+runs `mintlify dev` only to download Mintlify's pre-built Next.js client
+(`~/.mintlify/mint/apps/client`), then serves that client statically via nginx + the Next.js
+standalone server. `build-docs.yml` builds this `mangrove-ai-docs` image; MangroveAI deploys
+it to Cloud Run behind `docs.mangrovedeveloper.ai`.
+
+Mintlify's **search/assistant is a hosted feature** — it needs a Mintlify cloud backend (a
+Trieve vector DB) **with the site's content indexed into it**. That backend is not part of the
+self-hosted client bundle, and the self-hosted build never indexes content into Mintlify's
+cloud. So the search box has nothing to call.
+
+Reverse-engineering the pinned client (`mintlify@4.2.414`, client bundle `0.0.2662`) shows
+exactly where the box tries to go — two routes, both pointing at an unset backend:
+
+| Surface | Client route | Forwards to | Env it needs |
+|---|---|---|---|
+| Public search box (no login) | `POST /_mintlify/api-public/search/<subdomain>` | `${API_ENDPOINT:-http://localhost:5000}/api/end-user-public/<subdomain>/search` | `API_ENDPOINT` (+ optional `ADMIN_TOKEN`) |
+| "Ask a question" assistant | `POST /_mintlify/api/search` | `${NEXT_PUBLIC_AI_MESSAGE_HOST}/api/end-user/search` | `NEXT_PUBLIC_AI_MESSAGE_HOST`, `NEXT_PUBLIC_TRIEVE_API_KEY` |
+
+In the self-hosted build none of `API_ENDPOINT` / `NEXT_PUBLIC_AI_MESSAGE_HOST` /
+`NEXT_PUBLIC_TRIEVE_API_KEY` is set, so `API_ENDPOINT` falls back to `http://localhost:5000`
+(nothing listening) and the assistant host is undefined. Every query fails at the forward.
+
+> The exact dead-state UI differs by client/runtime: an older/local-CLI client renders the
+> explicit **"Login into CLI to enable search"** prompt (what the tester's 2026-06-19
+> screenshot shows — Mintlify only enables CLI-preview search for an authenticated CLI user);
+> the current pinned client renders a normal **"Search…"** box that simply returns nothing.
+> Both are the same root cause: no search backend is provisioned.
+
+The earlier planning docs assumed Mintlify search "just works with no configuration." That is
+true **only when hosting on Mintlify's platform** (they index content and provision the backend
+for you), which this repo does not do.
+
+## Resolution options (pick one — this is a product/infra decision)
+
+1. **Host the docs on Mintlify's platform** (the original plan). Search + assistant work out of
+   the box (Mintlify indexes content and provisions the backend). Cost: a Mintlify plan + a DNS
+   change. Least code.
+2. **Keep self-hosting, provision Mintlify's cloud search.** Index the site via Mintlify's API
+   (a CI step) and set, at deploy time (Cloud Run env/secret in MangroveAI — read at runtime by
+   the standalone server):
+   - `NEXT_PUBLIC_AI_MESSAGE_HOST` — Mintlify search/assistant API host
+   - `NEXT_PUBLIC_TRIEVE_API_KEY` — public assistant key (`mint_dsc_…`)
+   - `API_ENDPOINT` — Mintlify API host backing the public search box
+   `Dockerfile.docs` now declares all three (empty by default — a no-op, see below) so this is
+   an explicit override surface. Requires a Mintlify account/secret + a CI indexing step.
+3. **Self-hosted search, no Mintlify cloud.** Stand up a small backend that implements the
+   public-search contract above (`POST /api/end-user-public/<subdomain>/search`, Trieve-shaped
+   response) and point `API_ENDPOINT` at it — backed by a static index (e.g.
+   [Pagefind](https://pagefind.app/) built over the docs at image-build time) or by Mangrove's
+   **existing** free, no-auth full-text endpoint `https://kb.mangrovedeveloper.ai/api/search`.
+   Most consistent with the current self-hosted model; most code (and it must match Mintlify's
+   response schema, which is version-pinned to the client bundle).
+
+## The no-op build change in this PR
+
+`Dockerfile.docs` declares `API_ENDPOINT`, `NEXT_PUBLIC_AI_MESSAGE_HOST`, and
+`NEXT_PUBLIC_TRIEVE_API_KEY` with empty defaults. Empty `API_ENDPOINT` falls back to the
+client's built-in `http://localhost:5000`, and Mintlify's env schema (`emptyStringAsUndefined`)
+treats the empty `NEXT_PUBLIC_*` values as undefined — so **behavior is identical to today**.
+The declarations only document the contract and give deploy an explicit override surface. They
+do **not** enable search on their own; that needs the chosen option above (plus indexed
+content). See issue #85.
+
+## Verifying the dead state (live prod + local container)
+
+```bash
+# Live production — the real public-search route has no backend:
+curl -s -o /dev/null -w "%{http_code}\n" -X POST \
+  https://docs.mangrovedeveloper.ai/_mintlify/api-public/search/docs \
+  -H 'Content-Type: application/json' -d '{"query":"backtest"}'
+# -> a non-200 (no search backend provisioned)
+
+# Mangrove already runs a free, no-auth full-text search that *does* work — it is just
+# not wired into the docs UI (this is the basis for option 3):
+curl -s "https://kb.mangrovedeveloper.ai/api/search?q=backtest" | head -c 200
+# -> {"query":"backtest","total_results":20,"results":[ ... ]}
+```


### PR DESCRIPTION
> ⚠️ DRAFT — this scaffolds + documents the fix but does NOT make search return results on its own; turning search on is a product/infra decision (issue #85).

## BLUF

The docs-site search box at `docs.mangrovedeveloper.ai` is **dead for everyone, signed in or
not** — it has no search backend. The tester saw it as *"Login into CLI to enable search"* with
no usable input (older/local-CLI client); the current client shows a *"Search…"* box that
simply returns nothing. Root cause is **architecture, not content**: we self-host Mintlify's
pre-built client, but Mintlify search is a *hosted* feature (a cloud vector DB with the site's
content indexed into it) that the self-hosted build never provisions.

This PR makes the build side explicit and documents the decision; it is a **draft** because a
working fix requires choosing one of three provisioning paths (below), each needing a Mintlify
account/secret or a new self-hosted search service. **It clears the draft once a chosen backend
is provisioned and a real query through `POST /_mintlify/api-public/search/<subdomain>` returns
results** (i.e. the human picks an option in #85 and wires the backend + indexed content).

## What's wrong (precise routes)

Reverse-engineering the pinned client (`mintlify@4.2.414`) shows the two search surfaces and the
unset backends they forward to:

| Surface | Client route | Forwards to | Needs |
|---|---|---|---|
| Public search box (no login) | `POST /_mintlify/api-public/search/<subdomain>` | `${API_ENDPOINT:-http://localhost:5000}/api/end-user-public/<subdomain>/search` | `API_ENDPOINT` (+ optional `ADMIN_TOKEN`) |
| "Ask a question" assistant | `POST /_mintlify/api/search` | `${NEXT_PUBLIC_AI_MESSAGE_HOST}/api/end-user/search` | `NEXT_PUBLIC_AI_MESSAGE_HOST`, `NEXT_PUBLIC_TRIEVE_API_KEY` |

The self-hosted build sets none, so `API_ENDPOINT` falls back to `http://localhost:5000` (nothing
there) and every query fails. (The original bug report's "404" was a wrong-path probe of
`/api/search`; the real routes are above and they **500**.)

## Change

- **`Dockerfile.docs`** — declare `API_ENDPOINT`, `NEXT_PUBLIC_AI_MESSAGE_HOST`,
  `NEXT_PUBLIC_TRIEVE_API_KEY` with **empty (no-op) defaults**. These are read at *runtime* by
  the standalone server, so real values belong in MangroveAI's Cloud Run env/secret; declaring
  them documents the contract and gives deploy an explicit override surface. Empty `API_ENDPOINT`
  keeps the built-in localhost fallback and Mintlify's env schema treats the empty `NEXT_PUBLIC_*`
  as undefined → **behavior is identical to today (no regression)**.
- **`findings/docs-search-provisioning.md`** — exact root cause, live evidence, and the three
  resolution options with the env each needs.

## Resolution options (the decision this draft unblocks — see #85)

1. **Host docs on Mintlify's platform** — search works out of the box (they index + provision).
   Cost: a Mintlify plan + DNS. Least code.
2. **Keep self-hosting, provision Mintlify cloud search** — index via Mintlify's API (CI step) and
   set the three env values at deploy time. Needs a Mintlify account/secret.
3. **Self-hosted search, no Mintlify cloud** — stand up a backend implementing
   `POST /api/end-user-public/<subdomain>/search` (Trieve-shaped) and point `API_ENDPOINT` at it,
   backed by a static index (Pagefind) or by Mangrove's **existing** free, no-auth
   `https://kb.mangrovedeveloper.ai/api/search`. Most consistent with self-hosting; most code.

## Verification (real, throwaway containers — torn down after)

Built `mangrove-docs-fix:verify` from this branch's `Dockerfile.docs` and ran it.

**1. Container is healthy; search is the only dead part (default config):**
```
GET  /api-reference/overview                         -> HTTP 200   (docs render fine)
POST /_mintlify/api-public/search/docs               -> HTTP 500   (public box: backend absent)
POST /_mintlify/api/search                           -> HTTP 500   (assistant: backend absent)
```
This reproduces the bug through the **real** routes, and matches live prod:
```
POST https://docs.mangrovedeveloper.ai/_mintlify/api-public/search/docs  -> HTTP 500
```

**2. The env lever works end-to-end — same real route, `API_ENDPOINT` pointed at a stub backend
on a shared docker network:**
```
POST /_mintlify/api-public/search/docs   body={"query":"backtest strategy lifecycle"}
 -> HTTP 200
 -> {"stub_backend":true,"received_path":"/api/end-user-public/docs/search",
     "results":[{"title":"STUB RESULT — forwarding works",
                 "query_echo":"{\"query\":\"backtest strategy lifecycle\"}"}]}

# stub backend log (proves the docs route forwarded the query):
STUB RECEIVED: POST /api/end-user-public/docs/search  body=b'{"query":"backtest strategy lifecycle"}'
```

**Honest scope:** this proves the docs route forwards to whatever `API_ENDPOINT` points at — i.e.
the enablement lever is correct and wired. It does **not** prove real search results, because
that needs a real (Mintlify or self-hosted) backend with the docs content indexed — the product
decision in #85. Hence draft.

Refs #85 (not `Fixes`: merging this scaffolding alone does not resolve search).
