### PR TITLE
docs: reconcile DeFiLlama Pro coverage (5 Pro endpoints + gate + cap)

### DIFF
--- a/docs/api-reference/defi.mdx
+++ b/docs/api-reference/defi.mdx
@@ -1,6 +1,6 @@
 ---
 title: "DeFi API"
-description: "DeFi metrics — protocol TVL, chain TVL, and stablecoin supply via DeFiLlama."
+description: "DeFi metrics via DeFiLlama — TVL, chain TVL, stablecoins (any plan); plus Pro: token unlocks, perp funding, treasuries, ETF flows, lending rates."
 ---
 
 # DeFi API
@@ -154,10 +154,46 @@ print(metrics["total_supply_usd"])
 }
 ```
 
+## Pro endpoints
+
+These five endpoints expose the paid DeFiLlama **Pro** tier. They require a
+**Pro, Startup, or Enterprise** plan (an unentitled plan returns `403`
+`TIER_UPGRADE_REQUIRED`) and share a **1,000 calls/account/month** budget
+(`429 quota_exceeded` once exhausted). Agents paying per call via x402 are not
+subscription-gated. Each returns a `{ "success": true, "count": N, "data": [...] }`
+envelope.
+
+| Endpoint | Returns | SDK method |
+|---|---|---|
+| `GET /defi/token-unlocks` | token unlock schedules + supply metrics | `client.defi.get_token_unlocks()` |
+| `GET /defi/perp-funding` | aggregated perpetual funding rates | `client.defi.get_perp_funding()` |
+| `GET /defi/treasuries` | protocol treasury holdings | `client.defi.get_treasuries()` |
+| `GET /defi/etf-flows` | crypto ETF net flows | `client.defi.get_etf_flows()` |
+| `GET /defi/lending-rates` | lending / borrow rates | `client.defi.get_lending_borrow_rates()` |
+
+<CodeGroup>
+```bash cURL
+curl -H "Authorization: Bearer YOUR_API_KEY" \
+  "https://api.mangrovedeveloper.ai/api/v1/defi/token-unlocks"
+```
+```python Python
+from mangrove_ai import MangroveAI
+
+client = MangroveAI()  # reads MANGROVE_API_KEY
+unlocks = client.defi.get_token_unlocks()
+print(unlocks.count)
+```
+</CodeGroup>
+
+The SDK ships a runnable quickstart for all five at `examples/defi_pro.py` (with
+403/429 handling).
+
 ## Error Codes
 
 | Code | HTTP Status | Description |
 |------|-------------|-------------|
 | `AUTH_REQUIRED` | 401 | Missing or invalid bearer token |
+| `TIER_UPGRADE_REQUIRED` | 403 | Pro endpoint requested on a plan without `defi_pro` (Pro/Startup/Enterprise required) |
 | `RESOURCE_NOT_FOUND` | 404 | Unknown protocol or chain slug |
+| `quota_exceeded` | 429 | Monthly DeFiLlama Pro cap reached (1,000 calls/account/month) |
 | `INTERNAL_ERROR` | 500 | Upstream provider (DeFiLlama) error |

--- a/docs/data-providers.mdx
+++ b/docs/data-providers.mdx
@@ -16,7 +16,7 @@ We surface coverage honestly. Where we expose 100% of a provider's plan, we say 
 | **Nansen** | Pro | `/on-chain/*` + `/crypto-assets/{token-holders,flow-intelligence,smart-money/*}` | Smart-money, Token God Mode (incl. hourly `tgm/flows` series), + `/v1beta1` backtesting family |
 | **WhaleAlert** | **Developer** | `/on-chain/{whale-transactions,exchange-flows,whale-activity}` | Full Developer surface; **30-day history cap**, ~10 req/min |
 | **X (Twitter)** | Pro v2 | `/social/*` | partial -- sentiment, mentions, influence |
-| **DeFiLlama** | API tier | `/defi/*` | partial -- protocol TVL, chain TVL, stablecoin metrics |
+| **DeFiLlama** | API tier | `/defi/*` | TVL/chain/stablecoins (any plan) + Pro: token unlocks, perp funding, treasuries, ETF flows, lending rates (Pro/Startup/Enterprise, capped 1k/mo) |
 | **CoinAPI** | Startup | `/crypto-assets/{ohlcv,market-data,symbols,exchanges}` | partial -- OHLCV + market data |
 | **CoinGecko** | Analyst | `/crypto-assets/{trending,global-market,market-data}` | partial -- discovery + macro |
 | **Kraken** | Public REST | `/crypto-assets/ohlcv?provider=kraken` | OHLCV fallback |
@@ -106,15 +106,28 @@ Backed by X API v2 (Pro tier). We currently expose three derived surfaces.
 
 Full-archive search (`tweets/search/all`) is available at our tier but not yet exposed as a dedicated route. Open an issue or contact us if it would unblock a use case.
 
-## DeFiLlama -- partial
+## DeFiLlama
 
-Three high-traffic endpoints from the DeFiLlama API tier. Full Pro-tier coverage (yields, options, hacks, raises, unlocks, liquidity-depth, active-users) is on the roadmap.
+Eight endpoints from the DeFiLlama API tier. The three TVL/stablecoin routes are
+available on any plan. The five **Pro** routes (token unlocks, perp funding,
+treasuries, ETF flows, lending rates) require a **Pro, Startup, or Enterprise**
+plan -- an unentitled plan gets `403 TIER_UPGRADE_REQUIRED` -- and share a
+**1,000 calls/account/month** budget (`429 quota_exceeded` past the cap). Agents
+paying per call via x402 are not subscription-gated.
 
-| Capability | Mangrove route | SDK method |
-|---|---|---|
-| Protocol TVL | `GET /defi/protocol/{protocol}/tvl` | `client.defi.get_protocol_tvl(protocol)` |
-| Chain TVL | `GET /defi/chain/{chain}/tvl` | `client.defi.get_chain_tvl(chain)` |
-| Stablecoin metrics | `GET /defi/stablecoins/metrics` | `client.defi.get_stablecoin_metrics()` |
+| Capability | Plan | Mangrove route | SDK method |
+|---|---|---|---|
+| Protocol TVL | any | `GET /defi/protocol/{protocol}/tvl` | `client.defi.get_protocol_tvl(protocol)` |
+| Chain TVL | any | `GET /defi/chain/{chain}/tvl` | `client.defi.get_chain_tvl(chain)` |
+| Stablecoin metrics | any | `GET /defi/stablecoins/metrics` | `client.defi.get_stablecoin_metrics()` |
+| Token unlocks | Pro | `GET /defi/token-unlocks` | `client.defi.get_token_unlocks()` |
+| Perp funding | Pro | `GET /defi/perp-funding` | `client.defi.get_perp_funding()` |
+| Treasuries | Pro | `GET /defi/treasuries` | `client.defi.get_treasuries()` |
+| ETF flows | Pro | `GET /defi/etf-flows` | `client.defi.get_etf_flows()` |
+| Lending rates | Pro | `GET /defi/lending-rates` | `client.defi.get_lending_borrow_rates()` |
+
+Remaining Pro families (yields, options, hacks, raises, liquidity-depth,
+active-users) are on the roadmap.
 
 ## CoinAPI + CoinGecko -- price + market data
 

--- a/docs/sdks/mangroveai.mdx
+++ b/docs/sdks/mangroveai.mdx
@@ -51,7 +51,7 @@ The client exposes these service attributes, each mapping to a domain in the RES
 | `client.ai_copilot` | Conversational strategy creation |
 | `client.crypto_assets` | Asset metadata, OHLCV, market data |
 | `client.on_chain` | Smart-money flows, DEX/perp trades, whale activity (Nansen + WhaleAlert) -- see [On-Chain API](/api-reference/on-chain) |
-| `client.defi` | Protocol/chain TVL, stablecoin metrics (DeFiLlama) -- see [DeFi API](/api-reference/defi) |
+| `client.defi` | TVL/chain/stablecoins (any plan) + Pro: token unlocks, perp funding, treasuries, ETF flows, lending rates (Pro/Startup/Enterprise, 1k/mo cap) -- see [DeFi API](/api-reference/defi) |
 | `client.social` | Topic sentiment, mentions, user influence (X / Twitter) -- see [Social API](/api-reference/social) |
 | `client.docs` | Search the knowledge base from your code |
 | `client.kb` | Signal and indicator metadata via the KB server |


### PR DESCRIPTION
The DeFiLlama Pro endpoints shipped (MangroveAI #696 / #697), but the public docs still described DeFiLlama as "partial — 3 endpoints" with unlocks "on the roadmap." Reconciles them.

- **`data-providers.mdx`** — DeFiLlama section now lists all **8** endpoints (3 any-plan + 5 Pro), the Pro tier gate (`403 TIER_UPGRADE_REQUIRED`), and the **1,000 calls/account/month** cap (`429`); coverage-table row updated.
- **`api-reference/defi.mdx`** — added a **Pro endpoints** section (5 routes + SDK methods + a cURL/Python example) and `403`/`429` rows to the error-code table.
- **`sdks/mangroveai.mdx`** — `client.defi` summary now reflects the Pro families + cap.

Part of closing the loose ends from the DeFiLlama Pro program (the editorial/doc surfaces that `/propagate-pricing` doesn't reconcile). Companion: MangroveAI #705 (portal copy + billable-endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)