### PR TITLE
docs(market-data): correct dead mangrovetrader.com hosts to mangrove.io

### DIFF
--- a/docs/api-reference/market-data.mdx
+++ b/docs/api-reference/market-data.mdx
@@ -11,9 +11,9 @@ The Market Data API provides access to real-time and historical market data incl
 
 | Environment | URL |
 |-------------|-----|
-| Dev | `https://dev-api.mangrovetrader.com` |
-| Test | `https://test-api.mangrovetrader.com` |
-| Prod | `https://api.mangrovetrader.com` |
+| Dev | `https://test-api.mangrove.io` |
+| Test | `https://test-api.mangrove.io` |
+| Prod | `https://api.mangrove.io` |
 
 All endpoints follow the pattern: `GET /api/v1/marketdata/{endpoint}`
 
@@ -80,7 +80,7 @@ The Market Data API requires Bearer token authentication.
 `GET /api/v1/marketdata/trades/{base}/{quote}/latest`
 
 ```bash
-curl -X GET "https://dev-api.mangrovetrader.com/api/v1/marketdata/trades/BTC/USDT/latest" \
+curl -X GET "https://test-api.mangrove.io/api/v1/marketdata/trades/BTC/USDT/latest" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -116,7 +116,7 @@ curl -X GET "https://dev-api.mangrovetrader.com/api/v1/marketdata/trades/BTC/USD
 | `period` | string | yes | `ONE_MINUTE`, `FIVE_MINUTES`, `FIFTEEN_MINUTES`, `THIRTY_MINUTES`, `ONE_HOUR`, `FOUR_HOURS`, `ONE_DAY` |
 
 ```bash
-curl -X GET "https://dev-api.mangrovetrader.com/api/v1/marketdata/ohlcv/BTC/USDT/latest?period=ONE_HOUR" \
+curl -X GET "https://test-api.mangrove.io/api/v1/marketdata/ohlcv/BTC/USDT/latest?period=ONE_HOUR" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -127,7 +127,7 @@ curl -X GET "https://dev-api.mangrovetrader.com/api/v1/marketdata/ohlcv/BTC/USDT
 Returns 1-minute bars for the specified time range.
 
 ```bash
-curl -X GET "https://dev-api.mangrovetrader.com/api/v1/marketdata/ohlcv/BTC/USDT/interval?start_time=2025-12-04T12:00:00Z&end_time=2025-12-04T13:00:00Z" \
+curl -X GET "https://test-api.mangrove.io/api/v1/marketdata/ohlcv/BTC/USDT/interval?start_time=2025-12-04T12:00:00Z&end_time=2025-12-04T13:00:00Z" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -142,22 +142,22 @@ Returns a single OHLCV bar for a specific period and end time.
 <CodeGroup>
 ```bash cURL
 # Get latest trade
-curl -X GET "https://dev-api.mangrovetrader.com/api/v1/marketdata/trades/BTC/USDT/latest" \
+curl -X GET "https://test-api.mangrove.io/api/v1/marketdata/trades/BTC/USDT/latest" \
   -H "Authorization: Bearer $TOKEN"
 
 # Get latest quote
-curl -X GET "https://dev-api.mangrovetrader.com/api/v1/marketdata/quotes/BTC/USDT/latest" \
+curl -X GET "https://test-api.mangrove.io/api/v1/marketdata/quotes/BTC/USDT/latest" \
   -H "Authorization: Bearer $TOKEN"
 
 # Get 1-hour OHLCV bars
-curl -X GET "https://dev-api.mangrovetrader.com/api/v1/marketdata/ohlcv/BTC/USDT/interval?start_time=2025-12-04T12:00:00Z&end_time=2025-12-04T13:00:00Z" \
+curl -X GET "https://test-api.mangrove.io/api/v1/marketdata/ohlcv/BTC/USDT/interval?start_time=2025-12-04T12:00:00Z&end_time=2025-12-04T13:00:00Z" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
 ```python Python
 import requests
 
-BASE = "https://dev-api.mangrovetrader.com/api/v1/marketdata"
+BASE = "https://test-api.mangrove.io/api/v1/marketdata"
 headers = {"Authorization": f"Bearer {token}"}
 
 # Latest trade


### PR DESCRIPTION
The Market Data API reference pointed at `*.mangrovetrader.com`, which has **no DNS records** (NXDOMAIN — confirmed in Route 53; those hosts never resolve). The live gateway is served on **mangrove.io**:

- **Prod** → `https://api.mangrove.io` (mangrove-prod-gateway ALB)
- **Dev / Test / Stage** → `https://test-api.mangrove.io` (mangrove-stage-gateway ALB; the dev/stage Cognito pool's tokens validate only against the stage gateway, 401 against prod)

10 occurrences corrected. Matches the now-canonical host used by the MangroveRoots client (v0.10.0) and verified live (`get_ohlcv served by MANGROVE` from `api.mangrove.io`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)