### PR TITLE
chore: auto-add new issues to Web Team project board

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,0 +1,25 @@
+name: Add new issues to Web Team board
+
+# Automatically adds any newly opened or reopened issue in this repo to the
+# org-level "Mangrove Platform Web Team Planning" project board (Project #6).
+# Requires an org/repo secret ADD_TO_PROJECT_PAT: a token with "Projects: read
+# and write" on the MangroveTechnologies org. The default GITHUB_TOKEN cannot
+# write to org-level Projects, so a PAT (or GitHub App token) is required.
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+permissions:
+  contents: read
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/MangroveTechnologies/projects/6
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          # To limit which issues get added, uncomment and set labels:
+          # labeled: web-team


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that automatically adds every newly opened / reopened issue in this repo to the org-level **Mangrove Platform Web Team Planning** board ([Project #6](https://github.com/orgs/MangroveTechnologies/projects/6)).

## Why

GitHub repos and Projects (v2) are decoupled — creating an issue does not put it on any board unless something adds it. This wires that automation so the board stays in sync without manual triage.

## Required before it works

An org (or repo) secret **`ADD_TO_PROJECT_PAT`** must exist: a token with **Projects: read and write** on the MangroveTechnologies org. The default `GITHUB_TOKEN` cannot write to org-level Projects.

## Notes

- Optional label filtering is available (commented `labeled:` line in the workflow).
- Adds are idempotent — an issue already on the board is not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)