### PR TITLE
docs: repoint Documentation links to mangrove.io/docs

### DIFF
--- a/PKG_README.md
+++ b/PKG_README.md
@@ -165,7 +165,7 @@ This package is part of [MangroveKnowledgeBase](https://github.com/MangroveTechn
 ## Links
 
 - [GitHub](https://github.com/MangroveTechnologies/MangroveKnowledgeBase) -- star it, fork it, contribute
-- [Documentation](https://docs.mangrovedeveloper.ai)
+- [Documentation](https://mangrove.io/docs)
 - [Contributing Guide](https://github.com/MangroveTechnologies/MangroveKnowledgeBase/blob/main/CONTRIBUTING.md)
 - [Mangrove](https://mangrove.ai)
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ docker compose up -d mkb-knowledge-base
 
 - [GitHub](https://github.com/MangroveTechnologies/MangroveKnowledgeBase)
 - [PyPI Package](https://pypi.org/project/mangrove-kb/)
-- [Documentation](https://docs.mangrovedeveloper.ai)
+- [Documentation](https://mangrove.io/docs)
 - [Mangrove](https://mangrove.ai)
 
 ## License


### PR DESCRIPTION
README.md and PKG_README.md (the PyPI long description) still link to docs.mangrovedeveloper.ai, which was torn down today (service, domain mapping, DNS -- https://github.com/MangroveTechnologies/MangroveAI/issues/831). Repoints both to https://mangrove.io/docs. Re-lands a commit that was accidentally pushed to the #97 branch minutes after that PR merged, so it never reached main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)