### PR TITLE
docs(strategy): note exit signal is effectively required for backtests (#801)

### DIFF
--- a/knowledge-base/04-strategy-design-modeling.md
+++ b/knowledge-base/04-strategy-design-modeling.md
@@ -839,6 +839,18 @@ def time_based_exit(entry_time, current_time, max_holding_period):
 - Don't let winners turn into losers (use break-even stops)
 - Test different exit strategies with same entry to find optimal
 - Document reason for each exit in trade log
+- **Always define at least one exit signal before backtesting.** A strategy
+  with entry signals but no exit signal still runs, but it never closes a
+  position on its own -- the Mangrove backtester force-closes every open
+  position at the end of the simulation window. That end-of-sim liquidation
+  understates drawdown and can overstate returns and Sharpe, so the reported
+  metrics will not reflect how the strategy would trade live.
+
+> **Backtest Warning:** When a strategy defines entry signals but an empty
+> `exit` list, the backtest is not rejected -- it returns a non-fatal
+> `NO_EXIT_SIGNAL` warning in the response `warnings` array (and the AI copilot
+> flags it). Treat the resulting metrics with caution until you add an exit
+> rule.
 
 ---
 


### PR DESCRIPTION
## Bottom line

Companion docs change for **MangroveAI #801**. A strategy with no exit signal backtests without error, but its positions are force-closed at end-of-sim, understating metrics. The KB strategy guide didn't call this out.

## What changed

`knowledge-base/04-strategy-design-modeling.md`, §4.6 Exit Logic:
- Added a best-practice bullet: **always define at least one exit signal before backtesting**, explaining the end-of-sim force-close and why it distorts drawdown / returns / Sharpe.
- Added a "Backtest Warning" callout documenting the non-fatal `NO_EXIT_SIGNAL` warning the API now returns (see MangroveAI PR).

Docs-only; markdown callout style matches the existing `>` blockquotes in the doc.

## Verification

Markdown-only change; rendered locally (well-formed list + blockquote, no broken structure). The behavioral fix and the `NO_EXIT_SIGNAL` warning it documents are verified end-to-end in the MangroveAI PR.

## Claude session

```
Session: 3e006bd5-5a31-4584-acbb-a20dc91361cf
Resume:  claude --resume 3e006bd5-5a31-4584-acbb-a20dc91361cf   (run from the bot's project dir)
```

Related: MangroveAI #801, MangroveAI PR #854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
