### PR TITLE
docs(strategy-design): exit signals are optional -- system brackets are the primary close mechanism

### DIFF
--- a/knowledge-base/04-strategy-design-modeling.md
+++ b/knowledge-base/04-strategy-design-modeling.md
@@ -494,6 +494,19 @@ def check_exit(data, position):
 - Should be defined before trade entry
 - Examples: `sma_cross_down`, `macd_bearish_cross`, `rsi_overbought`
 
+> **Exit signals are OPTIONAL on Mangrove.** Every position automatically
+> carries system exits from `execution_config`, independent of exit signals:
+> a dynamic-ATR **stop-loss** and a reward-factor **take-profit** bracket
+> attached at entry, plus time-based exits (`exit_on_loss_after_bars`,
+> `exit_on_profit_after_bars`, `max_hold_bars`). An entry-only strategy
+> (empty `exit` list) is a first-class configuration — the majority of the
+> reference strategy library is built this way — and its positions close
+> normally via those brackets. Defining exit signals adds a strategy-driven
+> exit path *on top of* the system brackets; it does not replace them.
+> The engine's close priority per bar: stop-loss → take-profit → exit
+> signal (if defined) → time-based exits; anything still open on the final
+> bar closes at end-of-simulation.
+
 **Filter Signals:**
 - Provide ongoing context rather than discrete triggers
 - Answer: "Should we be trading in this direction at all?"


### PR DESCRIPTION
Replaces the closed https://github.com/MangroveTechnologies/MangroveKnowledgeBase/pull/99, whose premise was refuted against engine source (evidence on https://github.com/MangroveTechnologies/MangroveAI/issues/801).

Adds the accurate exit-semantics callout to the strategy-design knowledge doc: every position carries a dynamic-ATR stop-loss + reward-factor take-profit bracket from `execution_config` plus time-based exits, independent of exit signals; entry-only strategies are first-class (majority of the reference library); exit signals are an optional strategy-driven path on top; engine close-priority order documented.

Docs-only; companion to https://github.com/MangroveTechnologies/MangroveAI/pull/857 (dev-portal docs) and https://github.com/MangroveTechnologies/mangrove-agent/pull/154 (agent knowledge + quick-mode caveat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)