### PR TITLE
ci: release checkout uses KB_RELEASE_PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          # Push the release tag with GH_PAT (not the default GITHUB_TOKEN) so the
+          # Push the release tag with KB_RELEASE_PAT (not the default GITHUB_TOKEN) so the
           # tag push CASCADES to the tag-triggered workflows (build-and-push.yaml +
           # build-docs.yml). GITHUB_TOKEN-pushed tags do NOT trigger other workflows,
           # which is why the KB image/docs builds previously had to be dispatched by hand.
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.KB_RELEASE_PAT }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
`GH_PAT` was revoked after it leaked, so the release run died at Checkout — `could not read Username for 'https://github.com'`. Nothing was tagged or published; it failed on the first step.

Renamed rather than reused: the replacement is a **fine-grained token scoped to this repository only**, and a distinct name stops the revoked one being resurrected by habit. It's also not the PyPI credential — that's `PYPI_API_TOKEN`, separate and unaffected — and the old name invited confusing the two.

Still a PAT rather than `GITHUB_TOKEN`: a tag pushed by `GITHUB_TOKEN` doesn't trigger tag-triggered workflows, so `build-and-push.yaml` would need hand-dispatching every release.

**Set the `KB_RELEASE_PAT` secret before merging**, or the next release fails the same way.