### PR TITLE
chore: keep working notes out of the repo (gitignore + fix the guard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,23 @@ appmap.log
 # the audits themselves superseded, and they read as current. Re-generate with
 # `python scripts/audit/run_all.py`.
 audit_results/
+
+# Working notes: status docs, session summaries, handoffs, next-steps, and anything stamped with a
+# date. They describe a moment and are then read as describing now -- STATUS.md, SESSION-SUMMARY.md,
+# kb-next-steps.md and findings/session-summary-2026-02-22.md were all committed and all stale, and
+# one of them opened with the words "Not committed. Working note only."
+#
+# Scoped to .md so nothing shadows real code (kb_server has a status route).
+# `tests/test_discoverability.py` fails the build if one is committed anyway -- belt and braces,
+# because .gitignore does nothing for a file already tracked or added with `-f`.
+[Ss][Tt][Aa][Tt][Uu][Ss].md
+*[-_][Ss][Tt][Aa][Tt][Uu][Ss].md
+*[Ss][Ee][Ss][Ss][Ii][Oo][Nn][-_][Ss][Uu][Mm][Mm][Aa][Rr][Yy]*.md
+*[Hh][Aa][Nn][Dd][Oo][Ff][Ff]*.md
+*[Nn][Ee][Xx][Tt][-_][Ss][Tt][Ee][Pp][Ss]*.md
+*[Ss][Cc][Rr][Aa][Tt][Cc][Hh][Pp][Aa][Dd]*.md
+*[Ww][Ii][Pp].md
+
+# Anything date-stamped: notes-2026-08-10.md, summary_2026_08_10.md, report-20260810.md
+*[-_][0-9][0-9][0-9][0-9][-_][0-9][0-9][-_][0-9][0-9].md
+*[-_][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9].md

--- a/tests/test_discoverability.py
+++ b/tests/test_discoverability.py
@@ -189,15 +189,22 @@ def test_no_session_or_handoff_docs_are_committed():
 
     They are written to describe a moment and then read as if they describe now. The one that was
     here opened with the words "Not committed. Working note only." -- and was committed.
+
+    Asks git what is TRACKED rather than globbing the filesystem. An uncommitted working note in
+    someone's checkout is fine -- that is the whole point of keeping them out of the repo -- and
+    globbing failed the build for one, which is the opposite of what this guards.
     """
-    banned = []
-    for path in REPO.rglob("*.md"):
-        rel = path.relative_to(REPO)
-        if ".git" in rel.parts or "build" in rel.parts or "node_modules" in rel.parts:
-            continue
-        name = rel.name.lower()
-        if any(w in name for w in ("session-summary", "handoff", "next-steps", "status")):
-            banned.append(str(rel))
+    import subprocess
+    try:
+        proc = subprocess.run(["git", "ls-files", "*.md", "**/*.md"], cwd=REPO,
+                              capture_output=True, text=True)
+    except FileNotFoundError:  # no git binary
+        pytest.skip("git unavailable -- nothing to ask about what is tracked")
+    if proc.returncode != 0:  # an unpacked sdist, not a checkout
+        pytest.skip("not a git checkout")
+    banned = [f for f in proc.stdout.split()
+              if any(w in Path(f).name.lower()
+                     for w in ("session-summary", "handoff", "next-steps", "status"))]
     assert not banned, f"summary/handoff docs must not be committed: {banned}"
 
 


### PR DESCRIPTION
Two halves of one concern: working notes (status docs, session summaries, handoffs, next-steps, anything date-stamped) must not be committed.

**The ignore rules never reached `main`.** `1f9d954` was committed on `feat/indicator-output-metadata` but never pushed, so the squash merge of #105 left it behind. The *test* that fails the build on a committed handoff doc did land; the `.gitignore` rules that stop `git add -A` picking one up did not. Cherry-picked here, unchanged.

**The guard was backwards.** `test_no_session_or_handoff_docs_are_committed` globbed the working tree with `rglob("*.md")`, so an **uncommitted** working note failed the build — the opposite of what it guards. Keeping notes out of the repo is the point; having one on disk is correct. It now asks `git ls-files`.

Verified both directions:

```
untracked HANDOFF.md present     19 passed
git add -f HANDOFF.md            FAILS: summary/handoff docs must not be committed: ['HANDOFF.md']
```

Also confirmed the ignore rules match a real file: `.gitignore:75:*[Hh][Aa][Nn][Dd][Oo][Ff][Ff]*.md  HANDOFF.md`.

Skips instead of erroring outside a git checkout, so an unpacked sdist does not fail.