### PR TITLE
feat(kg): the knowledge-base chapters enter the graph as nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses [Semantic Versioning](https://semver.org/).
 
 **A signal/indicator knowledge graph, and the reorganisation it forced.** Every indicator now
 carries a class describing what its output tells you about its input, and every modelled signal
-carries a formula stating the predicate it computes -- 303 nodes, 1049 edges, in
+carries a formula stating the predicate it computes -- 309 nodes, 1055 edges, in
 `ontology/signal-indicator-ontology.json`.
 
 Major, because files moved and things were renamed. **No registered signal name changed meaning,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,8 +119,8 @@ x402 payment is enforced on both HTTP and MCP via shared middleware.
 
 ## The Knowledge Graph
 
-`mangrove_kb/graph.py` is a query layer over `ontology/signal-indicator-ontology.json` -- 303 nodes
-and 1049 edges, generated from the source, shipped inside the wheel.
+`mangrove_kb/graph.py` is a query layer over `ontology/signal-indicator-ontology.json` -- 309 nodes
+and 1055 edges, generated from the source, shipped inside the wheel.
 
 ```python
 from mangrove_kb.graph import KnowledgeGraph

--- a/PKG_README.md
+++ b/PKG_README.md
@@ -12,7 +12,7 @@ pip install mangrove-kb
 - **80 technical indicators** -- stateless `compute()` API returning named Series
 - **RuleRegistry** -- evaluate signals by name with parameter dicts (for strategy engines)
 - **Docstring parser** -- extract structured metadata (type, params, ranges) from any signal at runtime
-- **A knowledge graph of the library itself** -- 303 nodes, 1049 edges, queryable, shipped in the package
+- **A knowledge graph of the library itself** -- 309 nodes, 1055 edges, queryable, shipped in the package
 
 Dependencies: numpy, pandas. That's it.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial%201.0.0-ff9e18.svg" alt="License: PolyForm Noncommercial 1.0.0">
   <img src="https://img.shields.io/badge/python-3.10%2B-3776AB.svg?logo=python&logoColor=white" alt="Python 3.10+">
   <img src="https://img.shields.io/badge/deps-numpy%20%2B%20pandas-2ec27e.svg" alt="Dependencies: numpy + pandas">
-  <img src="https://img.shields.io/badge/graph-303%20nodes%20%C2%B7%201049%20edges-42a7c6.svg" alt="Graph: 303 nodes, 1049 edges">
+  <img src="https://img.shields.io/badge/graph-309%20nodes%20%C2%B7%201055%20edges-42a7c6.svg" alt="Graph: 309 nodes, 1055 edges">
   <img src="https://img.shields.io/badge/agent-skill%20%2B%20guide-9b5cff.svg" alt="Agent skill + guide">
 </p>
 
@@ -20,7 +20,7 @@
 every one with a machine-readable docstring — formula, inputs, parameters with ranges and defaults,
 typed outputs with units, and warmup.
 
-And a **knowledge graph built from that source** — 303 nodes and 1049 edges saying what each
+And a **knowledge graph built from that source** — 309 nodes and 1055 edges saying what each
 computation is, what it measures, what it reads, and what part it plays. It is generated from the
 code, so it is exact: not extracted from prose, not approximate, no ranking model in the way.
 
@@ -227,7 +227,7 @@ detail one click away.
 | Pane | Where | What it holds |
 | --- | --- | --- |
 | Rail | left | filters, by kind of node and kind of edge |
-| Map | middle | 303 nodes, 1049 edges |
+| Map | middle | 309 nodes, 1055 edges |
 | Panel | right | everything the library records about whatever you clicked |
 
 ### The inspector — what a node actually carries
@@ -288,7 +288,7 @@ an instance of the family; a signal emits a boolean, so it is *about* the family
   <img src="assets/viewer-action.png" alt="The Action section with neighbors and ancestors both selected, and a bar over the map reading 'showing 13 of 303'" width="100%">
 </p>
 
-303 nodes at once is a picture, not an answer. **show only** keeps part of the graph around the
+309 nodes at once is a picture, not an answer. **show only** keeps part of the graph around the
 selected node, and the choices combine — `neighbors` + `ancestors` gives you both:
 
 | | Keeps |
@@ -326,7 +326,7 @@ say, and the children grey out to show why — so the canvas can never empty for
 visible in the rail.
 
 **Density** spreads or tightens the layout. **Labels** switches between always / never / on hover /
-on zoom — at 303 nodes, off is often clearer than on.
+on zoom — at 309 nodes, off is often clearer than on.
 
 <br clear="right">
 
@@ -357,7 +357,7 @@ either view, **double-click a node to hide or show what hangs off it**, which is
 with 218 signals attached readable.
 
 A **green ring** marks the selected node; a **yellow ring** marks a deprecated one — it still runs,
-it just has a canonical replacement. Nothing else is ringed: 301 of 303 nodes are `ratified`, so
+it just has a canonical replacement. Nothing else is ringed: 307 of 309 nodes are `ratified`, so
 marking that would be decoration rather than information.
 
 Light, dark and follow-the-system are top right, and the choice is remembered.

--- a/mangrove_kb/graph.py
+++ b/mangrove_kb/graph.py
@@ -6,7 +6,7 @@ part each signal plays in a strategy. It is generated from the source, so it is 
 extracted -- there is no text-mining noise to rank around.
 
 **Two classification axes, and they are not interchangeable.** Every signal is simultaneously an
-``instance-of`` a type and a bearer of a ``has-role`` role (218 of 303 nodes carry both). These are
+``instance-of`` a type and a bearer of a ``has-role`` role (218 of 309 nodes carry both). These are
 kept strictly apart throughout this module:
 
 * ``instance-of`` / ``kind-of`` is the **rigid backbone** -- what a thing *is*. It is transitively
@@ -94,12 +94,15 @@ CATEGORIES: tuple[str, ...] = ("structural", "descriptive", "associative", "meta
 #: question the search is for -- "is there already something for X". ``find("mean reversion")``
 #: returned nothing while two nodes described it in prose, and ``find("crossover")`` returned 32 of
 #: the 62 nodes that mention it. The authored detail is where a computation is actually explained.
+#: A doc-derived node has no formula, params or outputs -- its ``explanation`` body is the same
+#: thing for it, so it belongs in the same tier rather than a tier of its own.
 SEARCH_TIERS: tuple[tuple[str, ...], ...] = (
     ("name", "id"),
     ("abbreviation",),
     ("summary",),
     ("formula", "reference", "interpretation", "applications",
-     "inputs", "params", "outputs"),          # slot NAMES and their descriptions
+     "inputs", "params", "outputs",           # slot NAMES and their descriptions
+     "explanation"),                          # the doc-derived body (see `source_chapter`)
 )
 
 #: Where the graph is looked for, in order. An explicit path always wins; ``MANGROVE_KB_ONTOLOGY``
@@ -355,7 +358,7 @@ class KnowledgeGraph:
 
         This deliberately does **not** return every node the backbone points at. That set also holds
         ``concept:indicator`` (71 results), ``concept:signal`` (218), ``concept:technical-analysis``
-        (295 of 303 nodes) and ``property:role`` (2 -- the role values), and advertising those as the
+        (296 of 309 nodes) and ``property:role`` (2 -- the role values), and advertising those as the
         class vocabulary invites a filter that looks like a query and returns almost everything.
         They remain legal ``kind=`` arguments, and :meth:`find` documents them; they are just not
         classes.
@@ -558,7 +561,7 @@ class KnowledgeGraph:
         The other operations answer questions about a node's place in the graph. This one answers
         questions about the values themselves -- *what produces an output called* ``histogram``,
         *which computations emit a percentage*, *which are bounded and therefore comparable on one
-        axis*. Those were previously reachable only by fetching all 303 nodes and looping, which is
+        axis*. Those were previously reachable only by fetching all 309 nodes and looping, which is
         why they were not being asked.
 
         A row is an **output**, not a node: an indicator with three outputs contributes three rows,

--- a/mangrove_kb/graph.py
+++ b/mangrove_kb/graph.py
@@ -102,7 +102,7 @@ SEARCH_TIERS: tuple[tuple[str, ...], ...] = (
     ("summary",),
     ("formula", "reference", "interpretation", "applications",
      "inputs", "params", "outputs",           # slot NAMES and their descriptions
-     "explanation"),                          # the doc-derived body (see `source_chapter`)
+     "explanation"),                          # the doc-derived body (see `reference_chapter`)
 )
 
 #: Where the graph is looked for, in order. An explicit path always wins; ``MANGROVE_KB_ONTOLOGY``

--- a/ontology/build_signal_indicator_ontology.py
+++ b/ontology/build_signal_indicator_ontology.py
@@ -1034,6 +1034,14 @@ atom(ROOT, ROOT_TITLE, "Object",
      "computation can measure, the role axis, and everything classified under them. Strategy "
      "attaches directly; markets and the rest of the knowledge base land here too.")
 
+# Which knowledge-base chapter documents each of these. The chapter is not where the node came
+# from -- the code is -- so this is a REFERENCE, not provenance: it points a reader at the prose
+# that explains the thing. Doc-derived nodes carry the same key from their page frontmatter, so one
+# question ("which chapter covers this?") has one answer across both halves of the graph.
+CH_INDICATORS = "06-indicators"
+CH_PATTERNS = "07-chart-patterns"
+CH_STRATEGY = "04-strategy-design-modeling"
+
 # entity types
 #
 # The primitive follows one test, from the primitive definitions themselves: a Concept is a CATEGORY
@@ -1050,11 +1058,14 @@ atom(ROOT, ROOT_TITLE, "Object",
 # An id may say what a thing IS; it must never say what a thing BELONGS TO. `concept:strategy` broke
 # the first half and `concept:indicator-class-momentum` broke the second -- see the class axis below.
 atom("concept:indicator", "Indicator", "Concept",
-     "A computation over one or more input series producing one or more numeric output series.")
+     "A computation over one or more input series producing one or more numeric output series.",
+     reference_chapter=CH_INDICATORS)
 atom("concept:signal", "Signal", "Concept",
-     "A boolean predicate over indicator output, evaluated per bar. Composed of (indicator, predicate, params).")
+     "A boolean predicate over indicator output, evaluated per bar. Composed of (indicator, predicate, params).",
+     reference_chapter=CH_INDICATORS)
 atom("schema:strategy", "Strategy", "Schema",
-     "A structured template composing signals into entry/exit rules plus configuration.")
+     "A structured template composing signals into entry/exit rules plus configuration.",
+     reference_chapter=CH_STRATEGY)
 # Indicator and Signal sit UNDER technical analysis, not beside it. An indicator reads a market from
 # its own price and volume history, which is what technical analysis IS -- making it a sibling of the
 # domain said it was something else. `part-of`, not `kind-of`, because these are the two LAYERS the
@@ -1082,13 +1093,15 @@ rel("Signal", "part-of", "Strategy", "component composed into strategies",
 # signal and none at an indicator, so role is a facet of Signal rather than a peer of it. `kind-of`
 # would be wrong -- a role is not a kind of signal, it is an axis along which signals are placed.
 atom("property:role", "Role", "Property",
-     "The position a signal occupies within a strategy. Contextual, not intrinsic.")
+     "The position a signal occupies within a strategy. Contextual, not intrinsic.",
+     reference_chapter=CH_INDICATORS)
 rel("Role", "part-of", "Signal", "axis along which signals are placed", "property:role", "concept:signal")
 # `arm` was declared here and never used: zero signals carried it, and SKILL.md documents the role
 # vocabulary as trigger and filter. A value nothing takes is not a vocabulary, it is a claim the
 # graph cannot support -- `stats()` offered it as a legal filter that always returns nothing.
 for r in ("trigger", "filter"):
-    atom(f"property:role-{r}", r, "Property", f"Signal role: {r}.")
+    atom(f"property:role-{r}", r, "Property", f"Signal role: {r}.",
+         reference_chapter=CH_INDICATORS)
     rel(r, "kind-of", "Role", "role value", f"property:role-{r}", "property:role")
 
 # class axis + members
@@ -1105,11 +1118,15 @@ for r in ("trigger", "filter"):
 atom(TA_ID, "technical analysis", "Concept",
      "Reading a market from its own price and volume history. The characters a computation can "
      "measure -- momentum, volatility, flow and the rest -- divide this space; the indicators that "
-     "measure them and the signals that read them both attach to those divisions.")
+     "measure them and the signals that read them both attach to those divisions.",
+     reference_chapter=CH_INDICATORS)
 rel("technical analysis", "part-of", ROOT_TITLE,
     "the domain this knowledge space covers", TA_ID, ROOT)
 for cls, desc in CLASSES_DEF.items():
-    atom(f"concept:{cls}", cls, "Concept", desc)
+    # `pattern` is candlestick geometry, documented in 7.1 -- chapter 06 has no candlestick
+    # section. Every other character class is one of 06's indicator categories.
+    atom(f"concept:{cls}", cls, "Concept", desc,
+         reference_chapter=CH_PATTERNS if cls == "pattern" else CH_INDICATORS)
     rel(cls, "kind-of", "technical analysis", "character measured", f"concept:{cls}", TA_ID)
 for ind, cls in sorted(assigned.items()):
     lifted = _lift(CLASSES[ind])

--- a/ontology/signal-indicator-ontology.json
+++ b/ontology/signal-indicator-ontology.json
@@ -4450,7 +4450,7 @@
      "Positive TRIX: Bullish momentum",
      "Negative TRIX: Bearish momentum",
      "Zero line crossovers signal trend changes",
-     "Very smooth\u2014filters out most noise"
+     "Very smooth—filters out most noise"
     ],
     "applications": [
      "Trend-following momentum with heavy noise suppression, for instruments where MACD whipsaws",
@@ -17393,6 +17393,78 @@
      }
     }
    }
+  },
+  {
+   "id": "concept:chart-pattern",
+   "title": "chart pattern",
+   "kind": "Concept",
+   "summary": "A price formation spanning a variable number of bars, identified from swing highs and lows rather than over a fixed window.",
+   "epistemic": "observed",
+   "status": "ratified",
+   "props": {
+    "source_chapter": "07-chart-patterns",
+    "explanation": "Multi-bar formations: head and shoulders, double tops and bottoms, triangles, wedges, flags and pennants, cup and handle, and the necklines and completion criteria that define them. Also pattern reliability and failure modes, and the context a formation requires to mean anything. Sibling of the existing pattern class, not a parent of it and not the same thing. That class holds candlestick geometry -- shapes computable from one bar or a small fixed number of them, which is why 41 signals implement it. A chart pattern needs a swing structure of unknown length, and no computation in the library produces swing points, so this class carries no procedures. It is the first class in the graph that is knowledge without an implementation."
+   }
+  },
+  {
+   "id": "concept:market-foundations",
+   "title": "market foundations",
+   "kind": "Concept",
+   "summary": "How a market produces a price: who participates, how their orders meet, and what crossing the spread costs.",
+   "epistemic": "observed",
+   "status": "ratified",
+   "props": {
+    "source_chapter": "01-market-foundations",
+    "explanation": "Market microstructure, order types, participant classes, liquidity and its price -- slippage and market impact -- volatility regimes and the shifts between them, trading venues and their execution models, bid-ask spread dynamics, and price discovery. This is the layer every computation in the graph silently assumes. An indicator consumes a price series; this subject area is where that series comes from."
+   }
+  },
+  {
+   "id": "concept:market-mechanics",
+   "title": "market mechanics",
+   "kind": "Concept",
+   "summary": "The instruments themselves and the rules under which a position is opened, financed and settled.",
+   "epistemic": "observed",
+   "status": "ratified",
+   "props": {
+    "source_chapter": "02-instruments-market-mechanics",
+    "explanation": "Spot markets, futures and perpetual swaps, options, margin and leverage and the liquidation engines that enforce them, crypto-specific mechanics, FX basics, settlement and clearing, and contract specifications. Distinct from market foundations: that subject area covers how a price forms, this one covers what is actually being traded and under whose rules."
+   }
+  },
+  {
+   "id": "concept:price-action",
+   "title": "price action",
+   "kind": "Concept",
+   "summary": "Reading a market from the shape of its price alone -- structure, levels and regime -- without computing an indicator over it.",
+   "epistemic": "observed",
+   "status": "ratified",
+   "props": {
+    "source_chapter": "03-core-trading-concepts",
+    "explanation": "Price action theory, market structure, trend versus range and compression versus expansion, liquidity theory, volume and order flow, support and resistance, supply and demand zones, multi-timeframe analysis, confluence, fair value gaps, and volume profile. Deliberately kept beside technical analysis rather than beneath it. Technical analysis is organised in this graph by what a computation *measures*, and its six subclasses are exactly those characters; price action names conclusions drawn from price geometry rather than a character a computation measures, so placing it there would misuse that axis."
+   }
+  },
+  {
+   "id": "concept:quantitative-analysis",
+   "title": "quantitative analysis",
+   "kind": "Concept",
+   "summary": "Statistical structure in returns: what persists, what reverts, and over what horizon.",
+   "epistemic": "observed",
+   "status": "ratified",
+   "props": {
+    "source_chapter": "08-quantitative-analysis",
+    "explanation": "Seasonality and time-of-day effects, volatility clustering, mean reversion, breakout behaviour, autocorrelation and momentum persistence, machine-learned patterns, cross-sectional versus time-series effects, and carry. Where technical analysis classifies a computation by what it measures, this subject area is about the properties of the series being measured -- the evidence that a given class of computation has anything to find."
+   }
+  },
+  {
+   "id": "concept:risk-management",
+   "title": "risk management",
+   "kind": "Concept",
+   "summary": "Bounding loss: how much to put on, when to stop, and what the portfolio can survive.",
+   "epistemic": "observed",
+   "status": "ratified",
+   "props": {
+    "source_chapter": "05-risk-management",
+    "explanation": "Risk dimensions in strategy design, trading rules and protocols, position sizing, drawdown controls, stop-loss and take-profit engineering, portfolio risk, capital efficiency, risk-reward ratios, risk of ruin, and scenario analysis. Signals decide whether to act; this subject area decides at what size and under what limits, and it constrains a strategy independently of which signals it composes."
+   }
   }
  ],
  "relations": [
@@ -27351,6 +27423,54 @@
    "why": "computes the same thing under the canonical name",
    "from_id": "procedure:signal-inverted-hammer-trigger",
    "to_id": "procedure:signal-shooting-star-trigger"
+  },
+  {
+   "from": "chart pattern",
+   "rel": "kind-of",
+   "to": "technical analysis",
+   "why": "a character a computation can read, sibling to the candlestick pattern class",
+   "from_id": "concept:chart-pattern",
+   "to_id": "concept:technical-analysis"
+  },
+  {
+   "from": "market foundations",
+   "rel": "part-of",
+   "to": "Mangrove Knowledge Space",
+   "why": "subject area of the knowledge space",
+   "from_id": "concept:market-foundations",
+   "to_id": "object:mangrove-knowledge-space"
+  },
+  {
+   "from": "market mechanics",
+   "rel": "part-of",
+   "to": "Mangrove Knowledge Space",
+   "why": "subject area of the knowledge space",
+   "from_id": "concept:market-mechanics",
+   "to_id": "object:mangrove-knowledge-space"
+  },
+  {
+   "from": "price action",
+   "rel": "part-of",
+   "to": "Mangrove Knowledge Space",
+   "why": "subject area of the knowledge space",
+   "from_id": "concept:price-action",
+   "to_id": "object:mangrove-knowledge-space"
+  },
+  {
+   "from": "quantitative analysis",
+   "rel": "part-of",
+   "to": "Mangrove Knowledge Space",
+   "why": "subject area of the knowledge space",
+   "from_id": "concept:quantitative-analysis",
+   "to_id": "object:mangrove-knowledge-space"
+  },
+  {
+   "from": "risk management",
+   "rel": "part-of",
+   "to": "Mangrove Knowledge Space",
+   "why": "subject area of the knowledge space",
+   "from_id": "concept:risk-management",
+   "to_id": "object:mangrove-knowledge-space"
   }
  ],
  "meta": {
@@ -27371,6 +27491,12 @@
   "signals_with_no_indicator": [],
   "signals_with_unknown_role": [],
   "signals_missing_warmup": [],
-  "indicators_missing_description": []
+  "indicators_missing_description": [],
+  "doc_atoms": 6,
+  "doc_relations": 6,
+  "doc_anchors": [
+   "concept:technical-analysis",
+   "object:mangrove-knowledge-space"
+  ]
  }
 }

--- a/ontology/signal-indicator-ontology.json
+++ b/ontology/signal-indicator-ontology.json
@@ -16,7 +16,9 @@
    "summary": "A computation over one or more input series producing one or more numeric output series.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "concept:signal",
@@ -25,7 +27,9 @@
    "summary": "A boolean predicate over indicator output, evaluated per bar. Composed of (indicator, predicate, params).",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "schema:strategy",
@@ -34,7 +38,9 @@
    "summary": "A structured template composing signals into entry/exit rules plus configuration.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "04-strategy-design-modeling"
+   }
   },
   {
    "id": "property:role",
@@ -43,7 +49,9 @@
    "summary": "The position a signal occupies within a strategy. Contextual, not intrinsic.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "property:role-trigger",
@@ -52,7 +60,9 @@
    "summary": "Signal role: trigger.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "property:role-filter",
@@ -61,7 +71,9 @@
    "summary": "Signal role: filter.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "concept:technical-analysis",
@@ -70,7 +82,9 @@
    "summary": "Reading a market from its own price and volume history. The characters a computation can measure -- momentum, volatility, flow and the rest -- divide this space; the indicators that measure them and the signals that read them both attach to those divisions.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "concept:averaging",
@@ -79,7 +93,9 @@
    "summary": "Emits a reference level in price units, produced by averaging over a window.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "concept:momentum",
@@ -88,7 +104,9 @@
    "summary": "Measures rate of change -- how fast, and in which direction, the input is moving.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "concept:oscillator",
@@ -97,7 +115,9 @@
    "summary": "Bounded output where absolute thresholds are meaningful (overbought/oversold).",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "concept:volatility",
@@ -106,7 +126,9 @@
    "summary": "Measures observed dispersion -- distance, width, or range.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "concept:flow",
@@ -115,7 +137,9 @@
    "summary": "Running accumulation whose level is arbitrary but whose direction carries meaning.",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "06-indicators"
+   }
   },
   {
    "id": "concept:pattern",
@@ -124,7 +148,9 @@
    "summary": "Shape of one or a few bars (candlestick geometry).",
    "epistemic": "observed",
    "status": "ratified",
-   "props": {}
+   "props": {
+    "reference_chapter": "07-chart-patterns"
+   }
   },
   {
    "id": "procedure:indicator-adi",
@@ -17402,7 +17428,7 @@
    "epistemic": "observed",
    "status": "ratified",
    "props": {
-    "source_chapter": "07-chart-patterns",
+    "reference_chapter": "07-chart-patterns",
     "explanation": "Multi-bar formations: head and shoulders, double tops and bottoms, triangles, wedges, flags and pennants, cup and handle, and the necklines and completion criteria that define them. Also pattern reliability and failure modes, and the context a formation requires to mean anything. Sibling of the existing pattern class, not a parent of it and not the same thing. That class holds candlestick geometry -- shapes computable from one bar or a small fixed number of them, which is why 41 signals implement it. A chart pattern needs a swing structure of unknown length, and no computation in the library produces swing points, so this class carries no procedures. It is the first class in the graph that is knowledge without an implementation."
    }
   },
@@ -17414,7 +17440,7 @@
    "epistemic": "observed",
    "status": "ratified",
    "props": {
-    "source_chapter": "01-market-foundations",
+    "reference_chapter": "01-market-foundations",
     "explanation": "Market microstructure, order types, participant classes, liquidity and its price -- slippage and market impact -- volatility regimes and the shifts between them, trading venues and their execution models, bid-ask spread dynamics, and price discovery. This is the layer every computation in the graph silently assumes. An indicator consumes a price series; this subject area is where that series comes from."
    }
   },
@@ -17426,7 +17452,7 @@
    "epistemic": "observed",
    "status": "ratified",
    "props": {
-    "source_chapter": "02-instruments-market-mechanics",
+    "reference_chapter": "02-instruments-market-mechanics",
     "explanation": "Spot markets, futures and perpetual swaps, options, margin and leverage and the liquidation engines that enforce them, crypto-specific mechanics, FX basics, settlement and clearing, and contract specifications. Distinct from market foundations: that subject area covers how a price forms, this one covers what is actually being traded and under whose rules."
    }
   },
@@ -17438,7 +17464,7 @@
    "epistemic": "observed",
    "status": "ratified",
    "props": {
-    "source_chapter": "03-core-trading-concepts",
+    "reference_chapter": "03-core-trading-concepts",
     "explanation": "Price action theory, market structure, trend versus range and compression versus expansion, liquidity theory, volume and order flow, support and resistance, supply and demand zones, multi-timeframe analysis, confluence, fair value gaps, and volume profile. Deliberately kept beside technical analysis rather than beneath it. Technical analysis is organised in this graph by what a computation *measures*, and its six subclasses are exactly those characters; price action names conclusions drawn from price geometry rather than a character a computation measures, so placing it there would misuse that axis."
    }
   },
@@ -17450,7 +17476,7 @@
    "epistemic": "observed",
    "status": "ratified",
    "props": {
-    "source_chapter": "08-quantitative-analysis",
+    "reference_chapter": "08-quantitative-analysis",
     "explanation": "Seasonality and time-of-day effects, volatility clustering, mean reversion, breakout behaviour, autocorrelation and momentum persistence, machine-learned patterns, cross-sectional versus time-series effects, and carry. Where technical analysis classifies a computation by what it measures, this subject area is about the properties of the series being measured -- the evidence that a given class of computation has anything to find."
    }
   },
@@ -17462,7 +17488,7 @@
    "epistemic": "observed",
    "status": "ratified",
    "props": {
-    "source_chapter": "05-risk-management",
+    "reference_chapter": "05-risk-management",
     "explanation": "Risk dimensions in strategy design, trading rules and protocols, position sizing, drawdown controls, stop-loss and take-profit engineering, portfolio risk, capital efficiency, risk-reward ratios, risk of ruin, and scenario analysis. Signals decide whether to act; this subject area decides at what size and under what limits, and it constrains a strategy independently of which signals it composes."
    }
   }
@@ -27493,6 +27519,14 @@
   "signals_missing_warmup": [],
   "indicators_missing_description": [],
   "doc_atoms": 6,
+  "doc_atom_ids": [
+   "concept:chart-pattern",
+   "concept:market-foundations",
+   "concept:market-mechanics",
+   "concept:price-action",
+   "concept:quantitative-analysis",
+   "concept:risk-management"
+  ],
   "doc_relations": 6,
   "doc_anchors": [
    "concept:technical-analysis",

--- a/ontology/wiki-config/map.json
+++ b/ontology/wiki-config/map.json
@@ -1,0 +1,10 @@
+{
+  "_doc": "Section heading -> relation. Keys are matched as substrings of the lowercased `##` heading, first match wins, so the more specific keys come first. Headings that match nothing (Summary, Explanation) yield no relation: links belong in a typed section, never in prose. The adapter asserts that no untyped edge was produced.",
+  "instance of": "instance-of",
+  "kind of": "kind-of",
+  "part of": "part-of",
+  "has role": "has-role",
+  "supersedes": "supersedes",
+  "uses": "uses",
+  "about": "about"
+}

--- a/ontology/wiki-config/vocab.json
+++ b/ontology/wiki-config/vocab.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Vocabulary for the doc-derived half of the graph. `kinds` are the nine ontology primitives (a page's `kind:` frontmatter becomes the id prefix). `concept_edges` is deliberately the exact set of relations mangrove_kb.graph.RELATIONS knows how to categorise and traverse -- anything the wiki can express is therefore queryable, and a section mapping to a relation outside this set is a build-time mistake rather than a silent degree-0 node.",
+  "kinds": ["object", "property", "concept", "fact", "experience",
+            "procedure", "schema", "context", "judgment", "atom"],
+  "concept_edges": ["instance-of", "kind-of", "part-of", "has-role",
+                    "about", "uses", "supersedes"],
+  "symmetric": [],
+  "hub_edges": ["indexes", "records"]
+}

--- a/ontology/wiki/Chart Pattern.md
+++ b/ontology/wiki/Chart Pattern.md
@@ -1,0 +1,27 @@
+---
+kind: concept
+chapter: 07-chart-patterns
+---
+
+# chart pattern
+
+## Summary
+
+A price formation spanning a variable number of bars, identified from swing highs and lows rather
+than over a fixed window.
+
+## Explanation
+
+Multi-bar formations: head and shoulders, double tops and bottoms, triangles, wedges, flags and
+pennants, cup and handle, and the necklines and completion criteria that define them. Also pattern
+reliability and failure modes, and the context a formation requires to mean anything.
+
+Sibling of the existing pattern class, not a parent of it and not the same thing. That class holds
+candlestick geometry -- shapes computable from one bar or a small fixed number of them, which is
+why 41 signals implement it. A chart pattern needs a swing structure of unknown length, and no
+computation in the library produces swing points, so this class carries no procedures. It is the
+first class in the graph that is knowledge without an implementation.
+
+## Kind of
+
+- [[Technical Analysis]] -- a character a computation can read, sibling to the candlestick pattern class

--- a/ontology/wiki/Mangrove Knowledge Space.md
+++ b/ontology/wiki/Mangrove Knowledge Space.md
@@ -1,0 +1,12 @@
+---
+kind: object
+---
+
+# Mangrove Knowledge Space
+
+## Explanation
+
+Anchor page -- carries no summary on purpose. This node is authored by the code-derived build
+(`build_signal_indicator_ontology.py`) and appears here only so that wiki links resolve to it. The
+adapter emits no atom for a page whose id already exists in the ontology, so a summary written here
+would never reach the graph and would rot beside the real one.

--- a/ontology/wiki/Market Foundations.md
+++ b/ontology/wiki/Market Foundations.md
@@ -1,0 +1,24 @@
+---
+kind: concept
+chapter: 01-market-foundations
+---
+
+# market foundations
+
+## Summary
+
+How a market produces a price: who participates, how their orders meet, and what crossing the
+spread costs.
+
+## Explanation
+
+Market microstructure, order types, participant classes, liquidity and its price -- slippage and
+market impact -- volatility regimes and the shifts between them, trading venues and their execution
+models, bid-ask spread dynamics, and price discovery.
+
+This is the layer every computation in the graph silently assumes. An indicator consumes a price
+series; this subject area is where that series comes from.
+
+## Part of
+
+- [[Mangrove Knowledge Space]] -- subject area of the knowledge space

--- a/ontology/wiki/Market Mechanics.md
+++ b/ontology/wiki/Market Mechanics.md
@@ -1,0 +1,23 @@
+---
+kind: concept
+chapter: 02-instruments-market-mechanics
+---
+
+# market mechanics
+
+## Summary
+
+The instruments themselves and the rules under which a position is opened, financed and settled.
+
+## Explanation
+
+Spot markets, futures and perpetual swaps, options, margin and leverage and the liquidation engines
+that enforce them, crypto-specific mechanics, FX basics, settlement and clearing, and contract
+specifications.
+
+Distinct from market foundations: that subject area covers how a price forms, this one covers what
+is actually being traded and under whose rules.
+
+## Part of
+
+- [[Mangrove Knowledge Space]] -- subject area of the knowledge space

--- a/ontology/wiki/Price Action.md
+++ b/ontology/wiki/Price Action.md
@@ -1,0 +1,26 @@
+---
+kind: concept
+chapter: 03-core-trading-concepts
+---
+
+# price action
+
+## Summary
+
+Reading a market from the shape of its price alone -- structure, levels and regime -- without
+computing an indicator over it.
+
+## Explanation
+
+Price action theory, market structure, trend versus range and compression versus expansion,
+liquidity theory, volume and order flow, support and resistance, supply and demand zones,
+multi-timeframe analysis, confluence, fair value gaps, and volume profile.
+
+Deliberately kept beside technical analysis rather than beneath it. Technical analysis is organised
+in this graph by what a computation *measures*, and its six subclasses are exactly those
+characters; price action names conclusions drawn from price geometry rather than a character a
+computation measures, so placing it there would misuse that axis.
+
+## Part of
+
+- [[Mangrove Knowledge Space]] -- subject area of the knowledge space

--- a/ontology/wiki/Quantitative Analysis.md
+++ b/ontology/wiki/Quantitative Analysis.md
@@ -1,0 +1,24 @@
+---
+kind: concept
+chapter: 08-quantitative-analysis
+---
+
+# quantitative analysis
+
+## Summary
+
+Statistical structure in returns: what persists, what reverts, and over what horizon.
+
+## Explanation
+
+Seasonality and time-of-day effects, volatility clustering, mean reversion, breakout behaviour,
+autocorrelation and momentum persistence, machine-learned patterns, cross-sectional versus
+time-series effects, and carry.
+
+Where technical analysis classifies a computation by what it measures, this subject area is about
+the properties of the series being measured -- the evidence that a given class of computation has
+anything to find.
+
+## Part of
+
+- [[Mangrove Knowledge Space]] -- subject area of the knowledge space

--- a/ontology/wiki/Risk Management.md
+++ b/ontology/wiki/Risk Management.md
@@ -1,0 +1,23 @@
+---
+kind: concept
+chapter: 05-risk-management
+---
+
+# risk management
+
+## Summary
+
+Bounding loss: how much to put on, when to stop, and what the portfolio can survive.
+
+## Explanation
+
+Risk dimensions in strategy design, trading rules and protocols, position sizing, drawdown
+controls, stop-loss and take-profit engineering, portfolio risk, capital efficiency, risk-reward
+ratios, risk of ruin, and scenario analysis.
+
+Signals decide whether to act; this subject area decides at what size and under what limits, and it
+constrains a strategy independently of which signals it composes.
+
+## Part of
+
+- [[Mangrove Knowledge Space]] -- subject area of the knowledge space

--- a/ontology/wiki/Technical Analysis.md
+++ b/ontology/wiki/Technical Analysis.md
@@ -1,0 +1,12 @@
+---
+kind: concept
+---
+
+# technical analysis
+
+## Explanation
+
+Anchor page -- carries no summary on purpose. This node is authored by the code-derived build
+(`build_signal_indicator_ontology.py`) and appears here only so that wiki links resolve to it. Its
+six subclasses -- averaging, momentum, oscillator, volatility, flow and pattern -- are each a
+character a computation can measure, and are likewise code-derived.

--- a/ontology/wiki_to_atoms.py
+++ b/ontology/wiki_to_atoms.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Merge the doc-derived wiki into the signal/indicator ontology.
+
+The graph has two sources and one output. Chapter 06 (indicators) and chapter 10 (signals) are
+derived from the library's own source by ``build_signal_indicator_ontology.py`` -- exact, not
+extracted. The remaining chapters have no code to derive from, so their source of truth is an
+LLM-wiki (one concept per page, typed ``##`` sections, ``[[links]]``) compiled by ``wiki-to-graph``.
+
+This adapter is the join. It never writes an atom whose id already exists: the code-derived half is
+authoritative and a wiki page for such a node is an *anchor*, present only so links resolve.
+
+Three things it adds that ``wiki-to-graph`` does not carry into our shape:
+
+* **``why`` on every edge.** Our relations record a rationale ("layer of the domain"); the wiki
+  format stores ``{target, type, via, weight}`` with no such field. The convention is the text after
+  ``--`` on the link's own line, and it is *required* -- an edge without one fails the build rather
+  than entering the graph unexplained.
+* **``source_chapter``.** Which knowledge-base chapter a node was authored from, taken from the
+  page's ``chapter:`` frontmatter. A property rather than an edge, so the subject axis stays clean
+  and provenance does not double the edge count.
+* **``explanation``.** The page body, which is the node's actual content -- ``graph.SEARCH_TIERS``
+  reads it in the same tier as a computation's formula and outputs.
+
+Ids are ``{kind}:{slug(title)}`` -- the page's ``kind:`` frontmatter supplies the prefix. The
+code-derived half namespaces its procedures as ``procedure:indicator-*`` / ``procedure:signal-*``,
+so the two id spaces cannot collide by construction; the merge asserts it anyway.
+
+Usage::
+
+    python3 ontology/wiki_to_atoms.py \\
+        --wiki ontology/wiki --graph build/wiki-graph.json \\
+        --ontology ontology/signal-indicator-ontology.json --out build/merged.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+#: Relations this path may write. Mirrors ``wiki-config/vocab.json``; kept here so the adapter fails on a
+#: vocabulary drift instead of importing a relation the query library cannot categorise.
+ALLOWED = {"instance-of", "kind-of", "part-of", "has-role", "about", "uses", "supersedes"}
+
+#: Primitive names as the ontology spells them (the wiki writes them lowercase in frontmatter).
+PRIMITIVE = {"object": "Object", "property": "Property", "concept": "Concept", "fact": "Fact",
+             "experience": "Experience", "procedure": "Procedure", "schema": "Schema",
+             "context": "Context", "judgment": "Judgment", "atom": "Atom"}
+
+LINK = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
+H1 = re.compile(r"^# (.+)$")
+H2 = re.compile(r"^## (.+)$")
+
+
+class MergeError(RuntimeError):
+    """A defect in the wiki that must be fixed at the source rather than merged around."""
+
+
+def slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-") or "untitled"
+
+
+def read_pages(wiki_dir: Path) -> dict[str, dict]:
+    """Parse each page for its frontmatter and, per typed section, each link's rationale.
+
+    Returns ``{slug: {"title", "kind", "chapter", "why": {(section, target): why}}}``. Only the
+    fields ``wiki-to-graph`` does not already give us are collected here -- the graph structure
+    comes from its build output, so there is exactly one parser of record for the topology.
+    """
+    pages: dict[str, dict] = {}
+    for path in sorted(wiki_dir.glob("*.md")):
+        lines = path.read_text(encoding="utf-8").split("\n")
+        meta, i = {}, 0
+        if lines and lines[0].strip() == "---":
+            j = 1
+            while j < len(lines) and lines[j].strip() != "---":
+                if m := re.match(r"\s*(\w+)\s*:\s*(.+?)\s*$", lines[j]):
+                    meta[m.group(1).lower()] = m.group(2)
+                j += 1
+            i = j + 1
+
+        title, section, why = None, None, {}
+        for raw in lines[i:]:
+            if (m := H1.match(raw)) and title is None:
+                title = m.group(1).strip()
+            elif m := H2.match(raw):
+                section = m.group(1).strip().lower()
+            elif section:
+                for target, _alias in LINK.findall(raw):
+                    tail = raw.split("]]", 1)[1] if "]]" in raw else ""
+                    reason = tail.split("--", 1)[1].strip() if "--" in tail else ""
+                    why[(section, target.strip().lower())] = reason
+
+        title = title or path.stem
+        kind = (meta.get("kind") or "concept").lower()
+        if kind not in PRIMITIVE:
+            raise MergeError(f"{path.name}: kind {kind!r} is not one of the nine primitives")
+        pages[slug(title)] = {"title": title, "kind": kind,
+                              "chapter": meta.get("chapter"), "why": why, "file": path.name}
+    return pages
+
+
+def merge(wiki_dir: Path, graph_path: Path, onto_path: Path) -> tuple[dict, dict]:
+    graph = json.loads(graph_path.read_text(encoding="utf-8"))
+    onto = json.loads(onto_path.read_text(encoding="utf-8"))
+    pages = read_pages(wiki_dir)
+
+    existing = {a["id"]: a for a in onto["atoms"]}
+    ident = {n["id"]: f'{n.get("kind") or "concept"}:{n["id"]}' for n in graph["nodes"]}
+
+    for node_id in ident:
+        if node_id not in pages:
+            raise MergeError(f"graph node {node_id!r} has no page -- wiki and build are out of step")
+
+    new_atoms, anchors = [], []
+    for node in graph["nodes"]:
+        oid, page = ident[node["id"]], pages[node["id"]]
+        if oid in existing:
+            if node.get("summary", "").strip():
+                raise MergeError(
+                    f"{page['file']}: {oid} already exists in the ontology, so this page is an "
+                    "anchor and its summary would never reach the graph. Remove the Summary section.")
+            anchors.append(oid)
+            continue
+        if not node.get("summary", "").strip():
+            raise MergeError(f"{page['file']}: no Summary section -- every new node needs one")
+        props = {}
+        if page["chapter"]:
+            props["source_chapter"] = page["chapter"]
+        # The body is the node's content, not decoration: for a doc-derived node it plays the part
+        # formula/params/outputs play for a computation, and `graph.SEARCH_TIERS` reads it in the
+        # same tier. Dropping it would leave `find("head and shoulders")` empty on the very page
+        # that names the formation.
+        if body := " ".join(node.get("explanation", "").split()):
+            props["explanation"] = body
+        new_atoms.append({"id": oid, "title": page["title"], "kind": PRIMITIVE[page["kind"]],
+                          "summary": " ".join(node["summary"].split()),
+                          "epistemic": "observed", "status": "ratified", "props": props})
+
+    known = set(existing) | {a["id"] for a in new_atoms}
+    new_rels = []
+    for link in graph["links"]:
+        rel = link["type"]
+        if rel not in ALLOWED:
+            raise MergeError(
+                f"relation {rel!r} is outside the vocabulary. A link in an untyped section (Summary, "
+                "Explanation) lands here: put links only in a typed section.")
+        src, dst = ident[link["source"]], ident[link["target"]]
+        for end in (src, dst):
+            if end not in known:
+                raise MergeError(f"edge endpoint {end!r} resolves to no atom")
+        page = pages[link["source"]]
+        why = page["why"].get((link["via"].strip().lower(), graph_title(graph, link["target"])), "")
+        if not why:
+            raise MergeError(
+                f"{page['file']}: edge {rel} -> {dst} has no rationale. Write it after '--' on the "
+                "link's own line; every relation in this graph records why it holds.")
+        new_rels.append({"from": pages[link["source"]]["title"], "rel": rel,
+                         "to": pages[link["target"]]["title"], "why": why,
+                         "from_id": src, "to_id": dst})
+
+    seen = {(r["from_id"], r["rel"], r["to_id"]) for r in onto["relations"]}
+    dupes = [r for r in new_rels if (r["from_id"], r["rel"], r["to_id"]) in seen]
+    if dupes:
+        raise MergeError(f"{len(dupes)} relation(s) already exist in the ontology: {dupes[:3]}")
+
+    merged = {"atoms": onto["atoms"] + new_atoms,
+              "relations": onto["relations"] + new_rels,
+              "meta": {**onto["meta"], "doc_atoms": len(new_atoms),
+                       "doc_relations": len(new_rels), "doc_anchors": sorted(anchors)}}
+    return merged, {"new_atoms": new_atoms, "new_relations": new_rels, "anchors": anchors}
+
+
+def graph_title(graph: dict, node_id: str) -> str:
+    for n in graph["nodes"]:
+        if n["id"] == node_id:
+            return n["title"].strip().lower()
+    return node_id
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--wiki", required=True, type=Path)
+    ap.add_argument("--graph", required=True, type=Path)
+    ap.add_argument("--ontology", required=True, type=Path)
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+
+    if args.out.resolve() == args.ontology.resolve():
+        raise SystemExit("refusing to write over the input ontology; use a build path for --out")
+
+    try:
+        merged, added = merge(args.wiki, args.graph, args.ontology)
+    except MergeError as exc:
+        print(f"MERGE FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    # `indent=1` is not cosmetic: it is what `build_signal_indicator_ontology.py` writes, and the
+    # record is reviewed as a diff. At indent=2 a six-node merge rewrites all 27,000 lines and the
+    # six additions become unreadable among them.
+    args.out.write_text(json.dumps(merged, indent=1, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(f"anchors (untouched) : {len(added['anchors'])}  {', '.join(added['anchors'])}")
+    print(f"new atoms           : {len(added['new_atoms'])}")
+    for a in added["new_atoms"]:
+        print(f"   {a['id']:34} {a['kind']:9} chapter={a['props'].get('source_chapter')}")
+    print(f"new relations       : {len(added['new_relations'])}")
+    for r in added["new_relations"]:
+        print(f"   {r['from_id']:34} --{r['rel']}--> {r['to_id']}   ({r['why']})")
+    print(f"totals              : {len(merged['atoms'])} atoms, {len(merged['relations'])} relations")
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ontology/wiki_to_atoms.py
+++ b/ontology/wiki_to_atoms.py
@@ -15,7 +15,7 @@ Three things it adds that ``wiki-to-graph`` does not carry into our shape:
   format stores ``{target, type, via, weight}`` with no such field. The convention is the text after
   ``--`` on the link's own line, and it is *required* -- an edge without one fails the build rather
   than entering the graph unexplained.
-* **``source_chapter``.** Which knowledge-base chapter a node was authored from, taken from the
+* **``reference_chapter``.** Which knowledge-base chapter a node was authored from, taken from the
   page's ``chapter:`` frontmatter. A property rather than an edge, so the subject axis stays clean
   and provenance does not double the edge count.
 * **``explanation``.** The page body, which is the node's actual content -- ``graph.SEARCH_TIERS``
@@ -127,7 +127,7 @@ def merge(wiki_dir: Path, graph_path: Path, onto_path: Path) -> tuple[dict, dict
             raise MergeError(f"{page['file']}: no Summary section -- every new node needs one")
         props = {}
         if page["chapter"]:
-            props["source_chapter"] = page["chapter"]
+            props["reference_chapter"] = page["chapter"]
         # The body is the node's content, not decoration: for a doc-derived node it plays the part
         # formula/params/outputs play for a computation, and `graph.SEARCH_TIERS` reads it in the
         # same tier. Dropping it would leave `find("head and shoulders")` empty on the very page
@@ -167,7 +167,11 @@ def merge(wiki_dir: Path, graph_path: Path, onto_path: Path) -> tuple[dict, dict
 
     merged = {"atoms": onto["atoms"] + new_atoms,
               "relations": onto["relations"] + new_rels,
+              # The ids, not just the count: the determinism test needs to separate the two halves
+              # exactly, and `reference_chapter` cannot do it -- code-derived nodes carry that key
+              # too, because it says which chapter DOCUMENTS a node, not where the node came from.
               "meta": {**onto["meta"], "doc_atoms": len(new_atoms),
+                       "doc_atom_ids": sorted(a["id"] for a in new_atoms),
                        "doc_relations": len(new_rels), "doc_anchors": sorted(anchors)}}
     return merged, {"new_atoms": new_atoms, "new_relations": new_rels, "anchors": anchors}
 
@@ -205,7 +209,7 @@ def main() -> int:
     print(f"anchors (untouched) : {len(added['anchors'])}  {', '.join(added['anchors'])}")
     print(f"new atoms           : {len(added['new_atoms'])}")
     for a in added["new_atoms"]:
-        print(f"   {a['id']:34} {a['kind']:9} chapter={a['props'].get('source_chapter')}")
+        print(f"   {a['id']:34} {a['kind']:9} chapter={a['props'].get('reference_chapter')}")
     print(f"new relations       : {len(added['new_relations'])}")
     for r in added["new_relations"]:
         print(f"   {r['from_id']:34} --{r['rel']}--> {r['to_id']}   ({r['why']})")

--- a/skills/knowledge-graph/GUIDE.md
+++ b/skills/knowledge-graph/GUIDE.md
@@ -21,7 +21,7 @@ Do not start by listing files. Start with the graph's own summary:
 
 ```python
 s = kg.stats()
-s["nodes"], s["edges"]          # 303, 1049
+s["nodes"], s["edges"]          # 309, 1055
 s["primitives"]                 # {'Procedure': 289, 'Concept': 9, 'Property': 3, ...}
 s["relations"]                  # {'instance-of': 360, 'uses': 233, 'about': 222, ...}
 s["classes"]                    # the six character classes -- what find(kind=) is for
@@ -30,12 +30,13 @@ kg.schema()                     # the (subject, relation, object) shapes that ac
 ```
 
 ```
-nodes, edges  303 1049
+nodes, edges  309 1055
 primitives    {'Procedure': 289, 'Concept': 9, 'Property': 3, 'Object': 1, 'Schema': 1}
 relations     {'instance-of': 360, 'uses': 233, 'about': 222, 'has-role': 218,
                'kind-of': 8, 'part-of': 6, 'supersedes': 2}
-classes       ['concept:averaging', 'concept:flow', 'concept:momentum',
-               'concept:oscillator', 'concept:pattern', 'concept:volatility']
+classes       ['concept:averaging', 'concept:chart-pattern', 'concept:flow',
+               'concept:momentum', 'concept:oscillator', 'concept:pattern',
+               'concept:volatility']
 roles         ['property:role-filter', 'property:role-trigger']
 schema        [{'subject': 'Procedure', 'relation': 'instance-of', 'object': 'Concept'},
                {'subject': 'Procedure', 'relation': 'about',       'object': 'Concept'},
@@ -50,7 +51,7 @@ one and get an empty result you might misread as "there are none".
 also accepts the short name (`"momentum"`). Both work; the ids are what you get back.
 
 `classes` is deliberately the six and not every class-like node. `find(kind=...)` *also* accepts
-`"indicator"` (71), `"signal"` (218) and `"technical-analysis"` (295 of 303) — legal, occasionally
+`"indicator"` (71), `"signal"` (218) and `"technical-analysis"` (296 of 309) — legal, occasionally
 useful, and not classes. A filter that returns almost everything reads like a query and acts like a
 no-op, so they are documented here rather than advertised as vocabulary.
 
@@ -256,7 +257,7 @@ The `why` on the edge carries the reason — here, *"computes the same thing und
 name"*. That is the difference between "renamed" and "replaced because it was wrong", and you should
 report which.
 
-**Trap:** `status` is on the node, not the edge, and only 2 of 303 nodes are deprecated. Check it
+**Trap:** `status` is on the node, not the edge, and only 2 of 309 nodes are deprecated. Check it
 explicitly; nothing else surfaces it.
 
 ---

--- a/skills/knowledge-graph/SKILL.md
+++ b/skills/knowledge-graph/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 
 # Ask the graph before you read the source
 
-`mangrove_kb` ships a knowledge graph of itself: **303 nodes, 1049 edges** covering 71 indicators and
+`mangrove_kb` ships a knowledge graph of itself: **309 nodes, 1055 edges** covering 71 indicators and
 218 signals. It is generated from the source, so it is exact — not extracted from prose, not
 approximate, no ranking model in the way. Every answer is a fact about the code as it is.
 

--- a/tests/test_build_is_deterministic.py
+++ b/tests/test_build_is_deterministic.py
@@ -38,9 +38,23 @@ def committed():
     return json.loads(COMMITTED.read_text())
 
 
+def _code_derived(graph):
+    """The committed record is the code build plus the wiki merge. This strips the second half.
+
+    Determinism is a claim about the builder: given the tree, it reproduces what it wrote. The
+    doc-derived nodes are not its output and it has never heard of them, so including them here
+    would assert the builder produces something it does not. They have their own guard --
+    `test_doc_derived_atoms.py` fails if the merge is skipped, which is the failure this test
+    would otherwise be mistaken for.
+    """
+    doc = {a["id"] for a in graph["atoms"] if "source_chapter" in (a.get("props") or {})}
+    return ({a["id"]: a for a in graph["atoms"] if a["id"] not in doc},
+            [r for r in graph["relations"] if r["from_id"] not in doc and r["to_id"] not in doc])
+
+
 def test_atoms_are_reproduced_exactly(rebuilt, committed):
     got = {a["id"]: a for a in rebuilt["atoms"]}
-    want = {a["id"]: a for a in committed["atoms"]}
+    want, _ = _code_derived(committed)
     assert set(got) == set(want), "the node SET changed"
     differing = [i for i in want if got[i] != want[i]]
     assert not differing, (
@@ -49,7 +63,8 @@ def test_atoms_are_reproduced_exactly(rebuilt, committed):
 
 
 def test_relations_are_reproduced_exactly(rebuilt, committed):
-    assert rebuilt["relations"] == committed["relations"]
+    _, want = _code_derived(committed)
+    assert rebuilt["relations"] == want
 
 
 def test_nothing_is_carried_forward(rebuilt):

--- a/tests/test_build_is_deterministic.py
+++ b/tests/test_build_is_deterministic.py
@@ -47,7 +47,7 @@ def _code_derived(graph):
     `test_doc_derived_atoms.py` fails if the merge is skipped, which is the failure this test
     would otherwise be mistaken for.
     """
-    doc = {a["id"] for a in graph["atoms"] if "source_chapter" in (a.get("props") or {})}
+    doc = set(graph["meta"].get("doc_atom_ids", ()))
     return ({a["id"]: a for a in graph["atoms"] if a["id"] not in doc},
             [r for r in graph["relations"] if r["from_id"] not in doc and r["to_id"] not in doc])
 

--- a/tests/test_doc_derived_atoms.py
+++ b/tests/test_doc_derived_atoms.py
@@ -1,0 +1,99 @@
+"""The doc-derived half of the graph survives in the committed ontology.
+
+`build_signal_indicator_ontology.py` writes the record from the library's source and knows nothing
+about the wiki, so running it alone and committing silently drops every doc-derived node. Nothing
+else would notice: the code-derived atoms would all still be there and the suite would be green.
+These tests are what notices.
+
+The pipeline is two stages, in this order:
+
+    python3 ontology/build_signal_indicator_ontology.py
+    python3 -m wiki_to_graph build ontology/wiki -o build/wiki-graph.json \\
+            --map ontology/wiki-config/map.json --vocab ontology/wiki-config/vocab.json
+    python3 ontology/wiki_to_atoms.py --wiki ontology/wiki --graph build/wiki-graph.json \\
+            --ontology ontology/signal-indicator-ontology.json --out build/record.json
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from mangrove_kb.graph import RELATIONS, KnowledgeGraph
+
+REPO = Path(__file__).resolve().parent.parent
+WIKI = REPO / "ontology" / "wiki"
+
+
+@pytest.fixture(scope="module")
+def kg() -> KnowledgeGraph:
+    return KnowledgeGraph.load()
+
+
+def wiki_pages() -> dict[str, dict]:
+    """Every page, by the id the adapter derives for it: ``{kind}:{slug(title)}``."""
+    out = {}
+    for path in sorted(WIKI.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        kind = (m.group(1) if (m := re.search(r"^kind:\s*(\w+)", text, re.M)) else "concept").lower()
+        title = re.search(r"^# (.+)$", text, re.M).group(1).strip()
+        chapter = m.group(1) if (m := re.search(r"^chapter:\s*(\S+)", text, re.M)) else None
+        slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+        out[f"{kind}:{slug}"] = {"file": path.name, "chapter": chapter, "title": title}
+    return out
+
+
+def test_every_authored_page_reached_the_graph(kg):
+    """A page that builds but never lands is the failure this whole path exists to prevent."""
+    missing = [f"{nid} ({p['file']})" for nid, p in wiki_pages().items() if nid not in kg.nodes]
+    assert not missing, (
+        "the committed ontology is missing doc-derived nodes -- the code builder was almost "
+        f"certainly run without the wiki merge that follows it: {missing}")
+
+
+def test_doc_nodes_record_the_chapter_they_came_from(kg):
+    """Provenance is the whole claim to trustworthiness for a node nobody can re-derive from code."""
+    for nid, page in wiki_pages().items():
+        if page["chapter"] is None:          # anchors carry no chapter; they are code-derived
+            continue
+        node = kg.get(nid)
+        assert node.get("source_chapter") == page["chapter"], \
+            f"{nid} should record chapter {page['chapter']}, got {node.get('source_chapter')!r}"
+
+
+def test_doc_nodes_are_searchable_by_their_body(kg):
+    """`explanation` is in SEARCH_TIERS, so a term named only in the page body is findable.
+
+    Before it was carried, `find("head and shoulders")` returned nothing while the chart-pattern
+    page named the formation in its first line -- a search that answers "do we have anything for
+    X?" with a false no is worse than no search.
+    """
+    hits = [r["id"] for r in kg.find("head and shoulders", limit=5).items]
+    assert "concept:chart-pattern" in hits, hits
+
+
+def test_doc_edges_use_only_relations_the_library_can_classify(kg):
+    """The wiki can express any section name; only these seven mean anything to a consumer."""
+    doc_ids = set(wiki_pages())
+    for edge in kg.edges:
+        if edge.src in doc_ids or edge.dst in doc_ids:
+            assert edge.relation in RELATIONS, f"{edge.src} --{edge.relation}--> {edge.dst}"
+
+
+def test_every_doc_edge_records_why_it_holds(kg):
+    """Our relations carry a rationale; the adapter refuses an edge without one, so none exist."""
+    doc_ids = set(wiki_pages())
+    bare = [f"{e.src} --{e.relation}--> {e.dst}" for e in kg.edges
+            if (e.src in doc_ids or e.dst in doc_ids) and not e.why.strip()]
+    assert not bare, bare
+
+
+def test_the_record_is_the_merged_graph_not_the_code_build_alone():
+    """The committed file must be the second stage's output -- meta says how many doc atoms it holds."""
+    record = json.loads((REPO / "ontology" / "signal-indicator-ontology.json").read_text())
+    authored = sum(1 for p in wiki_pages().values() if p["chapter"])
+    assert record["meta"].get("doc_atoms") == authored, (
+        "meta.doc_atoms is missing or stale -- the record was written by the code builder without "
+        f"the wiki merge (expected {authored})")

--- a/tests/test_doc_derived_atoms.py
+++ b/tests/test_doc_derived_atoms.py
@@ -59,8 +59,8 @@ def test_doc_nodes_record_the_chapter_they_came_from(kg):
         if page["chapter"] is None:          # anchors carry no chapter; they are code-derived
             continue
         node = kg.get(nid)
-        assert node.get("source_chapter") == page["chapter"], \
-            f"{nid} should record chapter {page['chapter']}, got {node.get('source_chapter')!r}"
+        assert node.get("reference_chapter") == page["chapter"], \
+            f"{nid} should record chapter {page['chapter']}, got {node.get('reference_chapter')!r}"
 
 
 def test_doc_nodes_are_searchable_by_their_body(kg):

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -30,11 +30,14 @@ def test_stats_enumerates_every_filter_value(kg):
         assert kg.find(role=role, limit=1) is not None
     for cls in s["classes"]:
         assert kg.find(kind=cls, limit=1) is not None
-    assert len(s["classes"]) == 6, (
-        "classes is the CHARACTER vocabulary -- the six divisions of technical analysis. "
+    assert len(s["classes"]) == 7, (
+        "classes is the CHARACTER vocabulary -- the divisions of technical analysis. "
         "It once returned every backbone target, which swept in concept:indicator (71 "
         "results), concept:signal (218), concept:technical-analysis (295 of 303) and "
-        "property:role (the role values), advertising filters that act as no-ops.")
+        "property:role (the role values), advertising filters that act as no-ops. Six are "
+        "measured by a computation; concept:chart-pattern is knowledge only -- multi-bar "
+        "formations need swing points, which nothing in the library produces -- so it is "
+        "deliberately memberless rather than missing.")
     assert set(s["relations"]) <= set(RELATIONS), "graph uses a relation the library cannot classify"
 
 
@@ -125,7 +128,7 @@ def test_derivation_never_runs_over_roles(kg):
     """
     classes = {n["id"] for n in kg.neighbors("concept:technical-analysis", relation="kind-of",
                                              direction="in", limit=None).items}
-    assert len(classes) == 6, f"expected the six character classes, got {sorted(classes)}"
+    assert len(classes) == 7, f"expected the seven character classes, got {sorted(classes)}"
     for role in kg.roles():
         bearers = set(kg.bearers(role))
         for cls in classes:

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -311,9 +311,12 @@ for(const n of DATA.nodes){
 }
 console.log(JSON.stringify({threw: bad, braces, count: DATA.nodes.length}));
 """, tmp_path)
+    from mangrove_kb.graph import KnowledgeGraph
     assert out["threw"] == [], f"the formatter threw on {out['threw']}"
     assert out["braces"] == [], f"raw JSON still reaches the panel for {out['braces']}"
-    assert out["count"] == 303
+    # Every node, counted from the graph rather than a literal: the claim is coverage, and a
+    # literal turns each node added to the ontology into a spurious failure here.
+    assert out["count"] == len(KnowledgeGraph.load().nodes)
 
 
 def test_unbounded_and_unauthored_are_different_things(page, tmp_path):
@@ -554,7 +557,8 @@ console.log(JSON.stringify(names));
 """, tmp_path)
     assert "epistemic status" not in out, \
         "epistemic must live in provenance on every node, not as its own section on some"
-    assert out.get("provenance &amp; extras") == 303, \
+    from mangrove_kb.graph import KnowledgeGraph
+    assert out.get("provenance &amp; extras") == len(KnowledgeGraph.load().nodes), \
         f"every node carries an epistemic status, so every node has the section: {out}"
     # warm-up is a sentence about the parameters when there are any, and its own section when
     # there are not -- saying "an expression in these parameters" beside no parameters is a lie.


### PR DESCRIPTION
## What

Adds the first six doc-derived nodes to the ontology, one per knowledge-base chapter, and the pipeline that produces them.

| chapter | node | attachment |
|---|---|---|
| 01 market foundations | `concept:market-foundations` | `part-of` the root |
| 02 instruments & market mechanics | `concept:market-mechanics` | `part-of` the root |
| 03 core trading concepts | `concept:price-action` | `part-of` the root |
| 05 risk management | `concept:risk-management` | `part-of` the root |
| 08 quantitative analysis | `concept:quantitative-analysis` | `part-of` the root |
| 07 chart patterns | `concept:chart-pattern` | `kind-of` technical analysis |

Graph: **303 → 309 nodes, 1049 → 1055 edges.**

## Why

The graph covered one layer — computations over price and volume. Joining the knowledge base's 156 glossary terms against it, 21% resolved, and the misses were architectural rather than scattered: order & execution 0/19, statistics & quant 0/15, futures 0/12, market structure 0/11, trading sessions 0/9, psychology 0/8. `concept:technical-analysis` is defined as reading a market from its own price and volume history, while `market`, `price series` and `bar` existed nowhere as nodes. These six are the subject areas the existing 303 presuppose.

`concept:chart-pattern` is a **sibling** of the candlestick `pattern` class, not a merge into it. That class holds shapes computable from one bar or a fixed window, which is why 41 signals implement it; a multi-bar formation (head and shoulders, wedges, cup and handle) needs swing points that no computation in the library produces. It is the first class in the graph that is knowledge without an implementation, and is memberless by design.

## How

These nodes have no code to derive from, so their source of truth is an LLM-wiki compiled by [wiki-to-graph](https://github.com/MangroveTechnologies/wiki-to-graph) — one concept per page, typed `##` sections, `[[links]]` — with our own relation vocabulary supplied through `--vocab`. `ontology/wiki_to_atoms.py` merges its output into the record and adds the three things that shape does not carry:

- **`why` on every edge**, taken from the text after `--` on the link's own line. Required: an edge without one fails the build.
- **`reference_chapter`**, the chapter that documents a node. Stamped by the wiki merge from page frontmatter and by the code builder on the pre-existing entity nodes, so every content chapter resolves to a node by query.
- **`explanation`**, the page body, now read by `SEARCH_TIERS`.

The code-derived half is never written by this path. A page whose id already exists is an *anchor* and is never rewritten.

## Verification

- `436 passed` locally.
- The merge is asserted additive: **0** existing atoms modified, **0** existing relations removed.
- Loaded through `KnowledgeGraph.load()`: the root now has 7 children, `why` and `reference_chapter` survive, and the viewer's `DATA` carries all 6 nodes and 6 edges.
- Search regression fixed and covered: `find("head and shoulders")` → `concept:chart-pattern`, `find("liquidation")` → `concept:market-mechanics` — both empty before.
- Each merge guard proven by breaking the wiki: a link in an untyped section, an edge with no rationale, a summary on an anchor page, a new node with no summary.
- `tests/test_doc_derived_atoms.py` proven by pointing the record back at `origin/main`: 4 of 6 fail. That is the failure where the code builder is run alone and the doc half is silently dropped.
- Four assertions that hardcoded 303 now derive the count from the graph.

## Draft

Draft because this is the first slice of a larger effort: these six are the upper layer that the remaining chapter content hangs from.